### PR TITLE
task/issue 32

### DIFF
--- a/claude-gh/bin/task-done
+++ b/claude-gh/bin/task-done
@@ -85,7 +85,7 @@ if [[ "$REMOVE_ONLY" != true ]]; then
   echo ""
 fi
 
-if [[ "$FORCE" != true ]]; then
+if [[ "$FORCE" != true && "$REMOVE_ONLY" != true ]]; then
   read -rp "Remove worktree and close tab? (y/N) " confirm
   [[ "$confirm" != "y" && "$confirm" != "Y" ]] && exit 0
 fi

--- a/claude-jira/bin/task-done
+++ b/claude-jira/bin/task-done
@@ -89,7 +89,7 @@ if [[ "$REMOVE_ONLY" != true ]]; then
   echo ""
 fi
 
-if [[ "$FORCE" != true ]]; then
+if [[ "$FORCE" != true && "$REMOVE_ONLY" != true ]]; then
   read -rp "Remove worktree and close tab? (y/N) " confirm
   [[ "$confirm" != "y" && "$confirm" != "Y" ]] && exit 0
 fi

--- a/claude-local/bin/task-done
+++ b/claude-local/bin/task-done
@@ -87,7 +87,7 @@ if [[ "$REMOVE_ONLY" != true ]]; then
   echo ""
 fi
 
-if [[ "$FORCE" != true ]]; then
+if [[ "$FORCE" != true && "$REMOVE_ONLY" != true ]]; then
   read -rp "Remove worktree and close tab? (y/N) " confirm
   [[ "$confirm" != "y" && "$confirm" != "Y" ]] && exit 0
 fi

--- a/claude-notion/bin/task-done
+++ b/claude-notion/bin/task-done
@@ -85,7 +85,7 @@ if [[ "$REMOVE_ONLY" != true ]]; then
   echo ""
 fi
 
-if [[ "$FORCE" != true ]]; then
+if [[ "$FORCE" != true && "$REMOVE_ONLY" != true ]]; then
   read -rp "Remove worktree and close tab? (y/N) " confirm
   [[ "$confirm" != "y" && "$confirm" != "Y" ]] && exit 0
 fi

--- a/kiro-gh/bin/task-done
+++ b/kiro-gh/bin/task-done
@@ -85,7 +85,7 @@ if [[ "$REMOVE_ONLY" != true ]]; then
   echo ""
 fi
 
-if [[ "$FORCE" != true ]]; then
+if [[ "$FORCE" != true && "$REMOVE_ONLY" != true ]]; then
   read -rp "Remove worktree and close tab? (y/N) " confirm
   [[ "$confirm" != "y" && "$confirm" != "Y" ]] && exit 0
 fi

--- a/kiro-local/bin/task-done
+++ b/kiro-local/bin/task-done
@@ -87,7 +87,7 @@ if [[ "$REMOVE_ONLY" != true ]]; then
   echo ""
 fi
 
-if [[ "$FORCE" != true ]]; then
+if [[ "$FORCE" != true && "$REMOVE_ONLY" != true ]]; then
   read -rp "Remove worktree and close tab? (y/N) " confirm
   [[ "$confirm" != "y" && "$confirm" != "Y" ]] && exit 0
 fi

--- a/kiro-notion/bin/task-done
+++ b/kiro-notion/bin/task-done
@@ -85,7 +85,7 @@ if [[ "$REMOVE_ONLY" != true ]]; then
   echo ""
 fi
 
-if [[ "$FORCE" != true ]]; then
+if [[ "$FORCE" != true && "$REMOVE_ONLY" != true ]]; then
   read -rp "Remove worktree and close tab? (y/N) " confirm
   [[ "$confirm" != "y" && "$confirm" != "Y" ]] && exit 0
 fi

--- a/tests/task_done.bats
+++ b/tests/task_done.bats
@@ -139,6 +139,22 @@ teardown() {
   assert [ ! -d "$WORKTREE_BASE/$SLUG" ]
 }
 
+@test "kiro: --remove-worktree alone exits 0 without reading stdin" {
+  # No --force, no piped input. Bug was that the "Remove worktree?" prompt
+  # still fired and would hang reading stdin.
+  run "$KIRO_TASK_DONE" --remove-worktree </dev/null
+  assert_success
+  refute_output --partial "Remove worktree and close tab?"
+  assert [ ! -d "$WORKTREE_BASE/$SLUG" ]
+}
+
+@test "jira: --remove-worktree alone exits 0 without reading stdin" {
+  run "$JIRA_TASK_DONE" --remove-worktree </dev/null
+  assert_success
+  refute_output --partial "Remove worktree and close tab?"
+  assert [ ! -d "$WORKTREE_BASE/$SLUG" ]
+}
+
 # ---------------------------------------------------------------------------
 # Cleanup
 # ---------------------------------------------------------------------------
@@ -231,6 +247,13 @@ teardown() {
 @test "claude-notion: --remove-worktree --force skips all prompts" {
   run "$CLAUDE_NOTION_TASK_DONE" --remove-worktree --force
   assert_success
+  assert [ ! -d "$WORKTREE_BASE/$SLUG" ]
+}
+
+@test "claude-notion: --remove-worktree alone exits 0 without reading stdin" {
+  run "$CLAUDE_NOTION_TASK_DONE" --remove-worktree </dev/null
+  assert_success
+  refute_output --partial "Remove worktree and close tab?"
   assert [ ! -d "$WORKTREE_BASE/$SLUG" ]
 }
 


### PR DESCRIPTION
- **docs: document claude-local and kiro-local loadouts: README updates for issue #29**
- **kiro-local loadout (child of #24): add Kiro CLI agents + local markdown task tracking**
- **kiro-local loadout (child of #24): address review nits**
- **docs: correct slug derivation claim (was: task-001, is: kebab slug)**
- **task-init: copy slash commands/agents instead of symlinking**
- **task-done --remove-worktree asks for removal: skip removal confirm when intent declared (#32)**
