### PR TITLE
feat: add GitHub Projects board + two-step install wizard

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -42,4 +42,12 @@ jobs:
             claude-notion/install.sh \
             claude-notion/bin/task-work \
             claude-notion/bin/task-done \
-            claude-notion/bin/task-init
+            claude-notion/bin/task-init \
+            claude-gh/install.sh \
+            claude-gh/bin/task-work \
+            claude-gh/bin/task-done \
+            claude-gh/bin/task-init \
+            kiro-gh/install.sh \
+            kiro-gh/bin/task-work \
+            kiro-gh/bin/task-done \
+            kiro-gh/bin/task-init

--- a/claude-gh/bin/task-done
+++ b/claude-gh/bin/task-done
@@ -1,0 +1,111 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+usage() {
+  echo "Usage: task-done [--force] [--remove-worktree]"
+  echo ""
+  echo "Run from within a worktree to:"
+  echo "  1. Show the diff summary and existing PR (or print gh pr create command)"
+  echo "  2. Remove the worktree"
+  echo "  3. Close the zellij tab"
+  echo ""
+  echo "Options:"
+  echo "  --force            Skip confirmation prompts"
+  echo "  --remove-worktree  Skip PR section — just clean up the worktree and tab."
+  echo "                     Use after the worker has already created the PR."
+  exit 1
+}
+
+FORCE=false
+REMOVE_ONLY=false
+
+while [[ $# -gt 0 ]]; do
+  case "$1" in
+    --force) FORCE=true; shift ;;
+    --remove-worktree) REMOVE_ONLY=true; shift ;;
+    -h|--help) usage ;;
+    *) echo "Unknown option: $1"; usage ;;
+  esac
+done
+
+# Detect worktree context
+WORKTREE_DIR=$(pwd)
+REPO_ROOT=$(git rev-parse --show-toplevel 2>/dev/null) || { echo "Error: not in a git repo"; exit 1; }
+
+# Check we're actually in a worktree (not the main repo)
+MAIN_WORKTREE=$(git worktree list --porcelain | head -1 | sed 's/worktree //')
+if [[ "$REPO_ROOT" == "$MAIN_WORKTREE" ]]; then
+  echo "Error: you're in the main repo, not a worktree. cd into a worktree first."
+  exit 1
+fi
+
+BRANCH=$(git rev-parse --abbrev-ref HEAD)
+SLUG="${BRANCH#task/}"
+REPO_NAME=$(basename "$MAIN_WORKTREE")
+WORKTREE_BASE="${MAIN_WORKTREE}/../${REPO_NAME}-worktrees"
+INFO_FILE="${WORKTREE_BASE}/.${SLUG}.info"
+
+# Load base branch written by task-work; fall back to "main"
+BASE_BRANCH="main"
+# shellcheck source=/dev/null
+[[ -f "$INFO_FILE" ]] && source "$INFO_FILE"
+
+echo "Worktree: $WORKTREE_DIR"
+echo "Branch:   $BRANCH"
+echo "Base:     $BASE_BRANCH"
+echo ""
+
+# Check for uncommitted changes
+if ! git diff --quiet || ! git diff --cached --quiet; then
+  echo "⚠ Uncommitted changes detected:"
+  git status --short
+  echo ""
+  if [[ "$FORCE" != true ]]; then
+    read -rp "Continue anyway? (y/N) " confirm
+    [[ "$confirm" != "y" && "$confirm" != "Y" ]] && exit 1
+  fi
+fi
+
+# Show summary
+COMMIT_COUNT=$(git rev-list --count "${BASE_BRANCH}..HEAD" 2>/dev/null || echo "?")
+echo "Commits ahead of ${BASE_BRANCH}: $COMMIT_COUNT"
+DIFF_STAT=$(git diff --shortstat "${BASE_BRANCH}..HEAD" 2>/dev/null || true)
+[[ -n "$DIFF_STAT" ]] && echo "Changes: $DIFF_STAT"
+echo ""
+
+if [[ "$REMOVE_ONLY" != true ]]; then
+  # Show existing PR URL, or print the creation command
+  PR_URL=$(gh pr view --json url -q .url 2>/dev/null || true)
+  if [[ -n "$PR_URL" ]]; then
+    echo "PR: $PR_URL"
+  else
+    echo "To create a PR:"
+    echo "  gh pr create --base $BASE_BRANCH --head $BRANCH --title \"${BRANCH#task/}\" --fill"
+  fi
+  echo ""
+fi
+
+if [[ "$FORCE" != true ]]; then
+  read -rp "Remove worktree and close tab? (y/N) " confirm
+  [[ "$confirm" != "y" && "$confirm" != "Y" ]] && exit 0
+fi
+
+# Move out of worktree before removing it
+cd "$MAIN_WORKTREE"
+
+# Remove worktree
+echo "Removing worktree..."
+git worktree remove "$WORKTREE_DIR" --force 2>/dev/null || {
+  echo "Warning: could not remove worktree cleanly. Trying prune..."
+  rm -rf "$WORKTREE_DIR"
+  git worktree prune
+}
+
+# Clean up info file
+[[ -f "$INFO_FILE" ]] && rm -f "$INFO_FILE"
+
+# Close current zellij tab
+echo "Closing zellij tab..."
+zellij action close-tab
+
+echo "Done. Branch '$BRANCH' still exists — delete after PR merge with: git branch -d $BRANCH"

