### PR TITLE
task-init: copy slash commands/agents instead of symlinking

### DIFF
--- a/claude-gh/bin/task-init
+++ b/claude-gh/bin/task-init
@@ -144,7 +144,8 @@ for cmd in "$COMMANDS_SRC"/*.md; do
   if [[ ( -e "$cmd_target" || -L "$cmd_target" ) && "$FORCE" != true ]]; then
     echo "⚠ $cmd_target already exists — skipping (use --force to overwrite)"
   else
-    ln -sf "$cmd" "$cmd_target"
+    rm -f "$cmd_target"
+    cp "$cmd" "$cmd_target"
     echo "✓ Slash command: /$(basename "$cmd_name" .md)"
   fi
 done

--- a/claude-jira/bin/task-init
+++ b/claude-jira/bin/task-init
@@ -110,7 +110,8 @@ for cmd in "$COMMANDS_SRC"/*.md; do
   if [[ ( -e "$cmd_target" || -L "$cmd_target" ) && "$FORCE" != true ]]; then
     echo "⚠ $cmd_target already exists — skipping (use --force to overwrite)"
   else
-    ln -sf "$cmd" "$cmd_target"
+    rm -f "$cmd_target"
+    cp "$cmd" "$cmd_target"
     echo "✓ Slash command: /$(basename "$cmd_name" .md)"
   fi
 done

--- a/claude-local/bin/task-init
+++ b/claude-local/bin/task-init
@@ -81,7 +81,8 @@ for cmd in "$COMMANDS_SRC"/*.md; do
   if [[ ( -e "$cmd_target" || -L "$cmd_target" ) && "$FORCE" != true ]]; then
     echo "⚠ $cmd_target already exists — skipping (use --force to overwrite)"
   else
-    ln -sf "$cmd" "$cmd_target"
+    rm -f "$cmd_target"
+    cp "$cmd" "$cmd_target"
     echo "✓ Slash command: /$(basename "$cmd_name" .md)"
   fi
 done

--- a/claude-notion/bin/task-init
+++ b/claude-notion/bin/task-init
@@ -112,7 +112,8 @@ for cmd in "$COMMANDS_SRC"/*.md; do
   if [[ ( -e "$cmd_target" || -L "$cmd_target" ) && "$FORCE" != true ]]; then
     echo "⚠ $cmd_target already exists — skipping (use --force to overwrite)"
   else
-    ln -sf "$cmd" "$cmd_target"
+    rm -f "$cmd_target"
+    cp "$cmd" "$cmd_target"
     echo "✓ Slash command: /$(basename "$cmd_name" .md)"
   fi
 done

--- a/kiro-gh/bin/task-init
+++ b/kiro-gh/bin/task-init
@@ -129,7 +129,8 @@ for agent in "$AGENTS_SRC"/*.json; do
   if [[ ( -e "$agent_target" || -L "$agent_target" ) && "$FORCE" != true ]]; then
     echo "⚠ $agent_target already exists — skipping (use --force to overwrite)"
   else
-    ln -sf "$agent" "$agent_target"
+    rm -f "$agent_target"
+    cp "$agent" "$agent_target"
     echo "✓ Agent: $agent_name"
   fi
 done

--- a/kiro-local/bin/task-init
+++ b/kiro-local/bin/task-init
@@ -66,7 +66,8 @@ for agent in "$AGENTS_SRC"/*.json; do
   if [[ ( -e "$agent_target" || -L "$agent_target" ) && "$FORCE" != true ]]; then
     echo "⚠ $agent_target already exists — skipping (use --force to overwrite)"
   else
-    ln -sf "$agent" "$agent_target"
+    rm -f "$agent_target"
+    cp "$agent" "$agent_target"
     echo "✓ Agent: $agent_name"
   fi
 done

--- a/kiro-notion/bin/task-init
+++ b/kiro-notion/bin/task-init
@@ -97,7 +97,8 @@ for agent in "$AGENTS_SRC"/*.json; do
   if [[ ( -e "$agent_target" || -L "$agent_target" ) && "$FORCE" != true ]]; then
     echo "⚠ $agent_target already exists — skipping (use --force to overwrite)"
   else
-    ln -sf "$agent" "$agent_target"
+    rm -f "$agent_target"
+    cp "$agent" "$agent_target"
     echo "✓ Agent: $agent_name"
   fi
 done

--- a/tests/claude_gh_task_init.bats
+++ b/tests/claude_gh_task_init.bats
@@ -188,20 +188,20 @@ teardown() {
 # Project-level slash commands
 # ---------------------------------------------------------------------------
 
-@test "installs pm/planner/worker symlinks into .claude/commands/" {
+@test "installs pm/planner/worker into .claude/commands/ as real files" {
   run "$CLAUDE_GH_TASK_INIT"
   assert_success
   for cmd in pm planner worker; do
-    assert [ -L "$TARGET_DIR/.claude/commands/$cmd.md" ]
     assert [ -f "$TARGET_DIR/.claude/commands/$cmd.md" ]
+    assert [ ! -L "$TARGET_DIR/.claude/commands/$cmd.md" ]
   done
 }
 
-@test "project-level slash commands link into claude-gh/commands/" {
+@test "project-level slash commands are copies of claude-gh/commands/" {
   run "$CLAUDE_GH_TASK_INIT"
   assert_success
-  run readlink "$TARGET_DIR/.claude/commands/pm.md"
-  assert_output --partial "claude-gh/commands/pm.md"
+  run cmp -s "$REPO_ROOT_REAL/claude-gh/commands/pm.md" "$TARGET_DIR/.claude/commands/pm.md"
+  assert_success
 }
 
 @test "--force overwrites pre-existing project-level slash command" {
@@ -209,9 +209,19 @@ teardown() {
   echo "stale" > "$TARGET_DIR/.claude/commands/pm.md"
   run "$CLAUDE_GH_TASK_INIT" --force
   assert_success
-  assert [ -L "$TARGET_DIR/.claude/commands/pm.md" ]
-  run readlink "$TARGET_DIR/.claude/commands/pm.md"
-  assert_output --partial "claude-gh/commands/pm.md"
+  assert [ ! -L "$TARGET_DIR/.claude/commands/pm.md" ]
+  run cmp -s "$REPO_ROOT_REAL/claude-gh/commands/pm.md" "$TARGET_DIR/.claude/commands/pm.md"
+  assert_success
+}
+
+@test "--force replaces a stale (broken) symlink" {
+  mkdir -p "$TARGET_DIR/.claude/commands"
+  ln -sf /nonexistent/path "$TARGET_DIR/.claude/commands/pm.md"
+  run "$CLAUDE_GH_TASK_INIT" --force
+  assert_success
+  assert [ ! -L "$TARGET_DIR/.claude/commands/pm.md" ]
+  run cmp -s "$REPO_ROOT_REAL/claude-gh/commands/pm.md" "$TARGET_DIR/.claude/commands/pm.md"
+  assert_success
 }
 
 @test "without --force, pre-existing project-level slash command is preserved" {
@@ -219,11 +229,10 @@ teardown() {
   echo "stale content" > "$TARGET_DIR/.claude/commands/pm.md"
   run "$CLAUDE_GH_TASK_INIT"
   assert_success
-  assert [ ! -L "$TARGET_DIR/.claude/commands/pm.md" ]
   run cat "$TARGET_DIR/.claude/commands/pm.md"
   assert_output "stale content"
-  assert [ -L "$TARGET_DIR/.claude/commands/planner.md" ]
-  assert [ -L "$TARGET_DIR/.claude/commands/worker.md" ]
+  assert [ -f "$TARGET_DIR/.claude/commands/planner.md" ]
+  assert [ -f "$TARGET_DIR/.claude/commands/worker.md" ]
 }
 
 # ---------------------------------------------------------------------------

--- a/tests/claude_local_task_init.bats
+++ b/tests/claude_local_task_init.bats
@@ -140,20 +140,20 @@ teardown() {
 # Project-level slash commands
 # ---------------------------------------------------------------------------
 
-@test "installs pm/planner/worker symlinks into .claude/commands/" {
+@test "installs pm/planner/worker into .claude/commands/ as real files" {
   run "$CLAUDE_LOCAL_TASK_INIT"
   assert_success
   for cmd in pm planner worker; do
-    assert [ -L "$TARGET_DIR/.claude/commands/$cmd.md" ]
     assert [ -f "$TARGET_DIR/.claude/commands/$cmd.md" ]
+    assert [ ! -L "$TARGET_DIR/.claude/commands/$cmd.md" ]
   done
 }
 
-@test "project-level slash commands link into claude-local/commands/" {
+@test "project-level slash commands are copies of claude-local/commands/" {
   run "$CLAUDE_LOCAL_TASK_INIT"
   assert_success
-  run readlink "$TARGET_DIR/.claude/commands/pm.md"
-  assert_output --partial "claude-local/commands/pm.md"
+  run cmp -s "$REPO_ROOT_REAL/claude-local/commands/pm.md" "$TARGET_DIR/.claude/commands/pm.md"
+  assert_success
 }
 
 @test "--force overwrites pre-existing project-level slash command" {
@@ -161,9 +161,19 @@ teardown() {
   echo "stale" > "$TARGET_DIR/.claude/commands/pm.md"
   run "$CLAUDE_LOCAL_TASK_INIT" --force
   assert_success
-  assert [ -L "$TARGET_DIR/.claude/commands/pm.md" ]
-  run readlink "$TARGET_DIR/.claude/commands/pm.md"
-  assert_output --partial "claude-local/commands/pm.md"
+  assert [ ! -L "$TARGET_DIR/.claude/commands/pm.md" ]
+  run cmp -s "$REPO_ROOT_REAL/claude-local/commands/pm.md" "$TARGET_DIR/.claude/commands/pm.md"
+  assert_success
+}
+
+@test "--force replaces a stale (broken) symlink" {
+  mkdir -p "$TARGET_DIR/.claude/commands"
+  ln -sf /nonexistent/path "$TARGET_DIR/.claude/commands/pm.md"
+  run "$CLAUDE_LOCAL_TASK_INIT" --force
+  assert_success
+  assert [ ! -L "$TARGET_DIR/.claude/commands/pm.md" ]
+  run cmp -s "$REPO_ROOT_REAL/claude-local/commands/pm.md" "$TARGET_DIR/.claude/commands/pm.md"
+  assert_success
 }
 
 @test "without --force, pre-existing slash command is preserved" {
@@ -171,11 +181,10 @@ teardown() {
   echo "stale content" > "$TARGET_DIR/.claude/commands/pm.md"
   run "$CLAUDE_LOCAL_TASK_INIT"
   assert_success
-  assert [ ! -L "$TARGET_DIR/.claude/commands/pm.md" ]
   run cat "$TARGET_DIR/.claude/commands/pm.md"
   assert_output "stale content"
-  assert [ -L "$TARGET_DIR/.claude/commands/planner.md" ]
-  assert [ -L "$TARGET_DIR/.claude/commands/worker.md" ]
+  assert [ -f "$TARGET_DIR/.claude/commands/planner.md" ]
+  assert [ -f "$TARGET_DIR/.claude/commands/worker.md" ]
 }
 
 # ---------------------------------------------------------------------------

--- a/tests/claude_notion_task_init.bats
+++ b/tests/claude_notion_task_init.bats
@@ -119,20 +119,20 @@ teardown() {
 # Project-level slash commands
 # ---------------------------------------------------------------------------
 
-@test "installs pm/planner/worker symlinks into .claude/commands/" {
+@test "installs pm/planner/worker into .claude/commands/ as real files" {
   run "$CLAUDE_NOTION_TASK_INIT"
   assert_success
   for cmd in pm planner worker; do
-    assert [ -L "$TARGET_DIR/.claude/commands/$cmd.md" ]
     assert [ -f "$TARGET_DIR/.claude/commands/$cmd.md" ]
+    assert [ ! -L "$TARGET_DIR/.claude/commands/$cmd.md" ]
   done
 }
 
-@test "project-level slash commands link into claude-notion/commands/" {
+@test "project-level slash commands are copies of claude-notion/commands/" {
   run "$CLAUDE_NOTION_TASK_INIT"
   assert_success
-  run readlink "$TARGET_DIR/.claude/commands/pm.md"
-  assert_output --partial "claude-notion/commands/pm.md"
+  run cmp -s "$REPO_ROOT_REAL/claude-notion/commands/pm.md" "$TARGET_DIR/.claude/commands/pm.md"
+  assert_success
 }
 
 @test "--force overwrites pre-existing project-level slash command" {
@@ -140,9 +140,19 @@ teardown() {
   echo "stale" > "$TARGET_DIR/.claude/commands/pm.md"
   run "$CLAUDE_NOTION_TASK_INIT" --force
   assert_success
-  assert [ -L "$TARGET_DIR/.claude/commands/pm.md" ]
-  run readlink "$TARGET_DIR/.claude/commands/pm.md"
-  assert_output --partial "claude-notion/commands/pm.md"
+  assert [ ! -L "$TARGET_DIR/.claude/commands/pm.md" ]
+  run cmp -s "$REPO_ROOT_REAL/claude-notion/commands/pm.md" "$TARGET_DIR/.claude/commands/pm.md"
+  assert_success
+}
+
+@test "--force replaces a stale (broken) symlink" {
+  mkdir -p "$TARGET_DIR/.claude/commands"
+  ln -sf /nonexistent/path "$TARGET_DIR/.claude/commands/pm.md"
+  run "$CLAUDE_NOTION_TASK_INIT" --force
+  assert_success
+  assert [ ! -L "$TARGET_DIR/.claude/commands/pm.md" ]
+  run cmp -s "$REPO_ROOT_REAL/claude-notion/commands/pm.md" "$TARGET_DIR/.claude/commands/pm.md"
+  assert_success
 }
 
 @test "without --force, pre-existing project-level slash command is preserved" {
@@ -150,11 +160,10 @@ teardown() {
   echo "stale content" > "$TARGET_DIR/.claude/commands/pm.md"
   run "$CLAUDE_NOTION_TASK_INIT"
   assert_success
-  assert [ ! -L "$TARGET_DIR/.claude/commands/pm.md" ]
   run cat "$TARGET_DIR/.claude/commands/pm.md"
   assert_output "stale content"
-  assert [ -L "$TARGET_DIR/.claude/commands/planner.md" ]
-  assert [ -L "$TARGET_DIR/.claude/commands/worker.md" ]
+  assert [ -f "$TARGET_DIR/.claude/commands/planner.md" ]
+  assert [ -f "$TARGET_DIR/.claude/commands/worker.md" ]
 }
 
 # ---------------------------------------------------------------------------

--- a/tests/jira_task_init.bats
+++ b/tests/jira_task_init.bats
@@ -119,20 +119,20 @@ teardown() {
 # Project-level slash commands
 # ---------------------------------------------------------------------------
 
-@test "installs pm/planner/worker symlinks into .claude/commands/" {
+@test "installs pm/planner/worker into .claude/commands/ as real files" {
   run "$JIRA_TASK_INIT"
   assert_success
   for cmd in pm planner worker; do
-    assert [ -L "$TARGET_DIR/.claude/commands/$cmd.md" ]
     assert [ -f "$TARGET_DIR/.claude/commands/$cmd.md" ]
+    assert [ ! -L "$TARGET_DIR/.claude/commands/$cmd.md" ]
   done
 }
 
-@test "project-level slash commands link into claude-jira/commands/" {
+@test "project-level slash commands are copies of claude-jira/commands/" {
   run "$JIRA_TASK_INIT"
   assert_success
-  run readlink "$TARGET_DIR/.claude/commands/pm.md"
-  assert_output --partial "claude-jira/commands/pm.md"
+  run cmp -s "$REPO_ROOT_REAL/claude-jira/commands/pm.md" "$TARGET_DIR/.claude/commands/pm.md"
+  assert_success
 }
 
 @test "--force overwrites pre-existing project-level slash command" {
@@ -140,9 +140,19 @@ teardown() {
   echo "stale" > "$TARGET_DIR/.claude/commands/pm.md"
   run "$JIRA_TASK_INIT" --force
   assert_success
-  assert [ -L "$TARGET_DIR/.claude/commands/pm.md" ]
-  run readlink "$TARGET_DIR/.claude/commands/pm.md"
-  assert_output --partial "claude-jira/commands/pm.md"
+  assert [ ! -L "$TARGET_DIR/.claude/commands/pm.md" ]
+  run cmp -s "$REPO_ROOT_REAL/claude-jira/commands/pm.md" "$TARGET_DIR/.claude/commands/pm.md"
+  assert_success
+}
+
+@test "--force replaces a stale (broken) symlink" {
+  mkdir -p "$TARGET_DIR/.claude/commands"
+  ln -sf /nonexistent/path "$TARGET_DIR/.claude/commands/pm.md"
+  run "$JIRA_TASK_INIT" --force
+  assert_success
+  assert [ ! -L "$TARGET_DIR/.claude/commands/pm.md" ]
+  run cmp -s "$REPO_ROOT_REAL/claude-jira/commands/pm.md" "$TARGET_DIR/.claude/commands/pm.md"
+  assert_success
 }
 
 @test "without --force, pre-existing project-level slash command is preserved" {
@@ -150,11 +160,10 @@ teardown() {
   echo "stale content" > "$TARGET_DIR/.claude/commands/pm.md"
   run "$JIRA_TASK_INIT"
   assert_success
-  assert [ ! -L "$TARGET_DIR/.claude/commands/pm.md" ]
   run cat "$TARGET_DIR/.claude/commands/pm.md"
   assert_output "stale content"
-  assert [ -L "$TARGET_DIR/.claude/commands/planner.md" ]
-  assert [ -L "$TARGET_DIR/.claude/commands/worker.md" ]
+  assert [ -f "$TARGET_DIR/.claude/commands/planner.md" ]
+  assert [ -f "$TARGET_DIR/.claude/commands/worker.md" ]
 }
 
 # ---------------------------------------------------------------------------

--- a/tests/kiro_gh_task_init.bats
+++ b/tests/kiro_gh_task_init.bats
@@ -139,20 +139,20 @@ teardown() {
 # Project-level agents
 # ---------------------------------------------------------------------------
 
-@test "installs pm/planner/worker symlinks into .kiro/agents/" {
+@test "installs pm/planner/worker into .kiro/agents/ as real files" {
   run "$KIRO_GH_TASK_INIT"
   assert_success
   for agent in pm planner worker; do
-    assert [ -L "$TARGET_DIR/.kiro/agents/$agent.json" ]
     assert [ -f "$TARGET_DIR/.kiro/agents/$agent.json" ]
+    assert [ ! -L "$TARGET_DIR/.kiro/agents/$agent.json" ]
   done
 }
 
-@test "project-level agents link into kiro-gh/agents/" {
+@test "project-level agents are copies of kiro-gh/agents/" {
   run "$KIRO_GH_TASK_INIT"
   assert_success
-  run readlink "$TARGET_DIR/.kiro/agents/pm.json"
-  assert_output --partial "kiro-gh/agents/pm.json"
+  run cmp -s "$REPO_ROOT_REAL/kiro-gh/agents/pm.json" "$TARGET_DIR/.kiro/agents/pm.json"
+  assert_success
 }
 
 @test "--force overwrites pre-existing project-level agent" {
@@ -160,9 +160,19 @@ teardown() {
   echo "stale" > "$TARGET_DIR/.kiro/agents/pm.json"
   run "$KIRO_GH_TASK_INIT" --force
   assert_success
-  assert [ -L "$TARGET_DIR/.kiro/agents/pm.json" ]
-  run readlink "$TARGET_DIR/.kiro/agents/pm.json"
-  assert_output --partial "kiro-gh/agents/pm.json"
+  assert [ ! -L "$TARGET_DIR/.kiro/agents/pm.json" ]
+  run cmp -s "$REPO_ROOT_REAL/kiro-gh/agents/pm.json" "$TARGET_DIR/.kiro/agents/pm.json"
+  assert_success
+}
+
+@test "--force replaces a stale (broken) symlink" {
+  mkdir -p "$TARGET_DIR/.kiro/agents"
+  ln -sf /nonexistent/path "$TARGET_DIR/.kiro/agents/pm.json"
+  run "$KIRO_GH_TASK_INIT" --force
+  assert_success
+  assert [ ! -L "$TARGET_DIR/.kiro/agents/pm.json" ]
+  run cmp -s "$REPO_ROOT_REAL/kiro-gh/agents/pm.json" "$TARGET_DIR/.kiro/agents/pm.json"
+  assert_success
 }
 
 @test "without --force, pre-existing project-level agent is preserved" {
@@ -170,11 +180,10 @@ teardown() {
   echo "stale content" > "$TARGET_DIR/.kiro/agents/pm.json"
   run "$KIRO_GH_TASK_INIT"
   assert_success
-  assert [ ! -L "$TARGET_DIR/.kiro/agents/pm.json" ]
   run cat "$TARGET_DIR/.kiro/agents/pm.json"
   assert_output "stale content"
-  assert [ -L "$TARGET_DIR/.kiro/agents/planner.json" ]
-  assert [ -L "$TARGET_DIR/.kiro/agents/worker.json" ]
+  assert [ -f "$TARGET_DIR/.kiro/agents/planner.json" ]
+  assert [ -f "$TARGET_DIR/.kiro/agents/worker.json" ]
 }
 
 # ---------------------------------------------------------------------------

--- a/tests/kiro_local_task_init.bats
+++ b/tests/kiro_local_task_init.bats
@@ -109,20 +109,20 @@ teardown() {
 # Project-level agents
 # ---------------------------------------------------------------------------
 
-@test "installs pm/planner/worker symlinks into .kiro/agents/" {
+@test "installs pm/planner/worker into .kiro/agents/ as real files" {
   run "$KIRO_LOCAL_TASK_INIT"
   assert_success
   for agent in pm planner worker; do
-    assert [ -L "$TARGET_DIR/.kiro/agents/$agent.json" ]
     assert [ -f "$TARGET_DIR/.kiro/agents/$agent.json" ]
+    assert [ ! -L "$TARGET_DIR/.kiro/agents/$agent.json" ]
   done
 }
 
-@test "project-level agents link into kiro-local/agents/" {
+@test "project-level agents are copies of kiro-local/agents/" {
   run "$KIRO_LOCAL_TASK_INIT"
   assert_success
-  run readlink "$TARGET_DIR/.kiro/agents/pm.json"
-  assert_output --partial "kiro-local/agents/pm.json"
+  run cmp -s "$REPO_ROOT_REAL/kiro-local/agents/pm.json" "$TARGET_DIR/.kiro/agents/pm.json"
+  assert_success
 }
 
 @test "--force overwrites pre-existing project-level agent" {
@@ -130,9 +130,19 @@ teardown() {
   echo "stale" > "$TARGET_DIR/.kiro/agents/pm.json"
   run "$KIRO_LOCAL_TASK_INIT" --force
   assert_success
-  assert [ -L "$TARGET_DIR/.kiro/agents/pm.json" ]
-  run readlink "$TARGET_DIR/.kiro/agents/pm.json"
-  assert_output --partial "kiro-local/agents/pm.json"
+  assert [ ! -L "$TARGET_DIR/.kiro/agents/pm.json" ]
+  run cmp -s "$REPO_ROOT_REAL/kiro-local/agents/pm.json" "$TARGET_DIR/.kiro/agents/pm.json"
+  assert_success
+}
+
+@test "--force replaces a stale (broken) symlink" {
+  mkdir -p "$TARGET_DIR/.kiro/agents"
+  ln -sf /nonexistent/path "$TARGET_DIR/.kiro/agents/pm.json"
+  run "$KIRO_LOCAL_TASK_INIT" --force
+  assert_success
+  assert [ ! -L "$TARGET_DIR/.kiro/agents/pm.json" ]
+  run cmp -s "$REPO_ROOT_REAL/kiro-local/agents/pm.json" "$TARGET_DIR/.kiro/agents/pm.json"
+  assert_success
 }
 
 @test "without --force, pre-existing project-level agent is preserved" {
@@ -140,11 +150,10 @@ teardown() {
   echo "stale content" > "$TARGET_DIR/.kiro/agents/pm.json"
   run "$KIRO_LOCAL_TASK_INIT"
   assert_success
-  assert [ ! -L "$TARGET_DIR/.kiro/agents/pm.json" ]
   run cat "$TARGET_DIR/.kiro/agents/pm.json"
   assert_output "stale content"
-  assert [ -L "$TARGET_DIR/.kiro/agents/planner.json" ]
-  assert [ -L "$TARGET_DIR/.kiro/agents/worker.json" ]
+  assert [ -f "$TARGET_DIR/.kiro/agents/planner.json" ]
+  assert [ -f "$TARGET_DIR/.kiro/agents/worker.json" ]
 }
 
 # ---------------------------------------------------------------------------

--- a/tests/kiro_notion_task_init.bats
+++ b/tests/kiro_notion_task_init.bats
@@ -88,20 +88,20 @@ teardown() {
 # Project-level agents
 # ---------------------------------------------------------------------------
 
-@test "installs pm/planner/worker symlinks into .kiro/agents/" {
+@test "installs pm/planner/worker into .kiro/agents/ as real files" {
   run "$KIRO_TASK_INIT"
   assert_success
   for agent in pm planner worker; do
-    assert [ -L "$TARGET_DIR/.kiro/agents/$agent.json" ]
     assert [ -f "$TARGET_DIR/.kiro/agents/$agent.json" ]
+    assert [ ! -L "$TARGET_DIR/.kiro/agents/$agent.json" ]
   done
 }
 
-@test "project-level agents link into kiro-notion/agents/" {
+@test "project-level agents are copies of kiro-notion/agents/" {
   run "$KIRO_TASK_INIT"
   assert_success
-  run readlink "$TARGET_DIR/.kiro/agents/pm.json"
-  assert_output --partial "kiro-notion/agents/pm.json"
+  run cmp -s "$REPO_ROOT_REAL/kiro-notion/agents/pm.json" "$TARGET_DIR/.kiro/agents/pm.json"
+  assert_success
 }
 
 @test "--force overwrites pre-existing project-level agent" {
@@ -109,9 +109,19 @@ teardown() {
   echo "stale" > "$TARGET_DIR/.kiro/agents/pm.json"
   run "$KIRO_TASK_INIT" --force
   assert_success
-  assert [ -L "$TARGET_DIR/.kiro/agents/pm.json" ]
-  run readlink "$TARGET_DIR/.kiro/agents/pm.json"
-  assert_output --partial "kiro-notion/agents/pm.json"
+  assert [ ! -L "$TARGET_DIR/.kiro/agents/pm.json" ]
+  run cmp -s "$REPO_ROOT_REAL/kiro-notion/agents/pm.json" "$TARGET_DIR/.kiro/agents/pm.json"
+  assert_success
+}
+
+@test "--force replaces a stale (broken) symlink" {
+  mkdir -p "$TARGET_DIR/.kiro/agents"
+  ln -sf /nonexistent/path "$TARGET_DIR/.kiro/agents/pm.json"
+  run "$KIRO_TASK_INIT" --force
+  assert_success
+  assert [ ! -L "$TARGET_DIR/.kiro/agents/pm.json" ]
+  run cmp -s "$REPO_ROOT_REAL/kiro-notion/agents/pm.json" "$TARGET_DIR/.kiro/agents/pm.json"
+  assert_success
 }
 
 @test "without --force, pre-existing project-level agent is preserved" {
@@ -119,11 +129,10 @@ teardown() {
   echo "stale content" > "$TARGET_DIR/.kiro/agents/pm.json"
   run "$KIRO_TASK_INIT"
   assert_success
-  assert [ ! -L "$TARGET_DIR/.kiro/agents/pm.json" ]
   run cat "$TARGET_DIR/.kiro/agents/pm.json"
   assert_output "stale content"
-  assert [ -L "$TARGET_DIR/.kiro/agents/planner.json" ]
-  assert [ -L "$TARGET_DIR/.kiro/agents/worker.json" ]
+  assert [ -f "$TARGET_DIR/.kiro/agents/planner.json" ]
+  assert [ -f "$TARGET_DIR/.kiro/agents/worker.json" ]
 }
 
 # ---------------------------------------------------------------------------

--- a/tests/task_init_dispatcher.bats
+++ b/tests/task_init_dispatcher.bats
@@ -152,11 +152,12 @@ teardown() {
   assert_success
 }
 
-@test "kiro-local via dispatcher: agents symlinked under .kiro/agents/" {
+@test "kiro-local via dispatcher: agents installed under .kiro/agents/" {
   run "$TASK_INIT_DISPATCHER" kiro-local
   assert_success
   for agent in pm planner worker; do
-    assert [ -L "$MAIN_REPO/.kiro/agents/$agent.json" ]
+    assert [ -f "$MAIN_REPO/.kiro/agents/$agent.json" ]
+    assert [ ! -L "$MAIN_REPO/.kiro/agents/$agent.json" ]
   done
 }
 


### PR DESCRIPTION
## Summary

- Every `*/bin/task-init` was using `ln -sf <abs-path>` to install slash commands (`.claude/commands/*.md`) and Kiro agents (`.kiro/agents/*.json`) — pinning each project to the agentic-workflow install path. Commit them, clone on another machine (or move the install), and all three links dangle.
- Switch to `rm -f && cp`. Project command/agent files are now real, self-contained, committable. `task-init --force` becomes the explicit "refresh after upgrading agentic-workflow" command.
- Tests across all 7 combos updated: `-L` symlink assertions → `-f && ! -L` + `cmp -s` against source. New per-combo test `--force replaces a stale (broken) symlink` locks in the upgrade path for repos already carrying broken symlinks (so re-running `task-init --force` heals them in place).

Same shape applied identically to claude-{jira,notion,gh,local} (commands) and kiro-{notion,gh,local} (agents). Trade-off: commands no longer auto-update on `git pull` of agentic-workflow; `task-init --force` is the explicit refresh.

## Test plan

- [x] `./run_tests.sh` — 396 tests, 0 failures
- [ ] In a real project with previously broken symlinks: `task-init <impl> --force` replaces them with real files; `git status` shows file content (not symlink target) ready to commit
- [ ] Clone that project on a different machine — slash commands work without agentic-workflow installed

🤖 Generated with [Claude Code](https://claude.com/claude-code)