### PR TITLE
ux: add fzf/gum TUI selector to task-init dispatcher

### DIFF
--- a/task-init
+++ b/task-init
@@ -6,7 +6,8 @@ usage() {
 Usage: task-init [--help] [--force] [impl] [impl-options]
 
 Sets up the current git repo for an agentic-workflow implementation.
-With no impl argument, shows an interactive two-step menu (AI tool → board).
+With no impl argument, shows an interactive TUI selector (fzf or gum) if available,
+or falls back to a two-step numbered menu.
 
 Implementations:
   claude-jira    Claude Code + Jira (Atlassian MCP)
@@ -58,38 +59,69 @@ done
 git rev-parse --show-toplevel >/dev/null 2>&1 || { echo "Error: not in a git repo" >&2; exit 1; }
 
 if [[ -z "$IMPL" ]]; then
-  echo "Which AI tool?"
-  echo "  1) Claude Code"
-  echo "  2) Kiro"
-  read -rp "Choice [1-2]: " tool_choice
+  _LABELS=(
+    "Claude Code + GitHub Projects  → .claude/gh-workflow.md"
+    "Claude Code + Notion           → .claude/notion-workflow.md"
+    "Claude Code + Jira             → .claude/jira-workflow.md"
+    "Kiro + GitHub Projects         → .kiro/steering/gh-workflow.md"
+    "Kiro + Notion                  → .kiro/steering/notion-workflow.md"
+  )
+  _TARGETS=(claude-gh claude-notion claude-jira kiro-gh kiro-notion)
 
-  case "$tool_choice" in
-    1)
-      echo ""
-      echo "Which board/tracker?"
-      echo "  1) Jira (Atlassian MCP)       → .claude/jira-workflow.md + CLAUDE.md"
-      echo "  2) Notion (Notion MCP)         → .claude/notion-workflow.md + CLAUDE.md"
-      echo "  3) GitHub Projects (GitHub MCP) → .claude/gh-workflow.md + CLAUDE.md"
-      read -rp "Choice [1-3]: " board_choice
-      case "$board_choice" in
-        1) IMPL="claude-jira" ;;
-        2) IMPL="claude-notion" ;;
-        3) IMPL="claude-gh" ;;
-        *) echo "Invalid choice: $board_choice" >&2; exit 1 ;;
-      esac ;;
-    2)
-      echo ""
-      echo "Which board/tracker?"
-      echo "  1) Notion (Notion MCP)         → .kiro/steering/notion-workflow.md"
-      echo "  2) GitHub Projects (GitHub MCP) → .kiro/steering/gh-workflow.md"
-      read -rp "Choice [1-2]: " board_choice
-      case "$board_choice" in
-        1) IMPL="kiro-notion" ;;
-        2) IMPL="kiro-gh" ;;
-        *) echo "Invalid choice: $board_choice" >&2; exit 1 ;;
-      esac ;;
-    *) echo "Invalid choice: $tool_choice" >&2; exit 1 ;;
-  esac
+  _resolve_label() {
+    local selected="$1" i
+    for i in "${!_LABELS[@]}"; do
+      [[ "${_LABELS[$i]}" == "$selected" ]] && echo "${_TARGETS[$i]}" && return 0
+    done
+  }
+
+  if command -v fzf &>/dev/null; then
+    if SELECTED=$(printf '%s\n' "${_LABELS[@]}" \
+      | fzf --prompt="Select implementation (↑↓ / Enter): "); then
+      IMPL=$(_resolve_label "$SELECTED")
+    else
+      exit 1
+    fi
+  elif command -v gum &>/dev/null; then
+    if SELECTED=$(gum choose "${_LABELS[@]}"); then
+      IMPL=$(_resolve_label "$SELECTED")
+    else
+      exit 1
+    fi
+  else
+    echo "Which AI tool?"
+    echo "  1) Claude Code"
+    echo "  2) Kiro"
+    read -rp "Choice [1-2]: " tool_choice
+
+    case "$tool_choice" in
+      1)
+        echo ""
+        echo "Which board/tracker?"
+        echo "  1) Jira (Atlassian MCP)        → .claude/jira-workflow.md + CLAUDE.md"
+        echo "  2) Notion (Notion MCP)          → .claude/notion-workflow.md + CLAUDE.md"
+        echo "  3) GitHub Projects (GitHub MCP) → .claude/gh-workflow.md + CLAUDE.md"
+        read -rp "Choice [1-3]: " board_choice
+        case "$board_choice" in
+          1) IMPL="claude-jira" ;;
+          2) IMPL="claude-notion" ;;
+          3) IMPL="claude-gh" ;;
+          *) echo "Invalid choice: $board_choice" >&2; exit 1 ;;
+        esac ;;
+      2)
+        echo ""
+        echo "Which board/tracker?"
+        echo "  1) Notion (Notion MCP)          → .kiro/steering/notion-workflow.md"
+        echo "  2) GitHub Projects (GitHub MCP)  → .kiro/steering/gh-workflow.md"
+        read -rp "Choice [1-2]: " board_choice
+        case "$board_choice" in
+          1) IMPL="kiro-notion" ;;
+          2) IMPL="kiro-gh" ;;
+          *) echo "Invalid choice: $board_choice" >&2; exit 1 ;;
+        esac ;;
+      *) echo "Invalid choice: $tool_choice" >&2; exit 1 ;;
+    esac
+  fi
 fi
 
 IMPL_INIT="$REPO_ROOT/$IMPL/bin/task-init"