--- a/claude-gh/bin/task-init
+++ b/claude-gh/bin/task-init
@@ -1,0 +1,70 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+usage() {
+  echo "Usage: task-init [--force]"
+  echo ""
+  echo "Set up the current repo for the claude-gh workflow:"
+  echo "  - Create .claude/gh-workflow.md from the bundled template"
+  echo "  - Add @.claude/gh-workflow.md to CLAUDE.md so it auto-loads in every session"
+  echo ""
+  echo "Options:"
+  echo "  --force   Overwrite .claude/gh-workflow.md if present"
+  exit 1
+}
+
+FORCE=false
+
+while [[ $# -gt 0 ]]; do
+  case "$1" in
+    --force) FORCE=true; shift ;;
+    -h|--help) usage ;;
+    *) echo "Unknown option: $1"; usage ;;
+  esac
+done
+
+# Resolve script path through symlinks (install.sh symlinks into ~/.local/bin)
+src="${BASH_SOURCE[0]}"
+while [ -L "$src" ]; do
+  dir=$(cd -P "$(dirname "$src")" && pwd)
+  src=$(readlink "$src")
+  [[ $src != /* ]] && src="$dir/$src"
+done
+SCRIPT_DIR=$(cd -P "$(dirname "$src")" && pwd)
+TEMPLATE="$SCRIPT_DIR/../steering/gh-workflow.example.md"
+
+if [[ ! -f "$TEMPLATE" ]]; then
+  echo "Error: template not found at $TEMPLATE"
+  exit 1
+fi
+
+git rev-parse --show-toplevel >/dev/null 2>&1 || { echo "Error: not in a git repo"; exit 1; }
+REPO_ROOT=$(git rev-parse --show-toplevel)
+TARGET="$REPO_ROOT/.claude/gh-workflow.md"
+CLAUDE_MD="$REPO_ROOT/CLAUDE.md"
+
+mkdir -p "$REPO_ROOT/.claude"
+
+if [[ -f "$TARGET" && "$FORCE" != true ]]; then
+  echo "$TARGET already exists. Use --force to overwrite."
+  exit 1
+fi
+
+cp "$TEMPLATE" "$TARGET"
+echo "✓ Wrote $TARGET"
+
+IMPORT_LINE="@.claude/gh-workflow.md"
+if [[ -f "$CLAUDE_MD" ]]; then
+  if grep -qF "$IMPORT_LINE" "$CLAUDE_MD"; then
+    echo "✓ CLAUDE.md already references gh-workflow.md"
+  else
+    printf '\n%s\n' "$IMPORT_LINE" >> "$CLAUDE_MD"
+    echo "✓ Appended $IMPORT_LINE to CLAUDE.md"
+  fi
+else
+  printf '%s\n' "$IMPORT_LINE" > "$CLAUDE_MD"
+  echo "✓ Created CLAUDE.md with $IMPORT_LINE"
+fi
+
+echo ""
+echo "Done. Open .claude/gh-workflow.md to fill in your GitHub owner, repo, and project number."

--- a/claude-gh/bin/task-work
+++ b/claude-gh/bin/task-work
@@ -1,0 +1,161 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+usage() {
+  cat <<'EOF'
+Usage:
+  task-work <slug> <gh-url> [options]    # explicit slug + GitHub issue URL (preferred when an agent kicks it off)
+  task-work <gh-url> [options]           # slug derived from issue number (issue-N)
+  task-work <free-form-slug> [options]   # ad-hoc, no GitHub URL
+
+Creates a git worktree + branch for a task and opens a new zellij tab
+with a Claude Code worker session. If a worktree for that slug already
+exists, a 5-char hash is appended so multiple agents can work the same
+task in parallel.
+
+Options:
+  -b, --base BRANCH   Base branch for the PR (default: current branch at call time).
+      --no-launch     Create the worktree and open the tab at its directory,
+                      but do NOT start claude. Use this when you want to
+                      pick the command/model interactively.
+  -h, --help          Show this help.
+
+Examples:
+  task-work add-auth "https://github.com/owner/repo/issues/42"
+  task-work https://github.com/owner/repo/issues/42
+  task-work refactor-auth
+  task-work spike-idea --no-launch
+EOF
+  exit "${1:-1}"
+}
+
+# ---------------- arg parsing ----------------
+POSITIONAL=()
+NO_LAUNCH=""
+BASE_BRANCH_OVERRIDE=""
+
+while [[ $# -gt 0 ]]; do
+  case "$1" in
+    -h|--help) usage 0 ;;
+    -b|--base)
+      [[ $# -ge 2 ]] || { echo "Error: --base requires a value" >&2; exit 1; }
+      BASE_BRANCH_OVERRIDE="$2"; shift 2 ;;
+    --no-launch) NO_LAUNCH="1"; shift ;;
+    --) shift; while [[ $# -gt 0 ]]; do POSITIONAL+=("$1"); shift; done ;;
+    -*) echo "Error: unknown flag '$1'" >&2; usage 1 ;;
+    *) POSITIONAL+=("$1"); shift ;;
+  esac
+done
+
+[[ ${#POSITIONAL[@]} -lt 1 ]] && usage
+
+is_github_url() {
+  [[ "$1" == *"github.com"*"/issues/"* ]]
+}
+
+derive_slug_from_url() {
+  local url="$1"
+  local issue_num
+  issue_num=$(echo "$url" | sed 's|.*/issues/||' | sed 's|[^0-9].*||')
+  if [[ -n "$issue_num" ]]; then
+    echo "issue-${issue_num}"
+  else
+    echo "$url" | sed 's|.*/||' | tr '[:upper:]' '[:lower:]' | sed 's/[^a-z0-9-]//g'
+  fi
+}
+
+sanitize_slug() {
+  echo "$1" | tr '[:upper:]' '[:lower:]' | tr ' ' '-' | sed 's/[^a-z0-9-]//g'
+}
+
+# Resolve GH_URL and SLUG from positional args:
+#   1 arg,  URL           → derive slug from issue number
+#   1 arg,  not URL       → slug only, no URL
+#   2 args, URL in either → other one is the slug
+GH_URL=""
+SLUG=""
+P0="${POSITIONAL[0]}"
+P1="${POSITIONAL[1]:-}"
+
+if [[ ${#POSITIONAL[@]} -ge 2 ]] && ! is_github_url "$P0" && is_github_url "$P1"; then
+  SLUG=$(sanitize_slug "$P0")
+  GH_URL="$P1"
+elif [[ ${#POSITIONAL[@]} -ge 2 ]] && is_github_url "$P0" && ! is_github_url "$P1"; then
+  GH_URL="$P0"
+  SLUG=$(sanitize_slug "$P1")
+elif is_github_url "$P0"; then
+  GH_URL="$P0"
+  SLUG=$(derive_slug_from_url "$P0")
+else
+  SLUG=$(sanitize_slug "$P0")
+fi
+
+[[ -z "$SLUG" ]] && { echo "Error: could not derive a slug from input" >&2; exit 1; }
+SLUG="${SLUG:0:50}"
+
+# ---------------- repo discovery ----------------
+REPO_ROOT=$(git rev-parse --show-toplevel 2>/dev/null) || { echo "Error: not in a git repo" >&2; exit 1; }
+REPO_NAME=$(basename "$REPO_ROOT")
+WORKTREE_BASE="${REPO_ROOT}/../${REPO_NAME}-worktrees"
+
+# Capture base branch now, before the worktree is created
+BASE_BRANCH="${BASE_BRANCH_OVERRIDE:-$(git rev-parse --abbrev-ref HEAD)}"
+
+BRANCH="task/${SLUG}"
+WORKTREE_DIR="${WORKTREE_BASE}/${SLUG}"
+
+# ---------------- command builder ----------------
+build_claude_cmd() {
+  if [[ -n "$GH_URL" ]]; then
+    echo "claude \"/worker Implement task: $GH_URL\""
+  else
+    echo "claude \"/worker\""
+  fi
+}
+
+# ---------------- zellij tab launch ----------------
+launch_in_tab() {
+  local dir="$1"
+  zellij action go-to-tab-name "$SLUG"
+  sleep 0.3
+
+  if [[ -n "$NO_LAUNCH" ]]; then
+    zellij action write-chars "cd $dir"
+  else
+    zellij action write-chars "cd $dir && $(build_claude_cmd)"
+  fi
+  sleep 0.1
+  zellij action write 10  # Enter
+}
+
+# ---------------- worktree creation ----------------
+if [[ -d "$WORKTREE_DIR" ]]; then
+  HASH=$(LC_ALL=C tr -dc 'a-z0-9' </dev/urandom | head -c 5 || :)
+  SLUG="${SLUG}-${HASH}"
+  BRANCH="task/${SLUG}"
+  WORKTREE_DIR="${WORKTREE_BASE}/${SLUG}"
+  echo "Existing worktree found — creating a parallel session: $SLUG"
+fi
+
+mkdir -p "$WORKTREE_BASE"
+echo "Creating branch $BRANCH and worktree at $WORKTREE_DIR..."
+git worktree add "$WORKTREE_DIR" -b "$BRANCH" 2>/dev/null || {
+  git worktree add "$WORKTREE_DIR" "$BRANCH" 2>/dev/null || {
+    echo "Error: could not create worktree. Check if branch '$BRANCH' exists elsewhere." >&2
+    exit 1
+  }
+}
+
+# Write task info so the worker and task-done can read it (stored outside the working tree)
+INFO_FILE="${WORKTREE_BASE}/.${SLUG}.info"
+printf 'BASE_BRANCH=%s\nSLUG=%s\nGH_URL=%s\n' "$BASE_BRANCH" "$SLUG" "$GH_URL" > "$INFO_FILE"
+
+echo "Opening zellij tab '$SLUG'..."
+zellij action new-tab --name "$SLUG" --cwd "$WORKTREE_DIR"
+launch_in_tab "$WORKTREE_DIR"
+
+if [[ -n "$NO_LAUNCH" ]]; then
+  echo "Tab opened at $WORKTREE_DIR (branch: $BRANCH, base: $BASE_BRANCH) — claude NOT launched (--no-launch)."
+else
+  echo "Started worker in $WORKTREE_DIR (branch: $BRANCH, base: $BASE_BRANCH)"
+fi

--- a/claude-gh/commands/planner.md
+++ b/claude-gh/commands/planner.md
@@ -1,0 +1,36 @@
+---
+description: Planner — designs solutions, writes implementation specs into GitHub Issues
+argument-hint: [optional GitHub issue URL or title]
+---
+
+You are now in Planner mode.
+
+Refer to the project's `.claude/gh-workflow.md` for GitHub owner/repo and conventions. Use the GitHub MCP (`@github`) to read and update GitHub Issues.
+
+Workflow:
+1. Given an issue URL or title, fetch it from GitHub to read the current description and any existing spec.
+2. Explore the codebase to understand the relevant architecture (read files, search symbols, grep patterns).
+3. Design the solution.
+4. Write the implementation spec into the issue body.
+
+Spec template (use when applicable, skip sections that are N/A):
+
+## Problem
+What we're solving and why.
+
+## Solution
+How to implement it. Be specific about approach.
+
+## Files to Create/Modify
+| File | Action | Purpose |
+|------|--------|---------|
+| path | CREATE/MODIFY | What and why |
+
+## Verification
+Concrete steps to test that it works.
+
+When asked to start work on a planned issue, run: `task-work <slug> <gh-issue-url>`
+
+You can READ code but should NOT write or modify files in this mode. Your output goes to GitHub only.
+
+$ARGUMENTS

--- a/claude-gh/commands/pm.md
+++ b/claude-gh/commands/pm.md
@@ -1,0 +1,22 @@
+---
+description: PM role — backlog grooming, task creation, prioritization via GitHub Projects
+argument-hint: [optional first instruction]
+---
+
+You are now in PM mode for this Claude Code session.
+
+Refer to the project's `.claude/gh-workflow.md` for GitHub owner/repo, project number, and conventions. Use the GitHub MCP (`@github`) to read and write GitHub Issues and Projects.
+
+Your responsibilities:
+- Show backlog status when asked (list open issues in the project, grouped by status and priority)
+- Create new issues with a clear title and brief body description, then add them to the project
+- Update issue labels, priorities, and project field values
+- Groom the backlog — flag stale issues, reprioritize, suggest what to work on next
+- When asked to start work on an issue, run: `task-work <slug> <gh-issue-url>`
+
+When creating issues, set the project Status field to "Todo" unless told otherwise.
+Keep issue titles concise and actionable.
+When showing the backlog, group by project Status and sort by priority.
+
+If arguments were provided after `/pm`, treat them as the first instruction:
+$ARGUMENTS

--- a/claude-gh/commands/worker.md
+++ b/claude-gh/commands/worker.md
@@ -1,0 +1,35 @@
+---
+description: Worker — implements tasks from GitHub Issue specs, commits with issue reference
+argument-hint: <GitHub issue URL>
+---
+
+You are now in Worker mode.
+
+Refer to the project's `.claude/gh-workflow.md` for GitHub owner/repo, project number, and conventions. Use the GitHub MCP (`@github`) to read and update GitHub Issues and Projects.
+
+Workflow:
+1. Identify which issue to implement. If `$ARGUMENTS` contains a GitHub issue URL, use it; otherwise ask.
+2. Fetch the issue from GitHub and read the spec (Problem, Solution, Files to Modify, Verification).
+3. Update the project item's Status field to the **Status when starting work** value from `.claude/gh-workflow.md`.
+4. Implement the solution following the spec.
+5. Write tests for new features or bug fixes.
+6. Run tests to verify.
+7. Commit with the issue title as a prefix: `<Issue title>: <short description>`.
+8. Update the project item's Status field to the **Status when done** value from `.claude/gh-workflow.md`.
+9. Create a pull request:
+   - Find the base branch by running:
+     ```bash
+     WSLUG=$(git rev-parse --abbrev-ref HEAD | sed 's:task/::')
+     WBASE=$(dirname $(git rev-parse --show-toplevel))
+     INFO=$WBASE/.$WSLUG.info
+     BASE=main; [ -f $INFO ] && . $INFO
+     ```
+   - Run: `gh pr create --base $BASE --head $(git rev-parse --abbrev-ref HEAD) --fill`
+     This opens an editor so the user can review and submit the PR.
+   - After the PR is created, tell the user: run `task-done --remove-worktree` to clean up the worktree and close this tab.
+
+Always run tests after changes. If tests fail, fix before committing.
+Stay focused on the spec — don't add features beyond what's specified.
+If the spec is unclear or missing, ask before proceeding.
+
+$ARGUMENTS

--- a/claude-gh/install.sh
+++ b/claude-gh/install.sh
@@ -1,0 +1,58 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+
+echo "Installing claude-gh commands and scripts..."
+
+# Slash commands → ~/.claude/commands/
+mkdir -p ~/.claude/commands
+for cmd in "$SCRIPT_DIR"/commands/*.md; do
+  name=$(basename "$cmd")
+  ln -sf "$cmd" ~/.claude/commands/"$name"
+  echo "  ✓ Slash command: /$(basename "$name" .md)"
+done
+
+# Scripts → ~/.local/bin/ (task-init handled separately via unified root script)
+mkdir -p ~/.local/bin
+for script in "$SCRIPT_DIR"/bin/*; do
+  name=$(basename "$script")
+  [[ "$name" == "task-init" ]] && continue
+  ln -sf "$script" ~/.local/bin/"$name"
+  echo "  ✓ Script: $name"
+done
+
+# Unified task-init (always points to repo-root task-init regardless of which impl was installed last)
+ln -sf "$SCRIPT_DIR/../task-init" ~/.local/bin/task-init
+echo "  ✓ Script: task-init (unified)"
+
+# Ensure ~/.local/bin is on PATH
+# shellcheck disable=SC2016  # literal string written to shell RC; $HOME must not expand here
+PATH_LINE='export PATH="$HOME/.local/bin:$PATH"'
+MARKER='# added by claude-gh install.sh'
+
+if [[ ":$PATH:" == *":$HOME/.local/bin:"* ]]; then
+  echo "  ✓ ~/.local/bin already on PATH"
+else
+  case "${SHELL:-}" in
+    */zsh)  rc="$HOME/.zshrc" ;;
+    */bash) rc="$HOME/.bashrc" ;;
+    *)      rc="$HOME/.profile" ;;
+  esac
+  if [[ -f "$rc" ]] && grep -qF "$MARKER" "$rc"; then
+    echo "  ✓ PATH already configured in $rc"
+  else
+    printf '\n%s\n%s\n' "$MARKER" "$PATH_LINE" >> "$rc"
+    echo "  ✓ Added ~/.local/bin to PATH in $rc"
+    echo "    Run: source $rc   (or open a new terminal)"
+  fi
+fi
+
+echo ""
+echo "Done. Next steps:"
+echo "  1. Set GITHUB_PERSONAL_ACCESS_TOKEN in your environment (needs repo + project scopes)"
+echo "  2. Verify the GitHub MCP is configured: claude mcp list"
+echo "     (If not: claude mcp add --transport stdio github -- npx -y @github/github-mcp-server)"
+echo "  3. In your project root, run: task-init claude-gh"
+echo "  4. Fill in your GitHub owner, repo, and project number in .claude/gh-workflow.md"
+echo "  5. Start with: claude   (then type /pm)"

--- a/claude-gh/steering/gh-workflow.example.md
+++ b/claude-gh/steering/gh-workflow.example.md
@@ -1,0 +1,66 @@
+## GitHub Projects Workflow (Claude Code)
+
+Copy this file to your project's `.claude/gh-workflow.md` and fill in your details.
+Or run `task-init claude-gh` in your project root to do this automatically.
+
+Then reference it from `CLAUDE.md` at your project root so every Claude Code session auto-loads it:
+
+```
+@.claude/gh-workflow.md
+```
+
+### GitHub MCP (Claude Code)
+
+This workflow requires the GitHub MCP server configured in Claude Code. Verify with:
+
+```bash
+claude mcp list
+```
+
+You should see a `github` entry. If not, add it (requires `GITHUB_PERSONAL_ACCESS_TOKEN` in your environment):
+
+```bash
+claude mcp add --transport stdio github -- npx -y @github/github-mcp-server
+```
+
+### GitHub Repository
+
+- **Owner**: `YOUR_OWNER` (GitHub user or org name)
+- **Repo**: `YOUR_REPO` (repository name)
+- **Project number**: `YOUR_PROJECT_NUMBER` (from the project URL: github.com/users/YOUR_OWNER/projects/N or github.com/orgs/YOUR_OWNER/projects/N)
+
+### Task Lifecycle
+
+Todo → In Progress → Done
+
+- **Status when starting work**: `In Progress`
+- **Status when done**: `Done`
+
+The worker reads these two values and updates the project item's Status field accordingly: to "starting work" before implementing, and to "done" after committing (before running `task-done`).
+
+### Task Properties
+
+- **Title** (issue title), **Status** (project single-select field), **Priority** (project field)
+- **Git commit** (URL — set to PR link after done)
+
+### Commit Convention
+
+Use the issue title as prefix: `<Issue title>: <short description>`
+
+### Shell Commands
+
+`task-work <slug> [gh-url] [options]` — create worktree + zellij tab + worker session
+
+- `-b, --base BRANCH` — base branch for the PR (default: current branch)
+- `--no-launch` — open the worktree tab but do NOT start Claude
+
+Examples:
+```bash
+task-work add-auth "https://github.com/YOUR_OWNER/YOUR_REPO/issues/42"
+task-work https://github.com/YOUR_OWNER/YOUR_REPO/issues/42
+task-work refactor-auth
+task-work spike-idea --no-launch
+```
+
+`task-done` — from within worktree: show diff, print/detect PR, cleanup
+`task-done --remove-worktree` — cleanup only (use after worker has already created the PR)

--- a/install.sh
+++ b/install.sh
@@ -5,21 +5,23 @@ SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
 
 usage() {
   cat <<'EOF'
-Usage: ./install.sh [--help] [impl]
+Usage: ./install.sh [--help] [impl|all]
 
-Install one or all agentic-workflow implementations.
+Install an agentic-workflow implementation.
 
-Arguments:
+Implementations:
   claude-jira    Claude Code + Jira (Atlassian MCP)
-  kiro-notion    Kiro CLI + Notion MCP
   claude-notion  Claude Code + Notion MCP
-  all            Install all three
+  claude-gh      Claude Code + GitHub Projects (GitHub MCP)
+  kiro-notion    Kiro CLI + Notion MCP
+  kiro-gh        Kiro CLI + GitHub Projects (GitHub MCP)
+  all            Install all five
 
-With no argument, shows an interactive menu.
+With no argument, shows an interactive two-step menu (AI tool → board).
 
 Examples:
   ./install.sh
-  ./install.sh claude-notion
+  ./install.sh claude-gh
   ./install.sh all
 EOF
   exit 0
@@ -39,28 +41,49 @@ fi
 TARGET="${1:-}"
 
 if [[ -z "$TARGET" ]]; then
-  echo "Which implementation would you like to install?"
-  echo "  1) claude-jira"
-  echo "  2) kiro-notion"
-  echo "  3) claude-notion"
-  echo "  4) all"
-  read -rp "Choice [1-4]: " choice
-  case "$choice" in
-    1) TARGET="claude-jira" ;;
-    2) TARGET="kiro-notion" ;;
-    3) TARGET="claude-notion" ;;
-    4) TARGET="all" ;;
-    *) echo "Invalid choice: $choice" >&2; exit 1 ;;
+  echo "Which AI tool?"
+  echo "  1) Claude Code"
+  echo "  2) Kiro"
+  read -rp "Choice [1-2]: " tool_choice
+
+  case "$tool_choice" in
+    1)
+      echo ""
+      echo "Which board/tracker?"
+      echo "  1) Jira (Atlassian MCP)"
+      echo "  2) Notion (Notion MCP)"
+      echo "  3) GitHub Projects (GitHub MCP)"
+      read -rp "Choice [1-3]: " board_choice
+      case "$board_choice" in
+        1) TARGET="claude-jira" ;;
+        2) TARGET="claude-notion" ;;
+        3) TARGET="claude-gh" ;;
+        *) echo "Invalid choice: $board_choice" >&2; exit 1 ;;
+      esac ;;
+    2)
+      echo ""
+      echo "Which board/tracker?"
+      echo "  1) Notion (Notion MCP)"
+      echo "  2) GitHub Projects (GitHub MCP)"
+      read -rp "Choice [1-2]: " board_choice
+      case "$board_choice" in
+        1) TARGET="kiro-notion" ;;
+        2) TARGET="kiro-gh" ;;
+        *) echo "Invalid choice: $board_choice" >&2; exit 1 ;;
+      esac ;;
+    *) echo "Invalid choice: $tool_choice" >&2; exit 1 ;;
   esac
 fi
 
 case "$TARGET" in
