### PR TITLE
feat: interactive prompts in task-init for GitHub implementations

### DIFF
--- a/claude-gh/bin/task-init
+++ b/claude-gh/bin/task-init
@@ -2,26 +2,81 @@
 set -euo pipefail
 
 usage() {
-  echo "Usage: task-init [--force]"
+  echo "Usage: task-init [--owner OWNER] [--repo REPO] [--project N] [--force]"
   echo ""
   echo "Set up the current repo for the claude-gh workflow:"
   echo "  - Create .claude/gh-workflow.md from the bundled template"
+  echo "  - Substitute owner / repo / project number if provided"
+  echo "    (auto-detected from git remote when possible; missing values prompted interactively)"
   echo "  - Add @.claude/gh-workflow.md to CLAUDE.md so it auto-loads in every session"
   echo ""
   echo "Options:"
-  echo "  --force   Overwrite .claude/gh-workflow.md if present"
+  echo "  --owner OWNER    GitHub user or org name"
+  echo "  --repo  REPO     Repository name"
+  echo "  --project N      GitHub Projects board number"
+  echo "  --force          Overwrite .claude/gh-workflow.md if present"
   exit 1
 }
 
+OWNER=""
+REPO=""
+PROJECT=""
 FORCE=false
+OWNER_VIA_FLAG=false
+REPO_VIA_FLAG=false
+PROJECT_VIA_FLAG=false
 
 while [[ $# -gt 0 ]]; do
   case "$1" in
-    --force) FORCE=true; shift ;;
-    -h|--help) usage ;;
-    *) echo "Unknown option: $1"; usage ;;
+    --owner)   OWNER="$2";   OWNER_VIA_FLAG=true;   shift 2;;
+    --repo)    REPO="$2";    REPO_VIA_FLAG=true;    shift 2;;
+    --project) PROJECT="$2"; PROJECT_VIA_FLAG=true; shift 2;;
+    --force)   FORCE=true; shift;;
+    -h|--help) usage;;
+    *) echo "Unknown option: $1"; usage;;
   esac
 done
+
+# Auto-detect owner/repo from git remote (only for values not set via flag)
+_detect_gh_remote() {
+  local url
+  url=$(git remote get-url origin 2>/dev/null) || return 1
+  url="${url%.git}"  # strip trailing .git before matching
+  if [[ "$url" =~ github\.com[:/]([^/]+)/([^/]+)$ ]]; then
+    echo "${BASH_REMATCH[1]} ${BASH_REMATCH[2]}"
+  fi
+}
+
+if ! $OWNER_VIA_FLAG || ! $REPO_VIA_FLAG; then
+  _detected=$(_detect_gh_remote 2>/dev/null) || true
+  if [[ -n "${_detected:-}" ]]; then
+    $OWNER_VIA_FLAG || OWNER="${_detected%% *}"
+    $REPO_VIA_FLAG  || REPO="${_detected##* }"
+  fi
+fi
+
+# Interactive prompts when running from a terminal (skipped for values set via flag)
+if [[ -t 0 ]]; then
+  if ! $OWNER_VIA_FLAG; then
+    if [[ -n "$OWNER" ]]; then
+      read -rp "GitHub owner [$OWNER]: " _in
+      [[ -n "${_in:-}" ]] && OWNER="$_in"
+    else
+      read -rp "GitHub owner (user or org) [blank → leaves {OWNER}]: " OWNER
+    fi
+  fi
+  if ! $REPO_VIA_FLAG; then
+    if [[ -n "$REPO" ]]; then
+      read -rp "Repository name [$REPO]: " _in
+      [[ -n "${_in:-}" ]] && REPO="$_in"
+    else
+      read -rp "Repository name [blank → leaves {REPO}]: " REPO
+    fi
+  fi
+  if ! $PROJECT_VIA_FLAG; then
+    read -rp "Project number (find at: github.com/users/${OWNER:-YOUR_OWNER}/projects/N) [blank → leaves {PROJECT}]: " PROJECT
+  fi
+fi
 
 # Resolve script path through symlinks (install.sh symlinks into ~/.local/bin)
 src="${BASH_SOURCE[0]}"
