### PR TITLE
feat: improve Notion task-init guidance (IDs cannot be auto-detected)

### DIFF
--- a/claude-notion/bin/task-init
+++ b/claude-notion/bin/task-init
@@ -2,26 +2,61 @@
 set -euo pipefail
 
 usage() {
-  echo "Usage: task-init [--force]"
+  echo "Usage: task-init [--force] [--help-ids]"
   echo ""
   echo "Set up the current repo for the claude-notion workflow:"
   echo "  - Create .claude/notion-workflow.md from the bundled template"
   echo "  - Add @.claude/notion-workflow.md to CLAUDE.md so it auto-loads in every session"
   echo ""
   echo "Options:"
-  echo "  --force   Overwrite .claude/notion-workflow.md if present"
+  echo "  --force      Overwrite .claude/notion-workflow.md if present"
+  echo "  --help-ids   Print guide for finding Notion database IDs (no setup)"
   exit 1
 }
 
+print_ids_guide() {
+  cat <<'GUIDE'
+
+How to find your Notion database IDs
+─────────────────────────────────────
+Notion IDs cannot be detected from the URL — you need an active Notion MCP
+session to discover them. Here's how:
+
+  1. Start a Claude Code session in this project directory:
+       claude
+
+  2. Ask Claude: "Help me find my Notion database IDs"
+     (Claude will use the Notion MCP to fetch your board and extract the IDs)
+
+  3. Paste the IDs into .claude/notion-workflow.md where marked:
+       Tasks:    collection://<YOUR_TASKS_DATA_SOURCE_ID>
+       Projects: collection://<YOUR_PROJECTS_DATA_SOURCE_ID>
+       Board:    <YOUR_BOARD_PAGE_ID>
+
+  Then run /pm to verify everything works.
+
+Tip: IDs look like UUID strings (e.g. 8a1b2c3d-...) or opaque alphanumeric
+     slugs depending on how you access Notion. The MCP response will show
+     them in <data-source url="collection://..."> attributes.
+GUIDE
+}
+
 FORCE=false
+HELP_IDS=false
 
 while [[ $# -gt 0 ]]; do
   case "$1" in
     --force) FORCE=true; shift ;;
+    --help-ids) HELP_IDS=true; shift ;;
     -h|--help) usage ;;
     *) echo "Unknown option: $1"; usage ;;
   esac
 done
+
+if [[ "$HELP_IDS" == true ]]; then
+  print_ids_guide
+  exit 0
+fi
 
 # Resolve script path through symlinks (install.sh symlinks into ~/.local/bin)
 src="${BASH_SOURCE[0]}"
@@ -66,5 +101,4 @@ else
   echo "✓ Created CLAUDE.md with $IMPORT_LINE"
 fi
 
-echo ""
-echo "Done. Open .claude/notion-workflow.md to fill in your Notion database IDs."
+print_ids_guide

--- a/claude-notion/steering/notion-workflow.example.md
+++ b/claude-notion/steering/notion-workflow.example.md
@@ -25,14 +25,22 @@ claude mcp add --transport http notion https://mcp.notion.com/mcp
 
 ### Notion Database IDs
 
+<!-- Replace each placeholder with the real ID.
+     Run `task-init claude-notion --help-ids` for step-by-step discovery instructions.
+
+     What each ID looks like:
+       collection://...  — opaque string from the Notion MCP (data-source URL)
+       board page ID     — UUID like 8a1b2c3d-e4f5-6789-abcd-ef0123456789
+
+     How to find them (requires Notion MCP active in Claude Code):
+       1. Run: claude
+       2. Ask: "Help me find my Notion database IDs"
+       3. Claude will list your boards and extract the IDs from the MCP response
+-->
+
 - **Tasks**: `collection://<YOUR_TASKS_DATA_SOURCE_ID>`
 - **Projects**: `collection://<YOUR_PROJECTS_DATA_SOURCE_ID>`
 - **Board page**: `<YOUR_BOARD_PAGE_ID>`
-
-To find these IDs:
-1. Open your Notion board in Claude Code with the Notion MCP
-2. Use `notion-fetch` on your database URL
-3. Look for `<data-source url="collection://...">` tags in the response
 
 ### Task Lifecycle
 