-  claude-jira|kiro-notion|claude-notion)
+  claude-jira|claude-notion|claude-gh|kiro-notion|kiro-gh)
     install_impl "$TARGET" ;;
   all)
     install_impl claude-jira
+    install_impl claude-notion
+    install_impl claude-gh
     install_impl kiro-notion
-    install_impl claude-notion ;;
+    install_impl kiro-gh ;;
   *)
     echo "Unknown implementation: $TARGET" >&2
     usage ;;

--- a/kiro-gh/agents/planner.json
+++ b/kiro-gh/agents/planner.json
@@ -1,0 +1,28 @@
+{
+  "name": "planner",
+  "description": "Planner — designs solutions, writes implementation specs into GitHub Issues",
+  "prompt": "You are a Planner agent. Your job is to design implementation plans for tasks.\n\nRefer to the project's .kiro/steering/gh-workflow.md for GitHub owner/repo and conventions.\n\nWorkflow:\n1. When given an issue URL or title, fetch it from GitHub to read the current description\n2. Explore the codebase to understand the relevant architecture (read files, search symbols, grep patterns)\n3. Design the solution\n4. Write the implementation spec directly into the GitHub issue body\n\nSpec template (use when applicable, skip sections that are N/A):\n\n## Problem\nWhat we're solving and why.\n\n## Solution\nHow to implement it. Be specific about approach.\n\n## Files to Create/Modify\n| File | Action | Purpose |\n|------|--------|---------|\n| path | CREATE/MODIFY | What and why |\n\n## Verification\nConcrete steps to test that it works.\n\nWhen asked to start work on a planned issue, run: task-work \"<gh-issue-url>\"\nPass --trust-all for autonomous runs, -m <model> to pick a specific kiro model,\nor --no-launch to open the worktree tab and let the user drive.\n\nYou can READ code but NEVER write or modify files. Your output goes to GitHub only.",
+  "tools": [
+    "fs_read",
+    "grep",
+    "glob",
+    "code",
+    "execute_bash",
+    "@github"
+  ],
+  "allowedTools": [
+    "fs_read",
+    "grep",
+    "glob",
+    "code",
+    "@github"
+  ],
+  "mcpServers": {
+    "github": {
+      "command": "npx",
+      "args": ["-y", "@github/github-mcp-server"]
+    }
+  },
+  "keyboardShortcut": "ctrl+shift+l",
+  "welcomeMessage": "Planner mode. Point me at a GitHub issue and I'll design the implementation plan."
+}