@@ -50,7 +105,16 @@ if [[ -f "$TARGET" && "$FORCE" != true ]]; then
   exit 1
 fi
 
-cp "$TEMPLATE" "$TARGET"
+sed_args=()
+[[ -n "$OWNER"   ]] && sed_args+=(-e "s|{OWNER}|$OWNER|g")
+[[ -n "$REPO"    ]] && sed_args+=(-e "s|{REPO}|$REPO|g")
+[[ -n "$PROJECT" ]] && sed_args+=(-e "s|{PROJECT}|$PROJECT|g")
+
+if [[ ${#sed_args[@]} -gt 0 ]]; then
+  sed "${sed_args[@]}" "$TEMPLATE" > "$TARGET"
+else
+  cp "$TEMPLATE" "$TARGET"
+fi
 echo "✓ Wrote $TARGET"
 
 IMPORT_LINE="@.claude/gh-workflow.md"
@@ -67,4 +131,4 @@ else
 fi
 
 echo ""
-echo "Done. Open .claude/gh-workflow.md to fill in your GitHub owner, repo, and project number."
+echo "Done. Open .claude/gh-workflow.md to fill in any remaining {placeholders}."

--- a/claude-gh/bin/task-init
+++ b/claude-gh/bin/task-init
@@ -37,6 +37,9 @@ while [[ $# -gt 0 ]]; do
   esac
 done
 
+# Escape special sed replacement characters (|, &, \) to prevent injection
+_sed_escape() { printf '%s' "$1" | sed 's/[|&\]/\\&/g'; }
+
 # Auto-detect owner/repo from git remote (only for values not set via flag)
 _detect_gh_remote() {
   local url
@@ -47,34 +50,34 @@ _detect_gh_remote() {
   fi
 }
 
-if ! $OWNER_VIA_FLAG || ! $REPO_VIA_FLAG; then
+if [[ "$OWNER_VIA_FLAG" == false ]] || [[ "$REPO_VIA_FLAG" == false ]]; then
   _detected=$(_detect_gh_remote 2>/dev/null) || true
   if [[ -n "${_detected:-}" ]]; then
-    $OWNER_VIA_FLAG || OWNER="${_detected%% *}"
-    $REPO_VIA_FLAG  || REPO="${_detected##* }"
+    [[ "$OWNER_VIA_FLAG" == false ]] && OWNER="${_detected%% *}"
+    [[ "$REPO_VIA_FLAG"  == false ]] && REPO="${_detected##* }"
   fi
 fi
 
 # Interactive prompts when running from a terminal (skipped for values set via flag)
 if [[ -t 0 ]]; then
-  if ! $OWNER_VIA_FLAG; then
+  if [[ "$OWNER_VIA_FLAG" == false ]]; then
     if [[ -n "$OWNER" ]]; then
-      read -rp "GitHub owner [$OWNER]: " _in
-      [[ -n "${_in:-}" ]] && OWNER="$_in"
+      read -rp "GitHub owner [$OWNER]: " _input
+      [[ -n "${_input:-}" ]] && OWNER="$_input"
     else
       read -rp "GitHub owner (user or org) [blank → leaves {OWNER}]: " OWNER
     fi
   fi
-  if ! $REPO_VIA_FLAG; then
+  if [[ "$REPO_VIA_FLAG" == false ]]; then
     if [[ -n "$REPO" ]]; then
-      read -rp "Repository name [$REPO]: " _in
-      [[ -n "${_in:-}" ]] && REPO="$_in"
+      read -rp "Repository name [$REPO]: " _input
+      [[ -n "${_input:-}" ]] && REPO="$_input"
     else
       read -rp "Repository name [blank → leaves {REPO}]: " REPO
     fi
   fi
-  if ! $PROJECT_VIA_FLAG; then
-    read -rp "Project number (find at: github.com/users/${OWNER:-YOUR_OWNER}/projects/N) [blank → leaves {PROJECT}]: " PROJECT
+  if [[ "$PROJECT_VIA_FLAG" == false ]]; then
+    read -rp "Project number (find at: github.com/users/OWNER/projects/N or github.com/orgs/OWNER/projects/N) [blank → leaves {PROJECT}]: " PROJECT
   fi
 fi
 
@@ -106,9 +109,9 @@ if [[ -f "$TARGET" && "$FORCE" != true ]]; then
 fi
 
 sed_args=()
-[[ -n "$OWNER"   ]] && sed_args+=(-e "s|{OWNER}|$OWNER|g")
-[[ -n "$REPO"    ]] && sed_args+=(-e "s|{REPO}|$REPO|g")
-[[ -n "$PROJECT" ]] && sed_args+=(-e "s|{PROJECT}|$PROJECT|g")
+[[ -n "$OWNER"   ]] && sed_args+=(-e "s|{OWNER}|$(_sed_escape "$OWNER")|g")
+[[ -n "$REPO"    ]] && sed_args+=(-e "s|{REPO}|$(_sed_escape "$REPO")|g")
+[[ -n "$PROJECT" ]] && sed_args+=(-e "s|{PROJECT}|$(_sed_escape "$PROJECT")|g")
 
 if [[ ${#sed_args[@]} -gt 0 ]]; then
   sed "${sed_args[@]}" "$TEMPLATE" > "$TARGET"

--- a/claude-gh/steering/gh-workflow.example.md
+++ b/claude-gh/steering/gh-workflow.example.md
@@ -25,9 +25,9 @@ claude mcp add --transport stdio github -- npx -y @github/github-mcp-server
 
 ### GitHub Repository
 
-- **Owner**: `YOUR_OWNER` (GitHub user or org name)
-- **Repo**: `YOUR_REPO` (repository name)
-- **Project number**: `YOUR_PROJECT_NUMBER` (from the project URL: github.com/users/YOUR_OWNER/projects/N or github.com/orgs/YOUR_OWNER/projects/N)
+- **Owner**: `{OWNER}` (GitHub user or org name)
+- **Repo**: `{REPO}` (repository name)
+- **Project number**: `{PROJECT}` (from the project URL: github.com/users/{OWNER}/projects/N or github.com/orgs/{OWNER}/projects/N)
 
 ### Task Lifecycle
 
@@ -56,8 +56,8 @@ Use the issue title as prefix: `<Issue title>: <short description>`
 
 Examples:
 ```bash
-task-work add-auth "https://github.com/YOUR_OWNER/YOUR_REPO/issues/42"
-task-work https://github.com/YOUR_OWNER/YOUR_REPO/issues/42
+task-work add-auth "https://github.com/{OWNER}/{REPO}/issues/42"
+task-work https://github.com/{OWNER}/{REPO}/issues/42
 task-work refactor-auth
 task-work spike-idea --no-launch
 ```

--- a/kiro-gh/bin/task-init
+++ b/kiro-gh/bin/task-init
@@ -2,25 +2,80 @@
 set -euo pipefail
 
 usage() {
-  echo "Usage: task-init [--force]"
+  echo "Usage: task-init [--owner OWNER] [--repo REPO] [--project N] [--force]"
   echo ""
   echo "Set up the current repo for the kiro-gh workflow:"
   echo "  - Create .kiro/steering/gh-workflow.md from the bundled template"
+  echo "  - Substitute owner / repo / project number if provided"
+  echo "    (auto-detected from git remote when possible; missing values prompted interactively)"
   echo ""
   echo "Options:"
-  echo "  --force   Overwrite .kiro/steering/gh-workflow.md if present"
+  echo "  --owner OWNER    GitHub user or org name"
+  echo "  --repo  REPO     Repository name"
+  echo "  --project N      GitHub Projects board number"
+  echo "  --force          Overwrite .kiro/steering/gh-workflow.md if present"
   exit 1
 }
 
+OWNER=""
+REPO=""
+PROJECT=""
 FORCE=false
+OWNER_VIA_FLAG=false
+REPO_VIA_FLAG=false
+PROJECT_VIA_FLAG=false
 
 while [[ $# -gt 0 ]]; do
   case "$1" in
-    --force) FORCE=true; shift ;;
-    -h|--help) usage ;;
-    *) echo "Unknown option: $1"; usage ;;
+    --owner)   OWNER="$2";   OWNER_VIA_FLAG=true;   shift 2;;
+    --repo)    REPO="$2";    REPO_VIA_FLAG=true;    shift 2;;
+    --project) PROJECT="$2"; PROJECT_VIA_FLAG=true; shift 2;;
+    --force)   FORCE=true; shift;;
+    -h|--help) usage;;
+    *) echo "Unknown option: $1"; usage;;
   esac
 done
+
+# Auto-detect owner/repo from git remote (only for values not set via flag)
+_detect_gh_remote() {
+  local url
+  url=$(git remote get-url origin 2>/dev/null) || return 1
+  url="${url%.git}"  # strip trailing .git before matching
+  if [[ "$url" =~ github\.com[:/]([^/]+)/([^/]+)$ ]]; then
+    echo "${BASH_REMATCH[1]} ${BASH_REMATCH[2]}"
+  fi
+}
+
+if ! $OWNER_VIA_FLAG || ! $REPO_VIA_FLAG; then
+  _detected=$(_detect_gh_remote 2>/dev/null) || true
+  if [[ -n "${_detected:-}" ]]; then
+    $OWNER_VIA_FLAG || OWNER="${_detected%% *}"
+    $REPO_VIA_FLAG  || REPO="${_detected##* }"
+  fi
+fi
+
+# Interactive prompts when running from a terminal (skipped for values set via flag)
+if [[ -t 0 ]]; then
+  if ! $OWNER_VIA_FLAG; then
+    if [[ -n "$OWNER" ]]; then
+      read -rp "GitHub owner [$OWNER]: " _in
+      [[ -n "${_in:-}" ]] && OWNER="$_in"
+    else
+      read -rp "GitHub owner (user or org) [blank → leaves {OWNER}]: " OWNER
+    fi
+  fi
+  if ! $REPO_VIA_FLAG; then
+    if [[ -n "$REPO" ]]; then
+      read -rp "Repository name [$REPO]: " _in
+      [[ -n "${_in:-}" ]] && REPO="$_in"
+    else
+      read -rp "Repository name [blank → leaves {REPO}]: " REPO
+    fi
+  fi
+  if ! $PROJECT_VIA_FLAG; then
+    read -rp "Project number (find at: github.com/users/${OWNER:-YOUR_OWNER}/projects/N) [blank → leaves {PROJECT}]: " PROJECT
+  fi
+fi
 
 # Resolve script path through symlinks
 src="${BASH_SOURCE[0]}"
@@ -48,7 +103,16 @@ if [[ -f "$TARGET" && "$FORCE" != true ]]; then
   exit 1
 fi
 
-cp "$TEMPLATE" "$TARGET"
+sed_args=()
+[[ -n "$OWNER"   ]] && sed_args+=(-e "s|{OWNER}|$OWNER|g")
+[[ -n "$REPO"    ]] && sed_args+=(-e "s|{REPO}|$REPO|g")
+[[ -n "$PROJECT" ]] && sed_args+=(-e "s|{PROJECT}|$PROJECT|g")
+
+if [[ ${#sed_args[@]} -gt 0 ]]; then
+  sed "${sed_args[@]}" "$TEMPLATE" > "$TARGET"
+else
+  cp "$TEMPLATE" "$TARGET"
+fi
 echo "✓ Wrote $TARGET"
 echo ""
-echo "Done. Open .kiro/steering/gh-workflow.md to fill in your GitHub owner, repo, and project number."
+echo "Done. Open .kiro/steering/gh-workflow.md to fill in any remaining {placeholders}."

--- a/kiro-gh/bin/task-init
+++ b/kiro-gh/bin/task-init
@@ -36,6 +36,9 @@ while [[ $# -gt 0 ]]; do
   esac
 done
 
+# Escape special sed replacement characters (|, &, \) to prevent injection
+_sed_escape() { printf '%s' "$1" | sed 's/[|&\]/\\&/g'; }
+
 # Auto-detect owner/repo from git remote (only for values not set via flag)
 _detect_gh_remote() {
   local url
@@ -46,34 +49,34 @@ _detect_gh_remote() {
   fi
 }
 
-if ! $OWNER_VIA_FLAG || ! $REPO_VIA_FLAG; then
+if [[ "$OWNER_VIA_FLAG" == false ]] || [[ "$REPO_VIA_FLAG" == false ]]; then
   _detected=$(_detect_gh_remote 2>/dev/null) || true
   if [[ -n "${_detected:-}" ]]; then
-    $OWNER_VIA_FLAG || OWNER="${_detected%% *}"
-    $REPO_VIA_FLAG  || REPO="${_detected##* }"
+    [[ "$OWNER_VIA_FLAG" == false ]] && OWNER="${_detected%% *}"
+    [[ "$REPO_VIA_FLAG"  == false ]] && REPO="${_detected##* }"
   fi
 fi
 
 # Interactive prompts when running from a terminal (skipped for values set via flag)
 if [[ -t 0 ]]; then
-  if ! $OWNER_VIA_FLAG; then
+  if [[ "$OWNER_VIA_FLAG" == false ]]; then
     if [[ -n "$OWNER" ]]; then
-      read -rp "GitHub owner [$OWNER]: " _in
-      [[ -n "${_in:-}" ]] && OWNER="$_in"
+      read -rp "GitHub owner [$OWNER]: " _input
+      [[ -n "${_input:-}" ]] && OWNER="$_input"
     else
       read -rp "GitHub owner (user or org) [blank → leaves {OWNER}]: " OWNER
     fi
   fi
-  if ! $REPO_VIA_FLAG; then
+  if [[ "$REPO_VIA_FLAG" == false ]]; then
     if [[ -n "$REPO" ]]; then
-      read -rp "Repository name [$REPO]: " _in
-      [[ -n "${_in:-}" ]] && REPO="$_in"
+      read -rp "Repository name [$REPO]: " _input
+      [[ -n "${_input:-}" ]] && REPO="$_input"
     else
       read -rp "Repository name [blank → leaves {REPO}]: " REPO
     fi
   fi
-  if ! $PROJECT_VIA_FLAG; then
-    read -rp "Project number (find at: github.com/users/${OWNER:-YOUR_OWNER}/projects/N) [blank → leaves {PROJECT}]: " PROJECT
+  if [[ "$PROJECT_VIA_FLAG" == false ]]; then
+    read -rp "Project number (find at: github.com/users/OWNER/projects/N or github.com/orgs/OWNER/projects/N) [blank → leaves {PROJECT}]: " PROJECT
   fi
 fi
 
@@ -104,9 +107,9 @@ if [[ -f "$TARGET" && "$FORCE" != true ]]; then
 fi
 
 sed_args=()
-[[ -n "$OWNER"   ]] && sed_args+=(-e "s|{OWNER}|$OWNER|g")
-[[ -n "$REPO"    ]] && sed_args+=(-e "s|{REPO}|$REPO|g")
-[[ -n "$PROJECT" ]] && sed_args+=(-e "s|{PROJECT}|$PROJECT|g")
+[[ -n "$OWNER"   ]] && sed_args+=(-e "s|{OWNER}|$(_sed_escape "$OWNER")|g")
+[[ -n "$REPO"    ]] && sed_args+=(-e "s|{REPO}|$(_sed_escape "$REPO")|g")
+[[ -n "$PROJECT" ]] && sed_args+=(-e "s|{PROJECT}|$(_sed_escape "$PROJECT")|g")
 
 if [[ ${#sed_args[@]} -gt 0 ]]; then
   sed "${sed_args[@]}" "$TEMPLATE" > "$TARGET"

--- a/kiro-gh/steering/gh-workflow.example.md
+++ b/kiro-gh/steering/gh-workflow.example.md
@@ -16,9 +16,9 @@ Set `GITHUB_PERSONAL_ACCESS_TOKEN` in your environment before running Kiro.
 
 ### GitHub Repository
 
-- **Owner**: `YOUR_OWNER` (GitHub user or org name)
-- **Repo**: `YOUR_REPO` (repository name)
-- **Project number**: `YOUR_PROJECT_NUMBER` (from the project URL: github.com/users/YOUR_OWNER/projects/N or github.com/orgs/YOUR_OWNER/projects/N)
+- **Owner**: `{OWNER}` (GitHub user or org name)
+- **Repo**: `{REPO}` (repository name)
+- **Project number**: `{PROJECT}` (from the project URL: github.com/users/{OWNER}/projects/N or github.com/orgs/{OWNER}/projects/N)
 
 ### Task Lifecycle
 

--- a/tests/kiro_gh_task_init.bats
+++ b/tests/kiro_gh_task_init.bats
@@ -1,5 +1,5 @@
 #!/usr/bin/env bats
-# Tests for claude-gh/bin/task-init
+# Tests for kiro-gh/bin/task-init
 
 bats_load_library bats-support
 bats_load_library bats-assert
@@ -22,16 +22,16 @@ teardown() {
 # File creation
 # ---------------------------------------------------------------------------
 
-@test "copies template to .claude/gh-workflow.md" {
-  run "$CLAUDE_GH_TASK_INIT"
+@test "copies template to .kiro/steering/gh-workflow.md" {
+  run "$KIRO_GH_TASK_INIT"
   assert_success
-  assert [ -f "$TARGET_DIR/.claude/gh-workflow.md" ]
+  assert [ -f "$TARGET_DIR/.kiro/steering/gh-workflow.md" ]
 }
 
 @test "copied file contains placeholder text when no values provided" {
-  run "$CLAUDE_GH_TASK_INIT"
+  run "$KIRO_GH_TASK_INIT"
   assert_success
-  run grep -F "{PROJECT}" "$TARGET_DIR/.claude/gh-workflow.md"
+  run grep -F "{PROJECT}" "$TARGET_DIR/.kiro/steering/gh-workflow.md"
   assert_success
 }
 
@@ -40,9 +40,9 @@ teardown() {
 # ---------------------------------------------------------------------------
 
 @test "all flags: substitutes {OWNER}, {REPO}, {PROJECT}" {
-  run "$CLAUDE_GH_TASK_INIT" --owner myorg --repo myrepo --project 42
+  run "$KIRO_GH_TASK_INIT" --owner myorg --repo myrepo --project 42
   assert_success
-  run cat "$TARGET_DIR/.claude/gh-workflow.md"
+  run cat "$TARGET_DIR/.kiro/steering/gh-workflow.md"
   assert_output --partial "myorg"
   assert_output --partial "myrepo"
   assert_output --partial "42"
@@ -52,36 +52,18 @@ teardown() {
 }
 
 @test "--owner only: {REPO} and {PROJECT} remain as placeholders" {
-  run "$CLAUDE_GH_TASK_INIT" --owner myorg
+  run "$KIRO_GH_TASK_INIT" --owner myorg
   assert_success
-  run cat "$TARGET_DIR/.claude/gh-workflow.md"
+  run cat "$TARGET_DIR/.kiro/steering/gh-workflow.md"
   assert_output --partial "myorg"
   assert_output --partial "{REPO}"
   assert_output --partial "{PROJECT}"
 }
 
-@test "--repo only: {OWNER} and {PROJECT} remain as placeholders" {
-  run "$CLAUDE_GH_TASK_INIT" --repo myrepo
-  assert_success
-  run cat "$TARGET_DIR/.claude/gh-workflow.md"
-  assert_output --partial "myrepo"
-  assert_output --partial "{OWNER}"
-  assert_output --partial "{PROJECT}"
-}
-
-@test "--project only: {OWNER} and {REPO} remain as placeholders" {
-  run "$CLAUDE_GH_TASK_INIT" --project 7
-  assert_success
-  run cat "$TARGET_DIR/.claude/gh-workflow.md"
-  assert_output --partial "{OWNER}"
-  assert_output --partial "{REPO}"
-  refute_output --partial "{PROJECT}"
-}
-
 @test "no flags (non-interactive stdin): all {placeholders} preserved" {
-  run "$CLAUDE_GH_TASK_INIT"
+  run "$KIRO_GH_TASK_INIT"
   assert_success
-  run cat "$TARGET_DIR/.claude/gh-workflow.md"
+  run cat "$TARGET_DIR/.kiro/steering/gh-workflow.md"
   assert_output --partial "{OWNER}"
   assert_output --partial "{REPO}"
   assert_output --partial "{PROJECT}"
@@ -93,9 +75,9 @@ teardown() {
 
 @test "auto-detects owner and repo from HTTPS remote" {
   git -C "$TARGET_DIR" remote add origin "https://github.com/acme/widget.git"
-  run "$CLAUDE_GH_TASK_INIT" --project 1
+  run "$KIRO_GH_TASK_INIT" --project 1
   assert_success
-  run cat "$TARGET_DIR/.claude/gh-workflow.md"
+  run cat "$TARGET_DIR/.kiro/steering/gh-workflow.md"
   assert_output --partial "acme"
   assert_output --partial "widget"
   refute_output --partial "{OWNER}"
@@ -104,9 +86,9 @@ teardown() {
 
 @test "auto-detects owner and repo from SSH remote" {
   git -C "$TARGET_DIR" remote add origin "git@github.com:acme/widget.git"
-  run "$CLAUDE_GH_TASK_INIT" --project 1
+  run "$KIRO_GH_TASK_INIT" --project 1
   assert_success
-  run cat "$TARGET_DIR/.claude/gh-workflow.md"
+  run cat "$TARGET_DIR/.kiro/steering/gh-workflow.md"
   assert_output --partial "acme"
   assert_output --partial "widget"
   refute_output --partial "{OWNER}"
@@ -115,71 +97,40 @@ teardown() {
 
 @test "--owner flag overrides auto-detected owner" {
   git -C "$TARGET_DIR" remote add origin "https://github.com/acme/widget.git"
-  run "$CLAUDE_GH_TASK_INIT" --owner override-org --project 1
+  run "$KIRO_GH_TASK_INIT" --owner override-org --project 1
   assert_success
-  run cat "$TARGET_DIR/.claude/gh-workflow.md"
+  run cat "$TARGET_DIR/.kiro/steering/gh-workflow.md"
   assert_output --partial "override-org"
   refute_output --partial "acme"
   refute_output --partial "{OWNER}"
 }
 
 @test "no remote: {OWNER} and {REPO} stay as placeholders" {
-  run "$CLAUDE_GH_TASK_INIT" --project 5
+  run "$KIRO_GH_TASK_INIT" --project 5
   assert_success
-  run cat "$TARGET_DIR/.claude/gh-workflow.md"
+  run cat "$TARGET_DIR/.kiro/steering/gh-workflow.md"
   assert_output --partial "{OWNER}"
   assert_output --partial "{REPO}"
-}
-
-# ---------------------------------------------------------------------------
-# CLAUDE.md integration
-# ---------------------------------------------------------------------------
-
-@test "creates CLAUDE.md with @.claude/gh-workflow.md when none exists" {
-  run "$CLAUDE_GH_TASK_INIT"
-  assert_success
-  assert [ -f "$TARGET_DIR/CLAUDE.md" ]
-  run grep -F "@.claude/gh-workflow.md" "$TARGET_DIR/CLAUDE.md"
-  assert_success
-}
-
-@test "appends to existing CLAUDE.md" {
-  echo "# Existing content" > "$TARGET_DIR/CLAUDE.md"
-  run "$CLAUDE_GH_TASK_INIT"
-  assert_success
-  run cat "$TARGET_DIR/CLAUDE.md"
-  assert_output --partial "# Existing content"
-  assert_output --partial "@.claude/gh-workflow.md"
-}
-
-@test "does not duplicate the import line in CLAUDE.md" {
-  run "$CLAUDE_GH_TASK_INIT"
-  assert_success
-  run "$CLAUDE_GH_TASK_INIT" --force
-  assert_success
-  local count
-  count=$(grep -c "@.claude/gh-workflow.md" "$TARGET_DIR/CLAUDE.md" || true)
-  assert_equal "$count" "1"
 }
 
 # ---------------------------------------------------------------------------
 # --force and overwrite guard
 # ---------------------------------------------------------------------------
 
-@test "fails if .claude/gh-workflow.md already exists (no --force)" {
-  run "$CLAUDE_GH_TASK_INIT"
+@test "fails if .kiro/steering/gh-workflow.md already exists (no --force)" {
+  run "$KIRO_GH_TASK_INIT"
   assert_success
-  run "$CLAUDE_GH_TASK_INIT"
+  run "$KIRO_GH_TASK_INIT"
   assert_failure
   assert_output --partial "already exists"
 }
 
 @test "--force overwrites existing gh-workflow.md" {
-  run "$CLAUDE_GH_TASK_INIT" --owner old
+  run "$KIRO_GH_TASK_INIT" --owner old
   assert_success
-  run "$CLAUDE_GH_TASK_INIT" --owner new --force
+  run "$KIRO_GH_TASK_INIT" --owner new --force
   assert_success
-  run cat "$TARGET_DIR/.claude/gh-workflow.md"
+  run cat "$TARGET_DIR/.kiro/steering/gh-workflow.md"
   assert_output --partial "new"
   refute_output --partial "**Owner**: \`old\`"
 }
@@ -190,7 +141,7 @@ teardown() {
 
 @test "fails outside a git repo" {
   cd /tmp
-  run "$CLAUDE_GH_TASK_INIT"
+  run "$KIRO_GH_TASK_INIT"
   assert_failure
   assert_output --partial "not in a git repo"
 }

--- a/tests/task_init_dispatcher.bats
+++ b/tests/task_init_dispatcher.bats
@@ -73,6 +73,24 @@ teardown() {
   assert_success
 }
 
+@test "passes --owner --repo --project through to claude-gh implementation" {
+  run "$TASK_INIT_DISPATCHER" claude-gh --owner myorg --repo myrepo --project 5
+  assert_success
+  run grep "myorg" "$MAIN_REPO/.claude/gh-workflow.md"
+  assert_success
+  run grep "myrepo" "$MAIN_REPO/.claude/gh-workflow.md"
+  assert_success
+}
+
+@test "passes --owner --repo --project through to kiro-gh implementation" {
+  run "$TASK_INIT_DISPATCHER" kiro-gh --owner myorg --repo myrepo --project 5
+  assert_success
+  run grep "myorg" "$MAIN_REPO/.kiro/steering/gh-workflow.md"
+  assert_success
+  run grep "myrepo" "$MAIN_REPO/.kiro/steering/gh-workflow.md"
+  assert_success
+}
+
 # ---------------------------------------------------------------------------
 # New implementations — delegation
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## Summary

- `task-init claude-gh` and `task-init kiro-gh` now auto-detect **owner** and **repo** from `git remote get-url origin` (both HTTPS and SSH remotes)
- Add `--owner`, `--repo`, `--project` CLI flags that skip prompts for non-interactive use
- When running in a TTY and a value is missing, prompt interactively; auto-detected values are shown as defaults and can be overridden
- Replace `YOUR_OWNER`/`YOUR_REPO`/`YOUR_PROJECT_NUMBER` placeholders in templates with `{OWNER}`/`{REPO}`/`{PROJECT}` (consistent with Jira's `{SITE}`/`{KEY}`/`{BOARD}` pattern)
- Non-TTY (piped) invocations leave placeholders unchanged — same as before

Closes #8

## Test plan

- [x] `task-init claude-gh` with all flags substitutes all values (no `{placeholder}` remains)
- [x] Partial flags leave other placeholders intact
- [x] Auto-detects owner/repo from HTTPS and SSH remotes
- [x] `--owner` flag overrides auto-detected owner
- [x] No remote → `{OWNER}`/`{REPO}` stay as placeholders
- [x] Non-TTY stdin preserves all placeholders
- [x] `--force` still overwrites existing config
- [x] Dispatcher passes `--owner/--repo/--project` through to implementations
- [x] All 182 tests pass (`kiro_gh_task_init.bats` newly added with 12 tests)

🤖 Generated with [Claude Code](https://claude.com/claude-code)