--- a/kiro-notion/bin/task-init
+++ b/kiro-notion/bin/task-init
@@ -2,25 +2,60 @@
 set -euo pipefail
 
 usage() {
-  echo "Usage: task-init [--force]"
+  echo "Usage: task-init [--force] [--help-ids]"
   echo ""
   echo "Set up the current repo for the kiro-notion workflow:"
   echo "  - Create .kiro/steering/notion-workflow.md from the bundled template"
   echo ""
   echo "Options:"
-  echo "  --force   Overwrite .kiro/steering/notion-workflow.md if present"
+  echo "  --force      Overwrite .kiro/steering/notion-workflow.md if present"
+  echo "  --help-ids   Print guide for finding Notion database IDs (no setup)"
   exit 1
 }
 
+print_ids_guide() {
+  cat <<'GUIDE'
+
+How to find your Notion database IDs
+─────────────────────────────────────
+Notion IDs cannot be detected from the URL — you need an active Notion MCP
+session to discover them. Here's how:
+
+  1. Start a Kiro session in this project directory:
+       kiro
+
+  2. Ask Kiro: "Help me find my Notion database IDs"
+     (Kiro will use the Notion MCP to fetch your board and extract the IDs)
+
+  3. Paste the IDs into .kiro/steering/notion-workflow.md where marked:
+       Tasks:    collection://<YOUR_TASKS_DATA_SOURCE_ID>
+       Projects: collection://<YOUR_PROJECTS_DATA_SOURCE_ID>
+       Board:    <YOUR_BOARD_PAGE_ID>
+
+  Then ask Kiro to run the pm agent to verify everything works.
+
+Tip: IDs look like UUID strings (e.g. 8a1b2c3d-...) or opaque alphanumeric
+     slugs depending on how you access Notion. The MCP response will show
+     them in <data-source url="collection://..."> attributes.
+GUIDE
+}
+
 FORCE=false
+HELP_IDS=false
 
 while [[ $# -gt 0 ]]; do
   case "$1" in
     --force) FORCE=true; shift ;;
+    --help-ids) HELP_IDS=true; shift ;;
     -h|--help) usage ;;
     *) echo "Unknown option: $1"; usage ;;
   esac
 done
+
+if [[ "$HELP_IDS" == true ]]; then
+  print_ids_guide
+  exit 0
+fi
 
 # Resolve script path through symlinks
 src="${BASH_SOURCE[0]}"
@@ -50,5 +85,5 @@ fi
 
 cp "$TEMPLATE" "$TARGET"
 echo "✓ Wrote $TARGET"
-echo ""
-echo "Done. Open .kiro/steering/notion-workflow.md to fill in your Notion database IDs."
+
+print_ids_guide

--- a/kiro-notion/steering/notion-workflow.example.md
+++ b/kiro-notion/steering/notion-workflow.example.md
@@ -3,14 +3,23 @@
 Copy this file to your project's `.kiro/steering/notion-workflow.md` and fill in your Notion database IDs.
 
 ### Notion Database IDs
+
+<!-- Replace each placeholder with the real ID.
+     Run `task-init kiro-notion --help-ids` for step-by-step discovery instructions.
+
+     What each ID looks like:
+       collection://...  — opaque string from the Notion MCP (data-source URL)
+       board page ID     — UUID like 8a1b2c3d-e4f5-6789-abcd-ef0123456789
+
+     How to find them (requires Notion MCP active in Kiro):
+       1. Run: kiro
+       2. Ask: "Help me find my Notion database IDs"
+       3. Kiro will list your boards and extract the IDs from the MCP response
+-->
+
 - **Tasks**: `collection://<YOUR_TASKS_DATA_SOURCE_ID>`
 - **Projects**: `collection://<YOUR_PROJECTS_DATA_SOURCE_ID>`
 - **Board page**: `<YOUR_BOARD_PAGE_ID>`
-
-To find these IDs:
-1. Open your Notion board in Kiro with the Notion MCP
-2. Use `notion-fetch` on your database URL
-3. Look for `<data-source url="collection://...">` tags in the response
 
 ### Task Lifecycle
 Not Started → In Progress → Done (or Archived)

--- a/task-init
+++ b/task-init
@@ -13,11 +13,11 @@ Implementations:
   claude-jira    Claude Code + Jira (Atlassian MCP)
                  Options: --site URL, --key PROJ, --board NAME, --force
   claude-notion  Claude Code + Notion MCP
-                 Options: --force
+                 Options: --force, --help-ids
   claude-gh      Claude Code + GitHub Projects (GitHub MCP)
                  Options: --force
   kiro-notion    Kiro CLI + Notion MCP
-                 Options: --force
+                 Options: --force, --help-ids
   kiro-gh        Kiro CLI + GitHub Projects (GitHub MCP)
                  Options: --force
 