--- a/kiro-gh/agents/pm.json
+++ b/kiro-gh/agents/pm.json
@@ -1,0 +1,26 @@
+{
+  "name": "pm",
+  "description": "Product Manager — backlog grooming, task creation, prioritization via GitHub Projects",
+  "prompt": "You are a PM agent. Your job is to manage the project backlog in GitHub Projects.\n\nRefer to the project's .kiro/steering/gh-workflow.md for GitHub owner/repo, project number, and conventions.\n\nYour responsibilities:\n- Show backlog status when asked (list open issues in the project, grouped by status and priority)\n- Create new issues with a clear title and brief body description, then add them to the project\n- Update issue labels, priorities, and project field values\n- Groom the backlog — identify stale issues, reprioritize, suggest what to work on next\n- When asked to start work on an issue, run: task-work \"<gh-issue-url>\"\n  Pass --trust-all for autonomous runs, -m <model> to pick a specific kiro model,\n  or --no-launch to open the worktree tab and let the user drive.\n\nWhen creating issues, set the project Status field to \"Todo\" unless told otherwise.\nKeep issue titles concise and actionable.\nWhen showing the backlog, group by project Status and sort by priority.",
+  "tools": [
+    "fs_read",
+    "grep",
+    "glob",
+    "execute_bash",
+    "@github"
+  ],
+  "allowedTools": [
+    "fs_read",
+    "grep",
+    "glob",
+    "@github"
+  ],
+  "mcpServers": {
+    "github": {
+      "command": "npx",
+      "args": ["-y", "@github/github-mcp-server"]
+    }
+  },
+  "keyboardShortcut": "ctrl+shift+p",
+  "welcomeMessage": "PM mode. I can show the backlog, create issues, groom priorities, or kick off a worker."
+}

--- a/kiro-gh/agents/worker.json
+++ b/kiro-gh/agents/worker.json
@@ -1,0 +1,30 @@
+{
+  "name": "worker",
+  "description": "Worker — implements tasks from GitHub Issue specs, commits with issue reference",
+  "prompt": "You are a Worker agent. Your job is to implement tasks from specs written in GitHub Issues.\n\nRefer to the project's .kiro/steering/gh-workflow.md for GitHub owner/repo, project number, and conventions.\n\nWorkflow:\n1. When starting, ask which issue to implement (or accept a GitHub issue URL)\n2. Fetch the issue from GitHub — read the spec (Problem, Solution, Files to Modify, Verification)\n3. Update the project item's Status field to the **Status when starting work** value from .kiro/steering/gh-workflow.md (use the @github MCP).\n4. Implement the solution following the spec\n5. Write tests for new features or bug fixes\n6. Run tests to verify\n7. Commit with the issue title as a prefix: `<Issue title>: <short description>`\n8. Update the project item's Status field to the **Status when done** value from .kiro/steering/gh-workflow.md.\n\nAlways run tests after changes. If tests fail, fix before committing.\nStay focused on the spec — don't add features beyond what's specified.\nIf the spec is unclear or missing, ask before proceeding.\n\n9. Create a pull request:\n   - Find the base branch by reading the task info file. Run:\n       WSLUG=$(git rev-parse --abbrev-ref HEAD | sed 's:task/::')\n       WBASE=$(dirname $(git rev-parse --show-toplevel))\n       INFO=$WBASE/.$WSLUG.info\n       BASE=main; [ -f $INFO ] && . $INFO\n   - Run: gh pr create --base $BASE --head $(git rev-parse --abbrev-ref HEAD) --fill\n     This opens an editor so the user can review and submit the PR.\n   - After the PR is created, tell the user: run `task-done --remove-worktree` to clean up the worktree and close this tab.",
+  "tools": [
+    "fs_read",
+    "fs_write",
+    "execute_bash",
+    "grep",
+    "glob",
+    "code",
+    "subagent",
+    "@github"
+  ],
+  "allowedTools": [
+    "fs_read",
+    "grep",
+    "glob",
+    "code",
+    "@github"
+  ],
+  "mcpServers": {
+    "github": {
+      "command": "npx",
+      "args": ["-y", "@github/github-mcp-server"]
+    }
+  },
+  "keyboardShortcut": "ctrl+shift+w",
+  "welcomeMessage": "Worker mode. Give me a GitHub issue URL and I'll implement it from the spec."
+}

--- a/kiro-gh/bin/task-done
+++ b/kiro-gh/bin/task-done
@@ -1,0 +1,111 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+usage() {
+  echo "Usage: task-done [--force] [--remove-worktree]"
+  echo ""
+  echo "Run from within a worktree to:"
+  echo "  1. Show the diff summary and existing PR (or print gh pr create command)"
+  echo "  2. Remove the worktree"
+  echo "  3. Close the zellij tab"
+  echo ""
+  echo "Options:"
+  echo "  --force            Skip confirmation prompts"
+  echo "  --remove-worktree  Skip PR section — just clean up the worktree and tab."
+  echo "                     Use after the worker has already created the PR."
+  exit 1
+}
+
+FORCE=false
+REMOVE_ONLY=false
+
+while [[ $# -gt 0 ]]; do
+  case "$1" in
+    --force) FORCE=true; shift ;;
+    --remove-worktree) REMOVE_ONLY=true; shift ;;
+    -h|--help) usage ;;
+    *) echo "Unknown option: $1"; usage ;;
+  esac
+done
+
+# Detect worktree context
+WORKTREE_DIR=$(pwd)
+REPO_ROOT=$(git rev-parse --show-toplevel 2>/dev/null) || { echo "Error: not in a git repo"; exit 1; }
+
+# Check we're actually in a worktree (not the main repo)
+MAIN_WORKTREE=$(git worktree list --porcelain | head -1 | sed 's/worktree //')
+if [[ "$REPO_ROOT" == "$MAIN_WORKTREE" ]]; then
+  echo "Error: you're in the main repo, not a worktree. cd into a worktree first."
+  exit 1
+fi
+
+BRANCH=$(git rev-parse --abbrev-ref HEAD)
+SLUG="${BRANCH#task/}"
+REPO_NAME=$(basename "$MAIN_WORKTREE")
+WORKTREE_BASE="${MAIN_WORKTREE}/../${REPO_NAME}-worktrees"
+INFO_FILE="${WORKTREE_BASE}/.${SLUG}.info"
+
+# Load base branch written by task-work; fall back to "main"
+BASE_BRANCH="main"
+# shellcheck source=/dev/null
+[[ -f "$INFO_FILE" ]] && source "$INFO_FILE"
+
+echo "Worktree: $WORKTREE_DIR"
+echo "Branch:   $BRANCH"
+echo "Base:     $BASE_BRANCH"
+echo ""
+
+# Check for uncommitted changes
+if ! git diff --quiet || ! git diff --cached --quiet; then
+  echo "⚠ Uncommitted changes detected:"
+  git status --short
+  echo ""
+  if [[ "$FORCE" != true ]]; then
+    read -rp "Continue anyway? (y/N) " confirm
+    [[ "$confirm" != "y" && "$confirm" != "Y" ]] && exit 1
+  fi
+fi
+
+# Show summary
+COMMIT_COUNT=$(git rev-list --count "${BASE_BRANCH}..HEAD" 2>/dev/null || echo "?")
+echo "Commits ahead of ${BASE_BRANCH}: $COMMIT_COUNT"
+DIFF_STAT=$(git diff --shortstat "${BASE_BRANCH}..HEAD" 2>/dev/null || true)
+[[ -n "$DIFF_STAT" ]] && echo "Changes: $DIFF_STAT"
+echo ""
+
+if [[ "$REMOVE_ONLY" != true ]]; then
+  # Show existing PR URL, or print the creation command
+  PR_URL=$(gh pr view --json url -q .url 2>/dev/null || true)
+  if [[ -n "$PR_URL" ]]; then
+    echo "PR: $PR_URL"
+  else
+    echo "To create a PR:"
+    echo "  gh pr create --base $BASE_BRANCH --head $BRANCH --title \"${BRANCH#task/}\" --fill"
+  fi
+  echo ""
+fi
+
+if [[ "$FORCE" != true ]]; then
+  read -rp "Remove worktree and close tab? (y/N) " confirm
+  [[ "$confirm" != "y" && "$confirm" != "Y" ]] && exit 0
+fi
+
+# Move out of worktree before removing it
+cd "$MAIN_WORKTREE"
+
+# Remove worktree
+echo "Removing worktree..."
+git worktree remove "$WORKTREE_DIR" --force 2>/dev/null || {
+  echo "Warning: could not remove worktree cleanly. Trying prune..."
+  rm -rf "$WORKTREE_DIR"
+  git worktree prune
+}
+
+# Clean up info file
+[[ -f "$INFO_FILE" ]] && rm -f "$INFO_FILE"
+
+# Close current zellij tab
+echo "Closing zellij tab..."
+zellij action close-tab
+
+echo "Done. Branch '$BRANCH' still exists — delete after PR merge with: git branch -d $BRANCH"

