### PR TITLE
task/issue 40

### DIFF
--- a/claude-gh/bin/task-done
+++ b/claude-gh/bin/task-done
@@ -104,12 +104,12 @@ git worktree remove "$WORKTREE_DIR" --force 2>/dev/null || {
 # Clean up info file
 [[ -f "$INFO_FILE" ]] && rm -f "$INFO_FILE"
 
-# Close current zellij tab
-echo "Closing zellij tab..."
-zellij action close-tab
-
 if git branch -d "$BRANCH" 2>/dev/null; then
   echo "Done. Deleted local branch '$BRANCH'."
 else
   echo "Done. Branch '$BRANCH' still has unmerged commits — delete manually after PR merge: git branch -D $BRANCH"
 fi
+
+# Close current zellij tab
+echo "Closing zellij tab..."
+zellij action close-tab

--- a/claude-gh/bin/task-done
+++ b/claude-gh/bin/task-done
@@ -108,4 +108,8 @@ git worktree remove "$WORKTREE_DIR" --force 2>/dev/null || {
 echo "Closing zellij tab..."
 zellij action close-tab
 
-echo "Done. Branch '$BRANCH' still exists — delete after PR merge with: git branch -d $BRANCH"
+if git branch -d "$BRANCH" 2>/dev/null; then
+  echo "Done. Deleted local branch '$BRANCH'."
+else
+  echo "Done. Branch '$BRANCH' still has unmerged commits — delete manually after PR merge: git branch -D $BRANCH"
+fi

--- a/claude-jira/bin/task-done
+++ b/claude-jira/bin/task-done
@@ -109,4 +109,8 @@ git worktree remove "$WORKTREE_DIR" --force 2>/dev/null || {
 echo "Closing zellij tab..."
 zellij action close-tab
 
-echo "Done. Branch '$BRANCH' still exists — delete after PR merge with: git branch -d $BRANCH"
+if git branch -d "$BRANCH" 2>/dev/null; then
+  echo "Done. Deleted local branch '$BRANCH'."
+else
+  echo "Done. Branch '$BRANCH' still has unmerged commits — delete manually after PR merge: git branch -D $BRANCH"
+fi

--- a/claude-jira/bin/task-done
+++ b/claude-jira/bin/task-done
@@ -106,11 +106,11 @@ git worktree remove "$WORKTREE_DIR" --force 2>/dev/null || {
 # Clean up info file
 [[ -f "$INFO_FILE" ]] && rm -f "$INFO_FILE"
 
-echo "Closing zellij tab..."
-zellij action close-tab
-
 if git branch -d "$BRANCH" 2>/dev/null; then
   echo "Done. Deleted local branch '$BRANCH'."
 else
   echo "Done. Branch '$BRANCH' still has unmerged commits — delete manually after PR merge: git branch -D $BRANCH"
 fi
+
+echo "Closing zellij tab..."
+zellij action close-tab

--- a/claude-local/bin/task-done
+++ b/claude-local/bin/task-done
@@ -126,4 +126,8 @@ fi
 echo "Closing zellij tab..."
 zellij action close-tab
 
-echo "Done. Branch '$BRANCH' still exists — delete after PR merge with: git branch -d $BRANCH"
+if git branch -d "$BRANCH" 2>/dev/null; then
+  echo "Done. Deleted local branch '$BRANCH'."
+else
+  echo "Done. Branch '$BRANCH' still has unmerged commits — delete manually after PR merge: git branch -D $BRANCH"
+fi

--- a/claude-local/bin/task-done
+++ b/claude-local/bin/task-done
@@ -122,12 +122,12 @@ else
   [[ -x "$_BOARD_SCRIPT" ]] && "$_BOARD_SCRIPT" --repo "$MAIN_WORKTREE" >/dev/null || true
 fi
 
-# Close current zellij tab
-echo "Closing zellij tab..."
-zellij action close-tab
-
 if git branch -d "$BRANCH" 2>/dev/null; then
   echo "Done. Deleted local branch '$BRANCH'."
 else
   echo "Done. Branch '$BRANCH' still has unmerged commits — delete manually after PR merge: git branch -D $BRANCH"
 fi
+
+# Close current zellij tab
+echo "Closing zellij tab..."
+zellij action close-tab

--- a/claude-notion/bin/task-done
+++ b/claude-notion/bin/task-done
@@ -104,12 +104,12 @@ git worktree remove "$WORKTREE_DIR" --force 2>/dev/null || {
 # Clean up info file
 [[ -f "$INFO_FILE" ]] && rm -f "$INFO_FILE"
 
-# Close current zellij tab
-echo "Closing zellij tab..."
-zellij action close-tab
-
 if git branch -d "$BRANCH" 2>/dev/null; then
   echo "Done. Deleted local branch '$BRANCH'."
 else
   echo "Done. Branch '$BRANCH' still has unmerged commits — delete manually after PR merge: git branch -D $BRANCH"
 fi
+
+# Close current zellij tab
+echo "Closing zellij tab..."
+zellij action close-tab

--- a/claude-notion/bin/task-done
+++ b/claude-notion/bin/task-done
@@ -108,4 +108,8 @@ git worktree remove "$WORKTREE_DIR" --force 2>/dev/null || {
 echo "Closing zellij tab..."
 zellij action close-tab
 
-echo "Done. Branch '$BRANCH' still exists — delete after PR merge with: git branch -d $BRANCH"
+if git branch -d "$BRANCH" 2>/dev/null; then
+  echo "Done. Deleted local branch '$BRANCH'."
+else
+  echo "Done. Branch '$BRANCH' still has unmerged commits — delete manually after PR merge: git branch -D $BRANCH"
+fi

--- a/kiro-gh/bin/task-done
+++ b/kiro-gh/bin/task-done
@@ -104,12 +104,12 @@ git worktree remove "$WORKTREE_DIR" --force 2>/dev/null || {
 # Clean up info file
 [[ -f "$INFO_FILE" ]] && rm -f "$INFO_FILE"
 
-# Close current zellij tab
-echo "Closing zellij tab..."
-zellij action close-tab
-
 if git branch -d "$BRANCH" 2>/dev/null; then
   echo "Done. Deleted local branch '$BRANCH'."
 else
   echo "Done. Branch '$BRANCH' still has unmerged commits — delete manually after PR merge: git branch -D $BRANCH"
 fi
+
+# Close current zellij tab
+echo "Closing zellij tab..."
+zellij action close-tab

--- a/kiro-gh/bin/task-done
+++ b/kiro-gh/bin/task-done
@@ -108,4 +108,8 @@ git worktree remove "$WORKTREE_DIR" --force 2>/dev/null || {
 echo "Closing zellij tab..."
 zellij action close-tab
 
-echo "Done. Branch '$BRANCH' still exists — delete after PR merge with: git branch -d $BRANCH"
+if git branch -d "$BRANCH" 2>/dev/null; then
+  echo "Done. Deleted local branch '$BRANCH'."
+else
+  echo "Done. Branch '$BRANCH' still has unmerged commits — delete manually after PR merge: git branch -D $BRANCH"
+fi

--- a/kiro-local/bin/task-done
+++ b/kiro-local/bin/task-done
@@ -126,4 +126,8 @@ fi
 echo "Closing zellij tab..."
 zellij action close-tab
 
-echo "Done. Branch '$BRANCH' still exists — delete after PR merge with: git branch -d $BRANCH"
+if git branch -d "$BRANCH" 2>/dev/null; then
+  echo "Done. Deleted local branch '$BRANCH'."
+else
+  echo "Done. Branch '$BRANCH' still has unmerged commits — delete manually after PR merge: git branch -D $BRANCH"
+fi

--- a/kiro-local/bin/task-done
+++ b/kiro-local/bin/task-done
@@ -122,12 +122,12 @@ else
   [[ -x "$_BOARD_SCRIPT" ]] && "$_BOARD_SCRIPT" --repo "$MAIN_WORKTREE" >/dev/null || true
 fi
 
-# Close current zellij tab
-echo "Closing zellij tab..."
-zellij action close-tab
-
 if git branch -d "$BRANCH" 2>/dev/null; then
   echo "Done. Deleted local branch '$BRANCH'."
 else
   echo "Done. Branch '$BRANCH' still has unmerged commits — delete manually after PR merge: git branch -D $BRANCH"
 fi
+
+# Close current zellij tab
+echo "Closing zellij tab..."
+zellij action close-tab

--- a/kiro-notion/bin/task-done
+++ b/kiro-notion/bin/task-done
@@ -104,12 +104,12 @@ git worktree remove "$WORKTREE_DIR" --force 2>/dev/null || {
 # Clean up info file
 [[ -f "$INFO_FILE" ]] && rm -f "$INFO_FILE"
 
-# Close current zellij tab
-echo "Closing zellij tab..."
-zellij action close-tab
-
 if git branch -d "$BRANCH" 2>/dev/null; then
   echo "Done. Deleted local branch '$BRANCH'."
 else
   echo "Done. Branch '$BRANCH' still has unmerged commits — delete manually after PR merge: git branch -D $BRANCH"
 fi
+
+# Close current zellij tab
+echo "Closing zellij tab..."
+zellij action close-tab

--- a/kiro-notion/bin/task-done
+++ b/kiro-notion/bin/task-done
@@ -108,4 +108,8 @@ git worktree remove "$WORKTREE_DIR" --force 2>/dev/null || {
 echo "Closing zellij tab..."
 zellij action close-tab
 
-echo "Done. Branch '$BRANCH' still exists — delete after PR merge with: git branch -d $BRANCH"
+if git branch -d "$BRANCH" 2>/dev/null; then
+  echo "Done. Deleted local branch '$BRANCH'."
+else
+  echo "Done. Branch '$BRANCH' still has unmerged commits — delete manually after PR merge: git branch -D $BRANCH"
+fi

--- a/tests/task_done.bats
+++ b/tests/task_done.bats
@@ -284,3 +284,69 @@ teardown() {
   run bash -c "echo y | $CLAUDE_NOTION_TASK_DONE --force"
   assert_output --partial "Uncommitted changes"
 }
+
+# ---------------------------------------------------------------------------
+# Local branch deletion after worktree removal
+# ---------------------------------------------------------------------------
+
+@test "kiro: deletes local branch when fully merged (no new commits)" {
+  # Fresh branch with no commits ahead of main is trivially merged.
+  run_task_done "$KIRO_TASK_DONE" --force
+  assert_success
+  assert_output --partial "Deleted local branch 'task/$SLUG'"
+  run git -C "$MAIN_REPO" branch --list "task/$SLUG"
+  assert_output ""
+}
+
+@test "kiro: keeps local branch when it has unmerged commits" {
+  # Commit on the task branch — now it's ahead of main and not merged.
+  touch "$WORKTREE_BASE/$SLUG/unmerged.txt"
+  git -C "$WORKTREE_BASE/$SLUG" add unmerged.txt
+  git -C "$WORKTREE_BASE/$SLUG" commit -q -m "unmerged work"
+
+  run_task_done "$KIRO_TASK_DONE" --force
+  assert_success
+  assert_output --partial "still has unmerged commits"
+  run git -C "$MAIN_REPO" branch --list "task/$SLUG"
+  assert_output --partial "task/$SLUG"
+}
+
+@test "jira: deletes local branch when fully merged (no new commits)" {
+  run_task_done "$JIRA_TASK_DONE" --force
+  assert_success
+  assert_output --partial "Deleted local branch 'task/$SLUG'"
+  run git -C "$MAIN_REPO" branch --list "task/$SLUG"
+  assert_output ""
+}
+
+@test "jira: keeps local branch when it has unmerged commits" {
+  touch "$WORKTREE_BASE/$SLUG/unmerged.txt"
+  git -C "$WORKTREE_BASE/$SLUG" add unmerged.txt
+  git -C "$WORKTREE_BASE/$SLUG" commit -q -m "unmerged work"
+
+  run_task_done "$JIRA_TASK_DONE" --force
+  assert_success
+  assert_output --partial "still has unmerged commits"
+  run git -C "$MAIN_REPO" branch --list "task/$SLUG"
+  assert_output --partial "task/$SLUG"
+}
+
+@test "claude-notion: deletes local branch when fully merged (no new commits)" {
+  run_task_done "$CLAUDE_NOTION_TASK_DONE" --force
+  assert_success
+  assert_output --partial "Deleted local branch 'task/$SLUG'"
+  run git -C "$MAIN_REPO" branch --list "task/$SLUG"
+  assert_output ""
+}
+
+@test "claude-notion: keeps local branch when it has unmerged commits" {
+  touch "$WORKTREE_BASE/$SLUG/unmerged.txt"
+  git -C "$WORKTREE_BASE/$SLUG" add unmerged.txt
+  git -C "$WORKTREE_BASE/$SLUG" commit -q -m "unmerged work"
+
+  run_task_done "$CLAUDE_NOTION_TASK_DONE" --force
+  assert_success
+  assert_output --partial "still has unmerged commits"
+  run git -C "$MAIN_REPO" branch --list "task/$SLUG"
+  assert_output --partial "task/$SLUG"
+}


### PR DESCRIPTION
- **docs: document claude-local and kiro-local loadouts: README updates for issue #29**
- **kiro-local loadout (child of #24): add Kiro CLI agents + local markdown task tracking**
- **kiro-local loadout (child of #24): address review nits**
- **docs: correct slug derivation claim (was: task-001, is: kebab slug)**
- **task-init: copy slash commands/agents instead of symlinking**
- **task-done --remove-worktree asks for removal: skip removal confirm when intent declared (#32)**
- **delete the branch (locally) when task-done: attempt safe `git branch -d` after worktree removal**