@@ -45,16 +45,30 @@ REPO_ROOT=$(cd -P "$(dirname "$src")" && pwd)
 
 IMPL=""
 FORCE_FLAG=""
+HELP_IDS=false
 PASSTHROUGH=()
 
 while [[ $# -gt 0 ]]; do
   case "$1" in
     -h|--help) usage ;;
     --force) FORCE_FLAG="--force"; shift ;;
+    --help-ids) HELP_IDS=true; PASSTHROUGH+=("$1"); shift ;;
     claude-jira|claude-notion|claude-gh|kiro-notion|kiro-gh) IMPL="$1"; shift ;;
     *) PASSTHROUGH+=("$1"); shift ;;
   esac
 done
+
+# --help-ids only prints a guide; skip git-repo check and TUI selector
+if [[ "$HELP_IDS" == true ]]; then
+  if [[ -z "$IMPL" ]]; then
+    echo "Error: specify an impl with --help-ids (e.g. task-init claude-notion --help-ids)" >&2
+    exit 1
+  fi
+  IMPL_INIT="$REPO_ROOT/$IMPL/bin/task-init"
+  [[ -f "$IMPL_INIT" ]] || { echo "Error: $IMPL_INIT not found. Is the repository complete?" >&2; exit 1; }
+  [[ -x "$IMPL_INIT" ]] || { echo "Error: $IMPL_INIT is not executable." >&2; exit 1; }
+  exec "$IMPL_INIT" "${PASSTHROUGH[@]}"
+fi
 
 git rev-parse --show-toplevel >/dev/null 2>&1 || { echo "Error: not in a git repo" >&2; exit 1; }
 

--- a/tests/claude_notion_task_init.bats
+++ b/tests/claude_notion_task_init.bats
@@ -87,6 +87,35 @@ teardown() {
 }
 
 # ---------------------------------------------------------------------------
+# Post-install guidance
+# ---------------------------------------------------------------------------
+
+@test "prints Notion ID discovery guide after setup" {
+  run "$CLAUDE_NOTION_TASK_INIT"
+  assert_success
+  assert_output --partial "How to find your Notion database IDs"
+  assert_output --partial "claude"
+}
+
+# ---------------------------------------------------------------------------
+# --help-ids flag
+# ---------------------------------------------------------------------------
+
+@test "--help-ids prints guide without running setup" {
+  run "$CLAUDE_NOTION_TASK_INIT" --help-ids
+  assert_success
+  assert_output --partial "How to find your Notion database IDs"
+  assert [ ! -f "$TARGET_DIR/.claude/notion-workflow.md" ]
+}
+
+@test "--help-ids works outside a git repo" {
+  cd /tmp
+  run "$CLAUDE_NOTION_TASK_INIT" --help-ids
+  assert_success
+  assert_output --partial "How to find your Notion database IDs"
+}
+
+# ---------------------------------------------------------------------------
 # Error cases
 # ---------------------------------------------------------------------------
 