--- a/kiro-gh/bin/task-init
+++ b/kiro-gh/bin/task-init
@@ -1,0 +1,54 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+usage() {
+  echo "Usage: task-init [--force]"
+  echo ""
+  echo "Set up the current repo for the kiro-gh workflow:"
+  echo "  - Create .kiro/steering/gh-workflow.md from the bundled template"
+  echo ""
+  echo "Options:"
+  echo "  --force   Overwrite .kiro/steering/gh-workflow.md if present"
+  exit 1
+}
+
+FORCE=false
+
+while [[ $# -gt 0 ]]; do
+  case "$1" in
+    --force) FORCE=true; shift ;;
+    -h|--help) usage ;;
+    *) echo "Unknown option: $1"; usage ;;
+  esac
+done
+
+# Resolve script path through symlinks
+src="${BASH_SOURCE[0]}"
+while [ -L "$src" ]; do
+  dir=$(cd -P "$(dirname "$src")" && pwd)
+  src=$(readlink "$src")
+  [[ $src != /* ]] && src="$dir/$src"
+done
+SCRIPT_DIR=$(cd -P "$(dirname "$src")" && pwd)
+TEMPLATE="$SCRIPT_DIR/../steering/gh-workflow.example.md"
+
+if [[ ! -f "$TEMPLATE" ]]; then
+  echo "Error: template not found at $TEMPLATE"
+  exit 1
+fi
+
+git rev-parse --show-toplevel >/dev/null 2>&1 || { echo "Error: not in a git repo"; exit 1; }
+REPO_ROOT=$(git rev-parse --show-toplevel)
+TARGET="$REPO_ROOT/.kiro/steering/gh-workflow.md"
+
+mkdir -p "$REPO_ROOT/.kiro/steering"
+
+if [[ -f "$TARGET" && "$FORCE" != true ]]; then
+  echo "$TARGET already exists. Use --force to overwrite."
+  exit 1
+fi
+
+cp "$TEMPLATE" "$TARGET"
+echo "✓ Wrote $TARGET"
+echo ""
+echo "Done. Open .kiro/steering/gh-workflow.md to fill in your GitHub owner, repo, and project number."

--- a/kiro-gh/bin/task-work
+++ b/kiro-gh/bin/task-work
@@ -1,0 +1,189 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+usage() {
+  cat <<'EOF'
+Usage:
+  task-work <slug> <gh-url> [options]    # explicit slug + GitHub issue URL (preferred when an agent kicks it off)
+  task-work <gh-url> [options]           # slug derived from issue number (issue-N)
+  task-work <free-form-slug> [options]   # ad-hoc, no GitHub URL
+
+Creates a git worktree + branch for a task and opens a new zellij tab
+with a worker agent. If a worktree for that slug already exists, a
+5-char hash is appended so multiple agents can work the same task in parallel.
+
+Options:
+  -m, --model MODEL   Model to pass to kiro-cli (e.g. claude-opus-4.6,
+                      claude-sonnet-4.5). Defaults to $TASK_WORK_MODEL if set,
+                      else kiro-cli's own default (auto).
+  -a, --trust-all     Pass --trust-all-tools to kiro-cli so the worker can run
+                      commands without per-tool confirmation. Defaults to
+                      $TASK_WORK_TRUST_ALL=1 if set.
+  -b, --base BRANCH   Base branch for the PR (default: current branch at call time).
+      --no-launch     Create the worktree and open the tab at its directory,
+                      but do NOT start kiro-cli. Use this when you want to
+                      pick the command/model interactively.
+  -h, --help          Show this help.
+
+Environment:
+  TASK_WORK_MODEL         Default model (overridable with --model)
+  TASK_WORK_TRUST_ALL     If set to 1/true, defaults --trust-all on
+
+Examples:
+  task-work add-auth "https://github.com/owner/repo/issues/42"
+  task-work https://github.com/owner/repo/issues/42
+  task-work refactor-auth -m claude-opus-4.6 --trust-all
+  task-work spike-idea --no-launch
+  TASK_WORK_MODEL=claude-sonnet-4.6 task-work new-thing https://github.com/owner/repo/issues/5
+EOF
+  exit "${1:-1}"
+}
+
+# ---------------- arg parsing ----------------
+POSITIONAL=()
+MODEL="${TASK_WORK_MODEL:-}"
+TRUST_ALL=""
+NO_LAUNCH=""
+BASE_BRANCH_OVERRIDE=""
+
+# Treat TASK_WORK_TRUST_ALL=1 / true / yes as enabled
+case "${TASK_WORK_TRUST_ALL:-}" in
+  1|true|TRUE|yes|YES) TRUST_ALL="1" ;;
+esac
+
+while [[ $# -gt 0 ]]; do
+  case "$1" in
+    -h|--help) usage 0 ;;
+    -m|--model)
+      [[ $# -ge 2 ]] || { echo "Error: --model requires a value" >&2; exit 1; }
+      MODEL="$2"; shift 2 ;;
+    -a|--trust-all) TRUST_ALL="1"; shift ;;
+    -b|--base)
+      [[ $# -ge 2 ]] || { echo "Error: --base requires a value" >&2; exit 1; }
+      BASE_BRANCH_OVERRIDE="$2"; shift 2 ;;
+    --no-launch) NO_LAUNCH="1"; shift ;;
+    --) shift; while [[ $# -gt 0 ]]; do POSITIONAL+=("$1"); shift; done ;;
+    -*) echo "Error: unknown flag '$1'" >&2; usage 1 ;;
+    *) POSITIONAL+=("$1"); shift ;;
+  esac
+done
+
+[[ ${#POSITIONAL[@]} -lt 1 ]] && usage
+
+is_github_url() {
+  [[ "$1" == *"github.com"*"/issues/"* ]]
+}
+
+derive_slug_from_url() {
+  local url="$1"
+  local issue_num
+  issue_num=$(echo "$url" | sed 's|.*/issues/||' | sed 's|[^0-9].*||')
+  if [[ -n "$issue_num" ]]; then
+    echo "issue-${issue_num}"
+  else
+    echo "$url" | sed 's|.*/||' | tr '[:upper:]' '[:lower:]' | sed 's/[^a-z0-9-]//g'
+  fi
+}
+
+sanitize_slug() {
+  echo "$1" | tr '[:upper:]' '[:lower:]' | tr ' ' '-' | sed 's/[^a-z0-9-]//g'
+}
+
+# Resolve GH_URL and SLUG from positional args:
+#   1 arg,  URL           → derive slug from issue number
+#   1 arg,  not URL       → slug only, no URL
+#   2 args, URL in either → other one is the slug
+GH_URL=""
+SLUG=""
+P0="${POSITIONAL[0]}"
+P1="${POSITIONAL[1]:-}"
+
+if [[ ${#POSITIONAL[@]} -ge 2 ]] && ! is_github_url "$P0" && is_github_url "$P1"; then
+  SLUG=$(sanitize_slug "$P0")
+  GH_URL="$P1"
+elif [[ ${#POSITIONAL[@]} -ge 2 ]] && is_github_url "$P0" && ! is_github_url "$P1"; then
+  GH_URL="$P0"
+  SLUG=$(sanitize_slug "$P1")
+elif is_github_url "$P0"; then
+  GH_URL="$P0"
+  SLUG=$(derive_slug_from_url "$P0")
+else
+  SLUG=$(sanitize_slug "$P0")
+fi
+
+[[ -z "$SLUG" ]] && { echo "Error: could not derive a slug from input" >&2; exit 1; }
+SLUG="${SLUG:0:50}"
+
+# ---------------- repo discovery ----------------
+REPO_ROOT=$(git rev-parse --show-toplevel 2>/dev/null) || { echo "Error: not in a git repo" >&2; exit 1; }
+REPO_NAME=$(basename "$REPO_ROOT")
+WORKTREE_BASE="${REPO_ROOT}/../${REPO_NAME}-worktrees"
+
+# Capture base branch now, before the worktree is created
+BASE_BRANCH="${BASE_BRANCH_OVERRIDE:-$(git rev-parse --abbrev-ref HEAD)}"
+
+BRANCH="task/${SLUG}"
+WORKTREE_DIR="${WORKTREE_BASE}/${SLUG}"
+
+# ---------------- command builder ----------------
+build_kiro_cmd() {
+  local cmd="kiro-cli chat --agent worker"
+  [[ -n "$MODEL" ]] && cmd+=" --model $MODEL"
+  [[ -n "$TRUST_ALL" ]] && cmd+=" --trust-all-tools"
+  if [[ -n "$GH_URL" ]]; then
+    cmd+=" \"Implement task: $GH_URL\""
+  fi
+  echo "$cmd"
+}
+
+# ---------------- zellij tab launch ----------------
+launch_in_tab() {
+  local dir="$1"
+  # Explicitly focus the new tab by name — idempotent, defeats the race
+  # where `write-chars` could otherwise target the previously-focused pane.
+  zellij action go-to-tab-name "$SLUG"
+  sleep 0.3
+
+  if [[ -n "$NO_LAUNCH" ]]; then
+    zellij action write-chars "cd $dir"
+  else
+    zellij action write-chars "cd $dir && $(build_kiro_cmd)"
+  fi
+  sleep 0.1
+  zellij action write 10  # Enter
+}
+
+# ---------------- worktree creation ----------------
+if [[ -d "$WORKTREE_DIR" ]]; then
+  HASH=$(LC_ALL=C tr -dc 'a-z0-9' </dev/urandom | head -c 5 || :)
+  SLUG="${SLUG}-${HASH}"
+  BRANCH="task/${SLUG}"
+  WORKTREE_DIR="${WORKTREE_BASE}/${SLUG}"
+  echo "Existing worktree found — creating a parallel session: $SLUG"
+fi
+
+mkdir -p "$WORKTREE_BASE"
+echo "Creating branch $BRANCH and worktree at $WORKTREE_DIR..."
+git worktree add "$WORKTREE_DIR" -b "$BRANCH" 2>/dev/null || {
+  git worktree add "$WORKTREE_DIR" "$BRANCH" 2>/dev/null || {
+    echo "Error: could not create worktree. Check if branch '$BRANCH' exists elsewhere." >&2
+    exit 1
+  }
+}
+
+# Write task info so the worker and task-done can read it (stored outside the working tree)
+INFO_FILE="${WORKTREE_BASE}/.${SLUG}.info"
+printf 'BASE_BRANCH=%s\nSLUG=%s\nGH_URL=%s\n' "$BASE_BRANCH" "$SLUG" "$GH_URL" > "$INFO_FILE"
+
+echo "Opening zellij tab '$SLUG'..."
+zellij action new-tab --name "$SLUG" --cwd "$WORKTREE_DIR"
+launch_in_tab "$WORKTREE_DIR"
+
+if [[ -n "$NO_LAUNCH" ]]; then
+  echo "Tab opened at $WORKTREE_DIR (branch: $BRANCH, base: $BASE_BRANCH) — kiro NOT launched (--no-launch)."
+else
+  desc="worker"
+  [[ -n "$MODEL" ]] && desc+=" [model=$MODEL]"
+  [[ -n "$TRUST_ALL" ]] && desc+=" [trust-all]"
+  echo "Started $desc in $WORKTREE_DIR (branch: $BRANCH, base: $BASE_BRANCH)"
+fi

--- a/kiro-gh/install.sh
+++ b/kiro-gh/install.sh
@@ -1,0 +1,56 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+
+echo "Installing kiro-gh agents..."
+
+# Agents → ~/.kiro/agents/
+mkdir -p ~/.kiro/agents
+for agent in "$SCRIPT_DIR"/agents/*.json; do
+  name=$(basename "$agent")
+  ln -sf "$agent" ~/.kiro/agents/"$name"
+  echo "  ✓ Agent: $name"
+done
+
+# Scripts → ~/.local/bin/ (task-init handled separately via unified root script)
+mkdir -p ~/.local/bin
+for script in "$SCRIPT_DIR"/bin/*; do
+  name=$(basename "$script")
+  [[ "$name" == "task-init" ]] && continue
+  ln -sf "$script" ~/.local/bin/"$name"
+  echo "  ✓ Script: $name"
+done
+
+# Unified task-init (always points to repo-root task-init regardless of which impl was installed last)
+ln -sf "$SCRIPT_DIR/../task-init" ~/.local/bin/task-init
+echo "  ✓ Script: task-init (unified)"
+
+# Ensure ~/.local/bin is on PATH
+# shellcheck disable=SC2016  # literal string written to shell RC; $HOME must not expand here
+PATH_LINE='export PATH="$HOME/.local/bin:$PATH"'
+MARKER='# added by kiro-gh install.sh'
+
+if [[ ":$PATH:" == *":$HOME/.local/bin:"* ]]; then
+  echo "  ✓ ~/.local/bin already on PATH"
+else
+  case "${SHELL:-}" in
+    */zsh)  rc="$HOME/.zshrc" ;;
+    */bash) rc="$HOME/.bashrc" ;;
+    *)      rc="$HOME/.profile" ;;
+  esac
+  if [[ -f "$rc" ]] && grep -qF "$MARKER" "$rc"; then
+    echo "  ✓ PATH already configured in $rc"
+  else
+    printf '\n%s\n%s\n' "$MARKER" "$PATH_LINE" >> "$rc"
+    echo "  ✓ Added ~/.local/bin to PATH in $rc"
+    echo "    Run: source $rc   (or open a new terminal)"
+  fi
+fi
+
+echo ""
+echo "Done. Next steps:"
+echo "  1. Set GITHUB_PERSONAL_ACCESS_TOKEN in your environment (needs repo + project scopes)"
+echo "  2. In your project root, run: task-init kiro-gh"
+echo "  3. Fill in your GitHub owner, repo, and project number in .kiro/steering/gh-workflow.md"
+echo "  4. Start with: kiro-cli chat --agent pm"

--- a/kiro-gh/steering/gh-workflow.example.md
+++ b/kiro-gh/steering/gh-workflow.example.md
@@ -1,0 +1,59 @@
+## GitHub Projects Workflow (Kiro)
+
+Copy this file to your project's `.kiro/steering/gh-workflow.md` and fill in your details.
+Or run `task-init kiro-gh` in your project root to do this automatically.
+
+### GitHub MCP (Kiro)
+
+This workflow requires the GitHub MCP server configured in Kiro. Add it to your agent definitions'
+`mcpServers` block (already done in the bundled agents):
+
+```json
+"github": { "command": "npx", "args": ["-y", "@github/github-mcp-server"] }
+```
+
+Set `GITHUB_PERSONAL_ACCESS_TOKEN` in your environment before running Kiro.
+
+### GitHub Repository
+
+- **Owner**: `YOUR_OWNER` (GitHub user or org name)
+- **Repo**: `YOUR_REPO` (repository name)
+- **Project number**: `YOUR_PROJECT_NUMBER` (from the project URL: github.com/users/YOUR_OWNER/projects/N or github.com/orgs/YOUR_OWNER/projects/N)
+
+### Task Lifecycle
+
+Todo → In Progress → Done
+
+- **Status when starting work**: `In Progress`
+- **Status when done**: `Done`
+
+The worker reads these two values and updates the project item's Status field accordingly: to "starting work" before implementing, and to "done" after committing (before running `task-done`).
+
+### Task Properties
+
+- **Title** (issue title), **Status** (project single-select field), **Priority** (project field)
+- **Git commit** (URL — set to PR link after done)
+
+### Commit Convention
+
+Use the issue title as prefix: `<Issue title>: <short description>`
+
+### Shell Commands
+
+`task-work <slug> [gh-url] [options]` — create worktree + zellij tab + worker agent
+
+- `-m, --model MODEL` — pick a specific kiro model
+- `-a, --trust-all` — pass `--trust-all-tools` so the worker runs without per-tool confirmation
+- `-b, --base BRANCH` — base branch for the PR (default: current branch)
+- `--no-launch` — open the worktree tab but do NOT start kiro
+
+Examples:
+```bash
+task-work add-auth "https://github.com/{OWNER}/{REPO}/issues/42"
+task-work https://github.com/{OWNER}/{REPO}/issues/42
+task-work refactor-auth -m claude-opus-4.6 --trust-all
+task-work spike-idea --no-launch
+```
+
+`task-done` — from within worktree: show diff, print/detect PR, cleanup
+`task-done --remove-worktree` — cleanup only (use after worker has already created the PR)

--- a/task-init
+++ b/task-init
@@ -6,14 +6,18 @@ usage() {
 Usage: task-init [--help] [--force] [impl] [impl-options]
 
 Sets up the current git repo for an agentic-workflow implementation.
-With no impl argument, shows an interactive menu.
+With no impl argument, shows an interactive two-step menu (AI tool → board).
 
 Implementations:
   claude-jira    Claude Code + Jira (Atlassian MCP)
                  Options: --site URL, --key PROJ, --board NAME, --force
+  claude-notion  Claude Code + Notion MCP
+                 Options: --force
+  claude-gh      Claude Code + GitHub Projects (GitHub MCP)
+                 Options: --force
   kiro-notion    Kiro CLI + Notion MCP
                  Options: --force
-  claude-notion  Claude Code + Notion MCP
+  kiro-gh        Kiro CLI + GitHub Projects (GitHub MCP)
                  Options: --force
 
 Global options:
@@ -22,8 +26,8 @@ Global options:
 
 Examples:
   task-init
-  task-init claude-notion
-  task-init kiro-notion --force
+  task-init claude-gh
+  task-init kiro-gh --force
   task-init claude-jira --site https://acme.atlassian.net --key PROJ --board "My Board"
 EOF
   exit 0
@@ -46,7 +50,7 @@ while [[ $# -gt 0 ]]; do
   case "$1" in
     -h|--help) usage ;;
     --force) FORCE_FLAG="--force"; shift ;;
-    claude-jira|kiro-notion|claude-notion) IMPL="$1"; shift ;;
+    claude-jira|claude-notion|claude-gh|kiro-notion|kiro-gh) IMPL="$1"; shift ;;
     *) PASSTHROUGH+=("$1"); shift ;;
   esac
 done
@@ -54,16 +58,37 @@ done
 git rev-parse --show-toplevel >/dev/null 2>&1 || { echo "Error: not in a git repo" >&2; exit 1; }
 
 if [[ -z "$IMPL" ]]; then
-  echo "Which implementation would you like to set up for this project?"
-  echo "  1) claude-jira   → .claude/jira-workflow.md + CLAUDE.md"
-  echo "  2) kiro-notion   → .kiro/steering/notion-workflow.md"
-  echo "  3) claude-notion → .claude/notion-workflow.md + CLAUDE.md"
-  read -rp "Choice [1-3]: " choice
-  case "$choice" in
-    1) IMPL="claude-jira" ;;
-    2) IMPL="kiro-notion" ;;
-    3) IMPL="claude-notion" ;;
-    *) echo "Invalid choice: $choice" >&2; exit 1 ;;
+  echo "Which AI tool?"
+  echo "  1) Claude Code"
+  echo "  2) Kiro"
+  read -rp "Choice [1-2]: " tool_choice
+
+  case "$tool_choice" in
+    1)
+      echo ""
+      echo "Which board/tracker?"
+      echo "  1) Jira (Atlassian MCP)       → .claude/jira-workflow.md + CLAUDE.md"
+      echo "  2) Notion (Notion MCP)         → .claude/notion-workflow.md + CLAUDE.md"
+      echo "  3) GitHub Projects (GitHub MCP) → .claude/gh-workflow.md + CLAUDE.md"
+      read -rp "Choice [1-3]: " board_choice
+      case "$board_choice" in
+        1) IMPL="claude-jira" ;;
+        2) IMPL="claude-notion" ;;
+        3) IMPL="claude-gh" ;;
+        *) echo "Invalid choice: $board_choice" >&2; exit 1 ;;
+      esac ;;
+    2)
+      echo ""
+      echo "Which board/tracker?"
+      echo "  1) Notion (Notion MCP)         → .kiro/steering/notion-workflow.md"
+      echo "  2) GitHub Projects (GitHub MCP) → .kiro/steering/gh-workflow.md"
+      read -rp "Choice [1-2]: " board_choice
+      case "$board_choice" in
+        1) IMPL="kiro-notion" ;;
+        2) IMPL="kiro-gh" ;;
+        *) echo "Invalid choice: $board_choice" >&2; exit 1 ;;
+      esac ;;
+    *) echo "Invalid choice: $tool_choice" >&2; exit 1 ;;
   esac
 fi
 

