### PR TITLE
ux: pace install output and improve next-steps readability

### DIFF
--- a/claude-gh/install.sh
+++ b/claude-gh/install.sh
@@ -10,7 +10,7 @@ mkdir -p ~/.claude/commands
 for cmd in "$SCRIPT_DIR"/commands/*.md; do
   name=$(basename "$cmd")
   ln -sf "$cmd" ~/.claude/commands/"$name"
-  echo "  ✓ Slash command: /$(basename "$name" .md)"
+  echo "  ✓ Slash command: /$(basename "$name" .md)"; sleep 0.05
 done
 
 # Scripts → ~/.local/bin/ (task-init handled separately via unified root script)
@@ -19,12 +19,12 @@ for script in "$SCRIPT_DIR"/bin/*; do
   name=$(basename "$script")
   [[ "$name" == "task-init" ]] && continue
   ln -sf "$script" ~/.local/bin/"$name"
-  echo "  ✓ Script: $name"
+  echo "  ✓ Script: $name"; sleep 0.05
 done
 
 # Unified task-init (always points to repo-root task-init regardless of which impl was installed last)
 ln -sf "$SCRIPT_DIR/../task-init" ~/.local/bin/task-init
-echo "  ✓ Script: task-init (unified)"
+echo "  ✓ Script: task-init (unified)"; sleep 0.05
 
 # Ensure ~/.local/bin is on PATH
 # shellcheck disable=SC2016  # literal string written to shell RC; $HOME must not expand here
@@ -49,10 +49,28 @@ else
 fi
 
 echo ""
+echo "━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━"
+sleep 0.3
+echo ""
 echo "Done. Next steps:"
-echo "  1. Set GITHUB_PERSONAL_ACCESS_TOKEN in your environment (needs repo + project scopes)"
-echo "  2. Verify the GitHub MCP is configured: claude mcp list"
-echo "     (If not: claude mcp add --transport stdio github -- npx -y @github/github-mcp-server)"
-echo "  3. In your project root, run: task-init claude-gh"
-echo "  4. Fill in your GitHub owner, repo, and project number in .claude/gh-workflow.md"
-echo "  5. Start with: claude   (then type /pm)"
+echo ""
+sleep 0.4
+echo "  1. Set GITHUB_PERSONAL_ACCESS_TOKEN in your environment"
+echo "     (needs repo + project scopes)"
+sleep 0.4
+echo ""
+echo "  2. Verify the GitHub MCP is configured:"
+echo "       claude mcp list"
+echo "     If missing:"
+echo "       claude mcp add --transport stdio github -- npx -y @github/github-mcp-server"
+sleep 0.4
+echo ""
+echo "  3. In your project root, run:"
+echo "       task-init claude-gh"
+echo "     (prompts for owner, repo, and project number — auto-detected from git remote)"
+sleep 0.4
+echo ""
+echo "  4. Start Claude and kick off the PM agent:"
+echo "       claude"
+echo "     then type /pm"
+echo ""

--- a/claude-jira/install.sh
+++ b/claude-jira/install.sh
@@ -10,7 +10,7 @@ mkdir -p ~/.claude/commands
 for cmd in "$SCRIPT_DIR"/commands/*.md; do
   name=$(basename "$cmd")
   ln -sf "$cmd" ~/.claude/commands/"$name"
-  echo "  ✓ Slash command: /$(basename "$name" .md)"
+  echo "  ✓ Slash command: /$(basename "$name" .md)"; sleep 0.05
 done
 
 # Scripts → ~/.local/bin/ (task-init handled separately via unified root script)
@@ -19,12 +19,12 @@ for script in "$SCRIPT_DIR"/bin/*; do
   name=$(basename "$script")
   [[ "$name" == "task-init" ]] && continue
   ln -sf "$script" ~/.local/bin/"$name"
-  echo "  ✓ Script: $name"
+  echo "  ✓ Script: $name"; sleep 0.05
 done
 
 # Unified task-init (always points to repo-root task-init regardless of which impl was installed last)
 ln -sf "$SCRIPT_DIR/../task-init" ~/.local/bin/task-init
-echo "  ✓ Script: task-init (unified)"
+echo "  ✓ Script: task-init (unified)"; sleep 0.05
 
 # shellcheck disable=SC2016  # literal string written to shell RC; $HOME must not expand here
 PATH_LINE='export PATH="$HOME/.local/bin:$PATH"'
@@ -48,8 +48,25 @@ else
 fi
 
 echo ""
+echo "━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━"
+sleep 0.3
+echo ""
 echo "Done. Next steps:"
-echo "  1. Verify the Atlassian MCP is configured: claude mcp list"
-echo "  2. In your project root, run: task-init claude-jira --site https://... --key PROJ"
+echo ""
+sleep 0.4
+echo "  1. Verify the Atlassian MCP is configured:"
+echo "       claude mcp list"
+sleep 0.4
+echo ""
+echo "  2. In your project root, run:"
+echo "       task-init claude-jira --site https://your-org.atlassian.net --key PROJ"
+echo "     (or run without flags to be prompted interactively)"
+sleep 0.4
+echo ""
 echo "  3. Fill in any remaining details in .claude/jira-workflow.md"
-echo "  4. Start with: claude   (then type /pm)"
+sleep 0.4
+echo ""
+echo "  4. Start Claude and kick off the PM agent:"
+echo "       claude"
+echo "     then type /pm"
+echo ""

--- a/claude-notion/install.sh
+++ b/claude-notion/install.sh
@@ -10,7 +10,7 @@ mkdir -p ~/.claude/commands
 for cmd in "$SCRIPT_DIR"/commands/*.md; do
   name=$(basename "$cmd")
   ln -sf "$cmd" ~/.claude/commands/"$name"
-  echo "  ✓ Slash command: /$(basename "$name" .md)"
+  echo "  ✓ Slash command: /$(basename "$name" .md)"; sleep 0.05
 done
 
 # Scripts → ~/.local/bin/ (task-init handled separately via unified root script)
@@ -19,12 +19,12 @@ for script in "$SCRIPT_DIR"/bin/*; do
   name=$(basename "$script")
   [[ "$name" == "task-init" ]] && continue
   ln -sf "$script" ~/.local/bin/"$name"
-  echo "  ✓ Script: $name"
+  echo "  ✓ Script: $name"; sleep 0.05
 done
 
 # Unified task-init (always points to repo-root task-init regardless of which impl was installed last)
 ln -sf "$SCRIPT_DIR/../task-init" ~/.local/bin/task-init
-echo "  ✓ Script: task-init (unified)"
+echo "  ✓ Script: task-init (unified)"; sleep 0.05
 
 # Ensure ~/.local/bin is on PATH
 # shellcheck disable=SC2016  # literal string written to shell RC; $HOME must not expand here
@@ -49,9 +49,27 @@ else
 fi
 
 echo ""
+echo "━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━"
+sleep 0.3
+echo ""
 echo "Done. Next steps:"
-echo "  1. Verify the Notion MCP is configured: claude mcp list"
-echo "     (If not: claude mcp add --transport http notion https://mcp.notion.com/mcp)"
-echo "  2. In your project root, run: task-init claude-notion"
+echo ""
+sleep 0.4
+echo "  1. Verify the Notion MCP is configured:"
+echo "       claude mcp list"
+echo "     If missing:"
+echo "       claude mcp add --transport http notion https://mcp.notion.com/mcp"
+sleep 0.4
+echo ""
+echo "  2. In your project root, run:"
+echo "       task-init claude-notion"
+sleep 0.4
+echo ""
 echo "  3. Fill in your Notion database IDs in .claude/notion-workflow.md"
-echo "  4. Start with: claude   (then type /pm)"
+echo "     (open your Notion board in Claude Code to find the collection:// IDs)"
+sleep 0.4
+echo ""
+echo "  4. Start Claude and kick off the PM agent:"
+echo "       claude"
+echo "     then type /pm"
+echo ""

--- a/kiro-gh/install.sh
+++ b/kiro-gh/install.sh
@@ -10,7 +10,7 @@ mkdir -p ~/.kiro/agents
 for agent in "$SCRIPT_DIR"/agents/*.json; do
   name=$(basename "$agent")
   ln -sf "$agent" ~/.kiro/agents/"$name"
-  echo "  ✓ Agent: $name"
+  echo "  ✓ Agent: $name"; sleep 0.05
 done
 
 # Scripts → ~/.local/bin/ (task-init handled separately via unified root script)
@@ -19,12 +19,12 @@ for script in "$SCRIPT_DIR"/bin/*; do
   name=$(basename "$script")
   [[ "$name" == "task-init" ]] && continue
   ln -sf "$script" ~/.local/bin/"$name"
-  echo "  ✓ Script: $name"
+  echo "  ✓ Script: $name"; sleep 0.05
 done
 
 # Unified task-init (always points to repo-root task-init regardless of which impl was installed last)
 ln -sf "$SCRIPT_DIR/../task-init" ~/.local/bin/task-init
-echo "  ✓ Script: task-init (unified)"
+echo "  ✓ Script: task-init (unified)"; sleep 0.05
 
 # Ensure ~/.local/bin is on PATH
 # shellcheck disable=SC2016  # literal string written to shell RC; $HOME must not expand here
@@ -49,8 +49,21 @@ else
 fi
 
 echo ""
+echo "━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━"
+sleep 0.3
+echo ""
 echo "Done. Next steps:"
-echo "  1. Set GITHUB_PERSONAL_ACCESS_TOKEN in your environment (needs repo + project scopes)"
-echo "  2. In your project root, run: task-init kiro-gh"
-echo "  3. Fill in your GitHub owner, repo, and project number in .kiro/steering/gh-workflow.md"
-echo "  4. Start with: kiro-cli chat --agent pm"
+echo ""
+sleep 0.4
+echo "  1. Set GITHUB_PERSONAL_ACCESS_TOKEN in your environment"
+echo "     (needs repo + project scopes)"
+sleep 0.4
+echo ""
+echo "  2. In your project root, run:"
+echo "       task-init kiro-gh"
+echo "     (prompts for owner, repo, and project number — auto-detected from git remote)"
+sleep 0.4
+echo ""
+echo "  3. Start the PM agent:"
+echo "       kiro-cli chat --agent pm"
+echo ""

--- a/kiro-notion/install.sh
+++ b/kiro-notion/install.sh
@@ -10,7 +10,7 @@ mkdir -p ~/.kiro/agents
 for agent in "$SCRIPT_DIR"/agents/*.json; do
   name=$(basename "$agent")
   ln -sf "$agent" ~/.kiro/agents/"$name"
-  echo "  ✓ Agent: $name"
+  echo "  ✓ Agent: $name"; sleep 0.05
 done
 
 # Scripts → ~/.local/bin/ (task-init handled separately via unified root script)
@@ -19,12 +19,12 @@ for script in "$SCRIPT_DIR"/bin/*; do
   name=$(basename "$script")
   [[ "$name" == "task-init" ]] && continue
   ln -sf "$script" ~/.local/bin/"$name"
-  echo "  ✓ Script: $name"
+  echo "  ✓ Script: $name"; sleep 0.05
 done
 
 # Unified task-init (always points to repo-root task-init regardless of which impl was installed last)
 ln -sf "$SCRIPT_DIR/../task-init" ~/.local/bin/task-init
-echo "  ✓ Script: task-init (unified)"
+echo "  ✓ Script: task-init (unified)"; sleep 0.05
 
 # Ensure ~/.local/bin is on PATH
 # shellcheck disable=SC2016  # literal string written to shell RC; $HOME must not expand here
@@ -49,7 +49,20 @@ else
 fi
 
 echo ""
+echo "━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━"
+sleep 0.3
+echo ""
 echo "Done. Next steps:"
-echo "  1. In your project root, run: task-init kiro-notion"
+echo ""
+sleep 0.4
+echo "  1. In your project root, run:"
+echo "       task-init kiro-notion"
+sleep 0.4
+echo ""
 echo "  2. Fill in your Notion database IDs in .kiro/steering/notion-workflow.md"
-echo "  3. Start with: kiro-cli chat --agent pm"
+echo "     (open your Notion board in Kiro to find the collection:// IDs)"
+sleep 0.4
+echo ""
+echo "  3. Start the PM agent:"
+echo "       kiro-cli chat --agent pm"
+echo ""


### PR DESCRIPTION
## Summary

- 50ms sleep between each `✓` checkmark — items register individually instead of flashing as a block
- Divider line + timed reveal for "Done. Next steps:" across all 5 install scripts
- Each next step appears 400ms apart so the user can read as they go
- `claude-gh` / `kiro-gh`: removed stale "fill in manually" step — `task-init` now prompts interactively (landed in #10)
- Expanded inline commands with context hints for MCP setup and `task-init` flags

## Before / After

**Before:** all output printed instantly, next steps wall of text  
**After:** checkmarks tick in one by one, divider signals phase change, steps reveal with breathing room

## Test plan

- [x] 205/205 tests pass (no behavioral changes — sleeps don't affect test stubs)
- [x] Manually verified pacing feels right on `claude-gh/install.sh`

🤖 Generated with [Claude Code](https://claude.com/claude-code)