--- a/tests/kiro_notion_task_init.bats
+++ b/tests/kiro_notion_task_init.bats
@@ -1,0 +1,96 @@
+#!/usr/bin/env bats
+# Tests for kiro-notion/bin/task-init
+
+bats_load_library bats-support
+bats_load_library bats-assert
+
+load helpers/common
+
+TARGET_DIR=""
+
+setup() {
+  setup_repo
+  TARGET_DIR="$MAIN_REPO"
+  cd "$TARGET_DIR"
+}
+
+teardown() {
+  teardown_all
+}
+
+# ---------------------------------------------------------------------------
+# File creation
+# ---------------------------------------------------------------------------
+
+@test "copies template to .kiro/steering/notion-workflow.md" {
+  run "$KIRO_TASK_INIT"
+  assert_success
+  assert [ -f "$TARGET_DIR/.kiro/steering/notion-workflow.md" ]
+}
+
+@test "copied file contains placeholder text" {
+  run "$KIRO_TASK_INIT"
+  assert_success
+  run grep -F "YOUR_TASKS_DATA_SOURCE_ID" "$TARGET_DIR/.kiro/steering/notion-workflow.md"
+  assert_success
+}
+
+# ---------------------------------------------------------------------------
+# Post-install guidance
+# ---------------------------------------------------------------------------
+
+@test "prints Notion ID discovery guide after setup" {
+  run "$KIRO_TASK_INIT"
+  assert_success
+  assert_output --partial "How to find your Notion database IDs"
+  assert_output --partial "kiro"
+}
+
+# ---------------------------------------------------------------------------
+# --help-ids flag
+# ---------------------------------------------------------------------------
+
+@test "--help-ids prints guide without running setup" {
+  run "$KIRO_TASK_INIT" --help-ids
+  assert_success
+  assert_output --partial "How to find your Notion database IDs"
+  assert [ ! -f "$TARGET_DIR/.kiro/steering/notion-workflow.md" ]
+}
+
+@test "--help-ids works outside a git repo" {
+  cd /tmp
+  run "$KIRO_TASK_INIT" --help-ids
+  assert_success
+  assert_output --partial "How to find your Notion database IDs"
+}
+
+# ---------------------------------------------------------------------------
+# --force and overwrite guard
+# ---------------------------------------------------------------------------
+
+@test "fails if .kiro/steering/notion-workflow.md already exists (no --force)" {
+  run "$KIRO_TASK_INIT"
+  assert_success
+  run "$KIRO_TASK_INIT"
+  assert_failure
+  assert_output --partial "already exists"
+}
+
+@test "--force overwrites existing notion-workflow.md" {
+  run "$KIRO_TASK_INIT"
+  assert_success
+  run "$KIRO_TASK_INIT" --force
+  assert_success
+  assert [ -f "$TARGET_DIR/.kiro/steering/notion-workflow.md" ]
+}
+
+# ---------------------------------------------------------------------------
+# Error cases
+# ---------------------------------------------------------------------------
+
+@test "fails outside a git repo" {
+  cd /tmp
+  run "$KIRO_TASK_INIT"
+  assert_failure
+  assert_output --partial "not in a git repo"
+}

--- a/tests/task_init_dispatcher.bats
+++ b/tests/task_init_dispatcher.bats
@@ -229,6 +229,44 @@ teardown() {
 }
 
 # ---------------------------------------------------------------------------
+# --help-ids passthrough
+# ---------------------------------------------------------------------------
+
+@test "--help-ids after impl name prints guide, creates no files" {
+  run "$TASK_INIT_DISPATCHER" claude-notion --help-ids
+  assert_success
+  assert_output --partial "How to find your Notion database IDs"
+  assert [ ! -f "$MAIN_REPO/.claude/notion-workflow.md" ]
+}
+
+@test "--help-ids before impl name prints guide, creates no files" {
+  run "$TASK_INIT_DISPATCHER" --help-ids claude-notion
+  assert_success
+  assert_output --partial "How to find your Notion database IDs"
+  assert [ ! -f "$MAIN_REPO/.claude/notion-workflow.md" ]
+}
+
+@test "--help-ids kiro-notion prints guide, creates no files" {
+  run "$TASK_INIT_DISPATCHER" kiro-notion --help-ids
+  assert_success
+  assert_output --partial "How to find your Notion database IDs"
+  assert [ ! -f "$MAIN_REPO/.kiro/steering/notion-workflow.md" ]
+}
+
+@test "--help-ids without impl name exits non-zero with helpful message" {
+  run "$TASK_INIT_DISPATCHER" --help-ids
+  assert_failure
+  assert_output --partial "specify an impl"
+}
+
+@test "--help-ids works outside a git repo" {
+  cd /tmp
+  run "$TASK_INIT_DISPATCHER" claude-notion --help-ids
+  assert_success
+  assert_output --partial "How to find your Notion database IDs"
+}
+
+# ---------------------------------------------------------------------------
 # Error paths
 # ---------------------------------------------------------------------------
 


### PR DESCRIPTION
## Summary

- Prints a step-by-step Notion database ID discovery guide after `task-init claude-notion` / `task-init kiro-notion`, replacing the vague "fill in your IDs" message
- Adds `--help-ids` flag to both Notion implementations: prints the guide without running setup, works outside a git repo
- Improves template comments in `notion-workflow.example.md` with concrete examples of what IDs look like and how to discover them via the MCP
- Updates the task-init dispatcher to document `--help-ids` and short-circuit the git-repo check when the flag is used

## Test plan

- [ ] `task-init claude-notion` prints discovery guide after setup
- [ ] `task-init claude-notion --help-ids` prints guide, creates no files, works outside git repo
- [ ] `task-init kiro-notion` prints discovery guide after setup
- [ ] `task-init kiro-notion --help-ids` prints guide, creates no files, works outside git repo
- [ ] All 225 existing + new tests pass (`bash run_tests.sh`)

Closes #9

🤖 Generated with [Claude Code](https://claude.com/claude-code)