--- a/tests/claude_gh_task_init.bats
+++ b/tests/claude_gh_task_init.bats
@@ -1,0 +1,98 @@
+#!/usr/bin/env bats
+# Tests for claude-gh/bin/task-init
+
+bats_load_library bats-support
+bats_load_library bats-assert
+
+load helpers/common
+
+TARGET_DIR=""
+
+setup() {
+  setup_repo
+  TARGET_DIR="$MAIN_REPO"
+  cd "$TARGET_DIR"
+}
+
+teardown() {
+  teardown_all
+}
+
+# ---------------------------------------------------------------------------
+# File creation
+# ---------------------------------------------------------------------------
+
+@test "copies template to .claude/gh-workflow.md" {
+  run "$CLAUDE_GH_TASK_INIT"
+  assert_success
+  assert [ -f "$TARGET_DIR/.claude/gh-workflow.md" ]
+}
+
+@test "copied file contains placeholder text" {
+  run "$CLAUDE_GH_TASK_INIT"
+  assert_success
+  run grep -F "YOUR_PROJECT_NUMBER" "$TARGET_DIR/.claude/gh-workflow.md"
+  assert_success
+}
+
+# ---------------------------------------------------------------------------
+# CLAUDE.md integration
+# ---------------------------------------------------------------------------
+
+@test "creates CLAUDE.md with @.claude/gh-workflow.md when none exists" {
+  run "$CLAUDE_GH_TASK_INIT"
+  assert_success
+  assert [ -f "$TARGET_DIR/CLAUDE.md" ]
+  run grep -F "@.claude/gh-workflow.md" "$TARGET_DIR/CLAUDE.md"
+  assert_success
+}
+
+@test "appends to existing CLAUDE.md" {
+  echo "# Existing content" > "$TARGET_DIR/CLAUDE.md"
+  run "$CLAUDE_GH_TASK_INIT"
+  assert_success
+  run cat "$TARGET_DIR/CLAUDE.md"
+  assert_output --partial "# Existing content"
+  assert_output --partial "@.claude/gh-workflow.md"
+}
+
+@test "does not duplicate the import line in CLAUDE.md" {
+  run "$CLAUDE_GH_TASK_INIT"
+  assert_success
+  run "$CLAUDE_GH_TASK_INIT" --force
+  assert_success
+  local count
+  count=$(grep -c "@.claude/gh-workflow.md" "$TARGET_DIR/CLAUDE.md" || true)
+  assert_equal "$count" "1"
+}
+
+# ---------------------------------------------------------------------------
+# --force and overwrite guard
+# ---------------------------------------------------------------------------
+
+@test "fails if .claude/gh-workflow.md already exists (no --force)" {
+  run "$CLAUDE_GH_TASK_INIT"
+  assert_success
+  run "$CLAUDE_GH_TASK_INIT"
+  assert_failure
+  assert_output --partial "already exists"
+}
+
+@test "--force overwrites existing gh-workflow.md" {
+  run "$CLAUDE_GH_TASK_INIT"
+  assert_success
+  run "$CLAUDE_GH_TASK_INIT" --force
+  assert_success
+  assert [ -f "$TARGET_DIR/.claude/gh-workflow.md" ]
+}
+
+# ---------------------------------------------------------------------------
+# Error cases
+# ---------------------------------------------------------------------------
+
+@test "fails outside a git repo" {
+  cd /tmp
+  run "$CLAUDE_GH_TASK_INIT"
+  assert_failure
+  assert_output --partial "not in a git repo"
+}