--- a/tests/helpers/common.bash
+++ b/tests/helpers/common.bash
@@ -61,7 +61,7 @@ setup_stubs() {
   STUB_CALLS_DIR=$(mktemp -d)
   export STUB_BIN STUB_CALLS_DIR
 
-  for stub in zellij gh kiro-cli claude; do
+  for stub in zellij gh kiro-cli claude fzf gum; do
     cp "$REPO_ROOT_REAL/tests/helpers/stubs/$stub" "$STUB_BIN/$stub"
     chmod +x "$STUB_BIN/$stub"
   done

--- a/tests/task_init_dispatcher.bats
+++ b/tests/task_init_dispatcher.bats
@@ -8,6 +8,9 @@ load helpers/common
 
 setup() {
   setup_repo
+  setup_stubs
+  # Restrict PATH so system-installed fzf/gum don't interfere with fallback tests.
+  export PATH="$STUB_BIN:/usr/bin:/bin"
   cd "$MAIN_REPO"
 }
 
@@ -108,46 +111,118 @@ teardown() {
 }
 
 # ---------------------------------------------------------------------------
-# Interactive menu (two-step: tool then board)
+# TUI selector (fzf path)
+# ---------------------------------------------------------------------------
+
+@test "fzf: Claude Code + GitHub Projects → claude-gh" {
+  run env FZF_STUB_CHOICE="Claude Code + GitHub Projects  → .claude/gh-workflow.md" "$TASK_INIT_DISPATCHER"
+  assert_success
+  assert [ -f "$MAIN_REPO/.claude/gh-workflow.md" ]
+}
+
+@test "fzf: Claude Code + Notion → claude-notion" {
+  run env FZF_STUB_CHOICE="Claude Code + Notion           → .claude/notion-workflow.md" "$TASK_INIT_DISPATCHER"
+  assert_success
+  assert [ -f "$MAIN_REPO/.claude/notion-workflow.md" ]
+}
+
+@test "fzf: Claude Code + Jira → claude-jira" {
+  run env FZF_STUB_CHOICE="Claude Code + Jira             → .claude/jira-workflow.md" "$TASK_INIT_DISPATCHER"
+  assert_success
+  assert [ -f "$MAIN_REPO/.claude/jira-workflow.md" ]
+}
+
+@test "fzf: Kiro + GitHub Projects → kiro-gh" {
+  run env FZF_STUB_CHOICE="Kiro + GitHub Projects         → .kiro/steering/gh-workflow.md" "$TASK_INIT_DISPATCHER"
+  assert_success
+  assert [ -f "$MAIN_REPO/.kiro/steering/gh-workflow.md" ]
+}
+
+@test "fzf: Kiro + Notion → kiro-notion" {
+  run env FZF_STUB_CHOICE="Kiro + Notion                  → .kiro/steering/notion-workflow.md" "$TASK_INIT_DISPATCHER"
+  assert_success
+  assert [ -f "$MAIN_REPO/.kiro/steering/notion-workflow.md" ]
+}
+
+@test "fzf: Ctrl-C exits non-zero, does not fall through to numbered menu" {
+  run "$TASK_INIT_DISPATCHER"
+  assert_failure
+  refute_output --partial "Which AI tool?"
+}
+
+# ---------------------------------------------------------------------------
+# TUI selector (gum path — fzf absent)
+# ---------------------------------------------------------------------------
+
+@test "gum: Claude Code + GitHub Projects → claude-gh" {
+  rm -f "$STUB_BIN/fzf"
+  run env GUM_STUB_CHOICE="Claude Code + GitHub Projects  → .claude/gh-workflow.md" "$TASK_INIT_DISPATCHER"
+  assert_success
+  assert [ -f "$MAIN_REPO/.claude/gh-workflow.md" ]
+}
+
+@test "gum: Kiro + Notion → kiro-notion" {
+  rm -f "$STUB_BIN/fzf"
+  run env GUM_STUB_CHOICE="Kiro + Notion                  → .kiro/steering/notion-workflow.md" "$TASK_INIT_DISPATCHER"
+  assert_success
+  assert [ -f "$MAIN_REPO/.kiro/steering/notion-workflow.md" ]
+}
+
+@test "gum: Ctrl-C exits non-zero, does not fall through to numbered menu" {
+  rm -f "$STUB_BIN/fzf"
+  run "$TASK_INIT_DISPATCHER"
+  assert_failure
+  refute_output --partial "Which AI tool?"
+}
+
+# ---------------------------------------------------------------------------
+# Fallback numbered menu (neither fzf nor gum present)
 # ---------------------------------------------------------------------------
 
 @test "interactive menu: Claude Code + Jira (1 then 1)" {
+  rm -f "$STUB_BIN/fzf" "$STUB_BIN/gum"
   run bash -c "printf '1\n1\n' | \"$TASK_INIT_DISPATCHER\""
   assert_success
   assert [ -f "$MAIN_REPO/.claude/jira-workflow.md" ]
 }
 
 @test "interactive menu: Claude Code + Notion (1 then 2)" {
+  rm -f "$STUB_BIN/fzf" "$STUB_BIN/gum"
   run bash -c "printf '1\n2\n' | \"$TASK_INIT_DISPATCHER\""
   assert_success
   assert [ -f "$MAIN_REPO/.claude/notion-workflow.md" ]
 }
 
 @test "interactive menu: Claude Code + GitHub Projects (1 then 3)" {
+  rm -f "$STUB_BIN/fzf" "$STUB_BIN/gum"
   run bash -c "printf '1\n3\n' | \"$TASK_INIT_DISPATCHER\""
   assert_success
   assert [ -f "$MAIN_REPO/.claude/gh-workflow.md" ]
 }
 
 @test "interactive menu: Kiro + Notion (2 then 1)" {
+  rm -f "$STUB_BIN/fzf" "$STUB_BIN/gum"
   run bash -c "printf '2\n1\n' | \"$TASK_INIT_DISPATCHER\""
   assert_success
   assert [ -f "$MAIN_REPO/.kiro/steering/notion-workflow.md" ]
 }
 
 @test "interactive menu: Kiro + GitHub Projects (2 then 2)" {
+  rm -f "$STUB_BIN/fzf" "$STUB_BIN/gum"
   run bash -c "printf '2\n2\n' | \"$TASK_INIT_DISPATCHER\""
   assert_success
   assert [ -f "$MAIN_REPO/.kiro/steering/gh-workflow.md" ]
 }
 
 @test "interactive menu invalid tool choice exits non-zero" {
+  rm -f "$STUB_BIN/fzf" "$STUB_BIN/gum"
   run bash -c "echo 9 | \"$TASK_INIT_DISPATCHER\""
   assert_failure
   assert_output --partial "Invalid choice"
 }
 
 @test "interactive menu invalid board choice exits non-zero" {
+  rm -f "$STUB_BIN/fzf" "$STUB_BIN/gum"
   run bash -c "printf '1\n9\n' | \"$TASK_INIT_DISPATCHER\""
   assert_failure
   assert_output --partial "Invalid choice"


### PR DESCRIPTION
## Summary

- `task-init` (no args) now shows a single-screen fzf/gum selector matching `install.sh` behavior
- Labels include destination file path so users know what they're getting
- Ctrl-C exits cleanly — does not fall through to numbered menu
- Numbered menu fallback still works when neither fzf nor gum is installed
- Direct args (`task-init claude-gh`) unchanged

## Tests

- Added fzf path, gum path, Ctrl-C cancel tests to `task_init_dispatcher.bats`
- Fixed PATH isolation in dispatcher test setup to prevent system fzf from leaking into fallback/gum tests (was causing hangs)
- Added fzf/gum to `setup_stubs` in `common.bash` for consistent test environment
- 214/214 tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)