--- a/tests/claude_gh_task_work.bats
+++ b/tests/claude_gh_task_work.bats
@@ -1,0 +1,165 @@
+#!/usr/bin/env bats
+# Tests for claude-gh/bin/task-work
+
+bats_load_library bats-support
+bats_load_library bats-assert
+
+load helpers/common
+
+setup() {
+  setup_repo
+  setup_stubs
+  cd "$MAIN_REPO"
+}
+
+teardown() {
+  teardown_all
+}
+
+# ---------------------------------------------------------------------------
+# Slug derivation
+# ---------------------------------------------------------------------------
+
+@test "free-form slug: lowercase and sanitize" {
+  run "$CLAUDE_GH_TASK_WORK" "My Feature Task"
+  assert_success
+  assert [ -d "$WORKTREE_BASE/my-feature-task" ]
+}
+
+@test "free-form slug: truncated to 50 chars" {
+  local long_slug
+  long_slug=$(printf 'abcde%.0s' {1..20})  # "abcde" x20 = 100 chars
+  run "$CLAUDE_GH_TASK_WORK" "$long_slug"
+  assert_success
+  run bash -c "ls '$WORKTREE_BASE' | head -1"
+  assert [ "${#output}" -le 50 ]
+}
+
+@test "github issue URL: derives slug as issue-N" {
+  run "$CLAUDE_GH_TASK_WORK" "https://github.com/owner/repo/issues/42"
+  assert_success
+  assert [ -d "$WORKTREE_BASE/issue-42" ]
+}
+
+@test "github issue URL with trailing params: still derives issue number" {
+  run "$CLAUDE_GH_TASK_WORK" "https://github.com/owner/repo/issues/99?foo=bar"
+  assert_success
+  assert [ -d "$WORKTREE_BASE/issue-99" ]
+}
+
+@test "explicit slug + URL: slug takes precedence over derived" {
+  run "$CLAUDE_GH_TASK_WORK" "my-explicit-slug" "https://github.com/owner/repo/issues/42"
+  assert_success
+  assert [ -d "$WORKTREE_BASE/my-explicit-slug" ]
+}
+
+# ---------------------------------------------------------------------------
+# Worktree + branch creation
+# ---------------------------------------------------------------------------
+
+@test "creates git worktree on branch task/<slug>" {
+  run "$CLAUDE_GH_TASK_WORK" my-feature
+  assert_success
+  local branches
+  branches=$(git -C "$MAIN_REPO" branch --list "task/my-feature")
+  assert [ -n "$branches" ]
+  assert [ -d "$WORKTREE_BASE/my-feature" ]
+}
+
+@test "parallel session: appends 5-char hash when worktree already exists" {
+  run "$CLAUDE_GH_TASK_WORK" my-feature
+  assert_success
+  run "$CLAUDE_GH_TASK_WORK" my-feature
+  assert_success
+  assert_output --partial "parallel session"
+  run bash -c "ls '$WORKTREE_BASE' | grep -c '^my-feature'"
+  assert_output "2"
+}
+
+# ---------------------------------------------------------------------------
+# .info file
+# ---------------------------------------------------------------------------
+
+@test "writes .info file with BASE_BRANCH=current branch" {
+  run "$CLAUDE_GH_TASK_WORK" my-feature
+  assert_success
+  local info="$WORKTREE_BASE/.my-feature.info"
+  assert [ -f "$info" ]
+  source "$info"
+  assert_equal "$BASE_BRANCH" "main"
+}
+
+@test "--base flag overrides BASE_BRANCH in .info" {
+  run "$CLAUDE_GH_TASK_WORK" --base develop my-feature
+  assert_success
+  source "$WORKTREE_BASE/.my-feature.info"
+  assert_equal "$BASE_BRANCH" "develop"
+}
+
+@test ".info records GH_URL when URL is provided" {
+  local url="https://github.com/owner/repo/issues/42"
+  run "$CLAUDE_GH_TASK_WORK" my-feature "$url"
+  assert_success
+  source "$WORKTREE_BASE/.my-feature.info"
+  assert_equal "$GH_URL" "$url"
+}
+
+@test ".info GH_URL is empty for free-form slugs" {
+  run "$CLAUDE_GH_TASK_WORK" my-feature
+  assert_success
+  source "$WORKTREE_BASE/.my-feature.info"
+  assert_equal "${GH_URL:-}" ""
+}
+
+# ---------------------------------------------------------------------------
+# Zellij interactions
+# ---------------------------------------------------------------------------
+
+@test "opens a new zellij tab named after the slug" {
+  run "$CLAUDE_GH_TASK_WORK" my-feature
+  assert_success
+  assert_stub_called zellij "new-tab --name my-feature"
+}
+
+@test "--no-launch: opens tab but does not inject claude command" {
+  run "$CLAUDE_GH_TASK_WORK" --no-launch my-feature
+  assert_success
+  assert_output --partial "claude NOT launched"
+  run grep -F "claude " "$STUB_CALLS_DIR/zellij.calls"
+  assert_failure
+}
+
+@test "claude command includes task URL when provided" {
+  local url="https://github.com/owner/repo/issues/42"
+  run "$CLAUDE_GH_TASK_WORK" my-feature "$url"
+  assert_success
+  assert_stub_called zellij "Implement task: $url"
+}
+
+@test "claude command uses /worker for free-form slugs" {
+  run "$CLAUDE_GH_TASK_WORK" my-feature
+  assert_success
+  assert_stub_called zellij "/worker\""
+}
+
+# ---------------------------------------------------------------------------
+# Error cases
+# ---------------------------------------------------------------------------
+
+@test "fails outside a git repo" {
+  cd /tmp
+  run "$CLAUDE_GH_TASK_WORK" my-feature
+  assert_failure
+  assert_output --partial "not in a git repo"
+}
+
+@test "fails when --base missing its value" {
+  run "$CLAUDE_GH_TASK_WORK" --base
+  assert_failure
+  assert_output --partial "--base requires a value"
+}
+
+@test "fails on unknown flag" {
+  run "$CLAUDE_GH_TASK_WORK" --unknown-flag
+  assert_failure
+}

--- a/tests/helpers/common.bash
+++ b/tests/helpers/common.bash
@@ -17,6 +17,14 @@ CLAUDE_NOTION_TASK_INIT="$REPO_ROOT_REAL/claude-notion/bin/task-init"
 CLAUDE_NOTION_TEMPLATE="$REPO_ROOT_REAL/claude-notion/steering/notion-workflow.example.md"
 KIRO_TASK_INIT="$REPO_ROOT_REAL/kiro-notion/bin/task-init"
 KIRO_TEMPLATE="$REPO_ROOT_REAL/kiro-notion/steering/notion-workflow.example.md"
+CLAUDE_GH_TASK_WORK="$REPO_ROOT_REAL/claude-gh/bin/task-work"
+CLAUDE_GH_TASK_DONE="$REPO_ROOT_REAL/claude-gh/bin/task-done"
+CLAUDE_GH_TASK_INIT="$REPO_ROOT_REAL/claude-gh/bin/task-init"
+CLAUDE_GH_TEMPLATE="$REPO_ROOT_REAL/claude-gh/steering/gh-workflow.example.md"
+KIRO_GH_TASK_WORK="$REPO_ROOT_REAL/kiro-gh/bin/task-work"
+KIRO_GH_TASK_DONE="$REPO_ROOT_REAL/kiro-gh/bin/task-done"
+KIRO_GH_TASK_INIT="$REPO_ROOT_REAL/kiro-gh/bin/task-init"
+KIRO_GH_TEMPLATE="$REPO_ROOT_REAL/kiro-gh/steering/gh-workflow.example.md"
 
 # Creates a temp directory with a git repo, sets up $MAIN_REPO,
 # $REPO_NAME, and $WORKTREE_BASE.

--- a/tests/kiro_gh_task_work.bats
+++ b/tests/kiro_gh_task_work.bats
@@ -1,0 +1,165 @@
+#!/usr/bin/env bats
+# Tests for kiro-gh/bin/task-work
+
+bats_load_library bats-support
+bats_load_library bats-assert
+
+load helpers/common
+
+setup() {
+  setup_repo
+  setup_stubs
+  cd "$MAIN_REPO"
+}
+
+teardown() {
+  teardown_all
+}
+
+# ---------------------------------------------------------------------------
+# Slug derivation
+# ---------------------------------------------------------------------------
+
+@test "free-form slug: lowercase and sanitize" {
+  run "$KIRO_GH_TASK_WORK" "My Feature Task"
+  assert_success
+  assert [ -d "$WORKTREE_BASE/my-feature-task" ]
+}
+
+@test "free-form slug: truncated to 50 chars" {
+  local long_slug
+  long_slug=$(printf 'abcde%.0s' {1..20})  # "abcde" x20 = 100 chars
+  run "$KIRO_GH_TASK_WORK" "$long_slug"
+  assert_success
+  run bash -c "ls '$WORKTREE_BASE' | head -1"
+  assert [ "${#output}" -le 50 ]
+}
+
+@test "github issue URL: derives slug as issue-N" {
+  run "$KIRO_GH_TASK_WORK" "https://github.com/owner/repo/issues/42"
+  assert_success
+  assert [ -d "$WORKTREE_BASE/issue-42" ]
+}
+
+@test "explicit slug + URL: slug takes precedence over derived" {
+  run "$KIRO_GH_TASK_WORK" "my-explicit-slug" "https://github.com/owner/repo/issues/42"
+  assert_success
+  assert [ -d "$WORKTREE_BASE/my-explicit-slug" ]
+}
+
+# ---------------------------------------------------------------------------
+# Worktree + branch creation
+# ---------------------------------------------------------------------------
+
+@test "creates git worktree on branch task/<slug>" {
+  run "$KIRO_GH_TASK_WORK" my-feature
+  assert_success
+  local branches
+  branches=$(git -C "$MAIN_REPO" branch --list "task/my-feature")
+  assert [ -n "$branches" ]
+  assert [ -d "$WORKTREE_BASE/my-feature" ]
+}
+
+@test "parallel session: appends 5-char hash when worktree already exists" {
+  run "$KIRO_GH_TASK_WORK" my-feature
+  assert_success
+  run "$KIRO_GH_TASK_WORK" my-feature
+  assert_success
+  assert_output --partial "parallel session"
+  run bash -c "ls '$WORKTREE_BASE' | grep -c '^my-feature'"
+  assert_output "2"
+}
+
+# ---------------------------------------------------------------------------
+# .info file
+# ---------------------------------------------------------------------------
+
+@test "writes .info file with BASE_BRANCH=current branch" {
+  run "$KIRO_GH_TASK_WORK" my-feature
+  assert_success
+  local info="$WORKTREE_BASE/.my-feature.info"
+  assert [ -f "$info" ]
+  source "$info"
+  assert_equal "$BASE_BRANCH" "main"
+}
+
+@test "--base flag overrides BASE_BRANCH in .info" {
+  run "$KIRO_GH_TASK_WORK" --base develop my-feature
+  assert_success
+  source "$WORKTREE_BASE/.my-feature.info"
+  assert_equal "$BASE_BRANCH" "develop"
+}
+
+@test ".info records GH_URL when URL is provided" {
+  local url="https://github.com/owner/repo/issues/42"
+  run "$KIRO_GH_TASK_WORK" my-feature "$url"
+  assert_success
+  source "$WORKTREE_BASE/.my-feature.info"
+  assert_equal "$GH_URL" "$url"
+}
+
+@test ".info GH_URL is empty for free-form slugs" {
+  run "$KIRO_GH_TASK_WORK" my-feature
+  assert_success
+  source "$WORKTREE_BASE/.my-feature.info"
+  assert_equal "${GH_URL:-}" ""
+}
+
+# ---------------------------------------------------------------------------
+# Zellij interactions
+# ---------------------------------------------------------------------------
+
+@test "opens a new zellij tab named after the slug" {
+  run "$KIRO_GH_TASK_WORK" my-feature
+  assert_success
+  assert_stub_called zellij "new-tab --name my-feature"
+}
+
+@test "--no-launch: opens tab but does not inject kiro command" {
+  run "$KIRO_GH_TASK_WORK" --no-launch my-feature
+  assert_success
+  assert_output --partial "kiro NOT launched"
+  run grep -F "kiro-cli" "$STUB_CALLS_DIR/zellij.calls"
+  assert_failure
+}
+
+@test "kiro command includes --model when -m is set" {
+  run "$KIRO_GH_TASK_WORK" -m claude-opus-4.6 my-feature
+  assert_success
+  assert_stub_called zellij "kiro-cli chat --agent worker --model claude-opus-4.6"
+}
+
+@test "kiro command includes --trust-all-tools when -a is set" {
+  run "$KIRO_GH_TASK_WORK" -a my-feature
+  assert_success
+  assert_stub_called zellij "--trust-all-tools"
+}
+
+@test "kiro command includes task URL when provided" {
+  local url="https://github.com/owner/repo/issues/42"
+  run "$KIRO_GH_TASK_WORK" my-feature "$url"
+  assert_success
+  assert_stub_called zellij "Implement task: $url"
+}
+
+# ---------------------------------------------------------------------------
+# Error cases
+# ---------------------------------------------------------------------------
+
+@test "fails outside a git repo" {
+  cd /tmp
+  run "$KIRO_GH_TASK_WORK" my-feature
+  assert_failure
+  assert_output --partial "not in a git repo"
+}
+
+@test "fails when --model missing its value" {
+  run "$KIRO_GH_TASK_WORK" --model
+  assert_failure
+  assert_output --partial "--model requires a value"
+}
+
+@test "fails on unknown flag" {
+  run "$KIRO_GH_TASK_WORK" --unknown-flag
+  assert_failure
+}

--- a/tests/task_init_dispatcher.bats
+++ b/tests/task_init_dispatcher.bats
@@ -74,29 +74,63 @@ teardown() {
 }
 
 # ---------------------------------------------------------------------------
-# Interactive menu
+# New implementations — delegation
 # ---------------------------------------------------------------------------
 
-@test "interactive menu choice 3 delegates to claude-notion" {
-  run bash -c "echo 3 | \"$TASK_INIT_DISPATCHER\""
+@test "delegates to claude-gh with no passthrough args" {
+  run "$TASK_INIT_DISPATCHER" claude-gh
   assert_success
-  assert [ -f "$MAIN_REPO/.claude/notion-workflow.md" ]
+  assert [ -f "$MAIN_REPO/.claude/gh-workflow.md" ]
 }
 
-@test "interactive menu choice 1 delegates to claude-jira" {
-  run bash -c "echo 1 | \"$TASK_INIT_DISPATCHER\""
+@test "delegates to kiro-gh with no passthrough args" {
+  run "$TASK_INIT_DISPATCHER" kiro-gh
+  assert_success
+  assert [ -f "$MAIN_REPO/.kiro/steering/gh-workflow.md" ]
+}
+
+# ---------------------------------------------------------------------------
+# Interactive menu (two-step: tool then board)
+# ---------------------------------------------------------------------------
+
+@test "interactive menu: Claude Code + Jira (1 then 1)" {
+  run bash -c "printf '1\n1\n' | \"$TASK_INIT_DISPATCHER\""
   assert_success
   assert [ -f "$MAIN_REPO/.claude/jira-workflow.md" ]
 }
 
-@test "interactive menu choice 2 delegates to kiro-notion" {
-  run bash -c "echo 2 | \"$TASK_INIT_DISPATCHER\""
+@test "interactive menu: Claude Code + Notion (1 then 2)" {
+  run bash -c "printf '1\n2\n' | \"$TASK_INIT_DISPATCHER\""
+  assert_success
+  assert [ -f "$MAIN_REPO/.claude/notion-workflow.md" ]
+}
+
+@test "interactive menu: Claude Code + GitHub Projects (1 then 3)" {
+  run bash -c "printf '1\n3\n' | \"$TASK_INIT_DISPATCHER\""
+  assert_success
+  assert [ -f "$MAIN_REPO/.claude/gh-workflow.md" ]
+}
+
+@test "interactive menu: Kiro + Notion (2 then 1)" {
+  run bash -c "printf '2\n1\n' | \"$TASK_INIT_DISPATCHER\""
   assert_success
   assert [ -f "$MAIN_REPO/.kiro/steering/notion-workflow.md" ]
 }
 
-@test "interactive menu invalid choice exits non-zero" {
+@test "interactive menu: Kiro + GitHub Projects (2 then 2)" {
+  run bash -c "printf '2\n2\n' | \"$TASK_INIT_DISPATCHER\""
+  assert_success
+  assert [ -f "$MAIN_REPO/.kiro/steering/gh-workflow.md" ]
+}
+
+@test "interactive menu invalid tool choice exits non-zero" {
   run bash -c "echo 9 | \"$TASK_INIT_DISPATCHER\""
+  assert_failure
+  assert_output --partial "Invalid choice"
+}
+
+@test "interactive menu invalid board choice exits non-zero" {
+  run bash -c "printf '1\n9\n' | \"$TASK_INIT_DISPATCHER\""
   assert_failure
   assert_output --partial "Invalid choice"
 }


### PR DESCRIPTION
## Summary

- Adds **`claude-gh`** (Claude Code + GitHub MCP) and **`kiro-gh`** (Kiro + GitHub MCP) implementations with full `task-work`, `task-init`, `task-done`, slash commands / agent configs, and per-project config templates
- Restructures **`install.sh`** and **`task-init`** from a flat list into a two-step wizard: pick AI tool first (Claude Code / Kiro), then board (Jira / Notion / GitHub Projects)
- GitHub Projects integration uses `npx -y @github/github-mcp-server` (stdio, requires `GITHUB_PERSONAL_ACCESS_TOKEN`); `gh` CLI continues to handle PRs as before
- GitHub issue URLs (`github.com/*/issues/N`) derive worktree slugs as `issue-N`; free-form slugs and explicit slug+URL work as in the existing Notion impls

## Test plan

- [x] `./run_tests.sh` — 159 tests, all pass (added 3 new suites: `claude_gh_task_work`, `claude_gh_task_init`, `kiro_gh_task_work`; updated `task_init_dispatcher` for two-step menu)
- [x] `shellcheck` passes on all new and modified scripts
- [x] CI (bats + shellcheck) passes on this PR

🤖 Generated with [Claude Code](https://claude.com/claude-code)