### PR TITLE
task-work silently reuses an existing branch on name collision: warn loudly when reusing (#38)

### DIFF
--- a/claude-gh/bin/task-work
+++ b/claude-gh/bin/task-work
@@ -5,6 +5,8 @@ set -euo pipefail
 AW_ROOT_REAL="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
 # shellcheck source=lib/zellij-tab.sh
 source "$AW_ROOT_REAL/lib/zellij-tab.sh"
+# shellcheck source=lib/worktree-create.sh
+source "$AW_ROOT_REAL/lib/worktree-create.sh"
 
 usage() {
   cat <<'EOF'
@@ -132,12 +134,7 @@ fi
 
 mkdir -p "$WORKTREE_BASE"
 echo "Creating branch $BRANCH and worktree at $WORKTREE_DIR..."
-git worktree add "$WORKTREE_DIR" -b "$BRANCH" 2>/dev/null || {
-  git worktree add "$WORKTREE_DIR" "$BRANCH" 2>/dev/null || {
-    echo "Error: could not create worktree. Check if branch '$BRANCH' exists elsewhere." >&2
-    exit 1
-  }
-}
+aw_create_worktree "$WORKTREE_DIR" "$BRANCH" "$BASE_BRANCH"
 
 # Write task info so the worker and task-done can read it (stored outside the working tree)
 INFO_FILE="${WORKTREE_BASE}/.${SLUG}.info"

--- a/claude-jira/bin/task-work
+++ b/claude-jira/bin/task-work
@@ -5,6 +5,8 @@ set -euo pipefail
 AW_ROOT_REAL="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
 # shellcheck source=lib/zellij-tab.sh
 source "$AW_ROOT_REAL/lib/zellij-tab.sh"
+# shellcheck source=lib/worktree-create.sh
+source "$AW_ROOT_REAL/lib/worktree-create.sh"
 
 usage() {
   echo "Usage: task-work [options] <jira-key-or-url-or-slug>"
@@ -87,12 +89,7 @@ fi
 
 mkdir -p "$WORKTREE_BASE"
 echo "Creating branch $BRANCH and worktree at $WORKTREE_DIR..."
-git worktree add "$WORKTREE_DIR" -b "$BRANCH" 2>/dev/null || {
-  git worktree add "$WORKTREE_DIR" "$BRANCH" 2>/dev/null || {
-    echo "Error: could not create worktree. Check if branch '$BRANCH' exists elsewhere."
-    exit 1
-  }
-}
+aw_create_worktree "$WORKTREE_DIR" "$BRANCH" "$BASE_BRANCH"
 
 # Write task info so the worker and task-done can read it (stored outside the working tree)
 INFO_FILE="${WORKTREE_BASE}/.${SLUG}.info"

--- a/claude-local/bin/task-work
+++ b/claude-local/bin/task-work
@@ -5,6 +5,8 @@ set -euo pipefail
 AW_ROOT_REAL="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
 # shellcheck source=lib/zellij-tab.sh
 source "$AW_ROOT_REAL/lib/zellij-tab.sh"
+# shellcheck source=lib/worktree-create.sh
+source "$AW_ROOT_REAL/lib/worktree-create.sh"
 
 usage() {
   cat <<'EOF'
@@ -120,12 +122,7 @@ fi
 
 mkdir -p "$WORKTREE_BASE"
 echo "Creating branch $BRANCH and worktree at $WORKTREE_DIR..."
-git worktree add "$WORKTREE_DIR" -b "$BRANCH" 2>/dev/null || {
-  git worktree add "$WORKTREE_DIR" "$BRANCH" 2>/dev/null || {
-    echo "Error: could not create worktree. Check if branch '$BRANCH' exists elsewhere." >&2
-    exit 1
-  }
-}
+aw_create_worktree "$WORKTREE_DIR" "$BRANCH" "$BASE_BRANCH"
 
 # Write task info so the worker and task-done can read it (stored outside the working tree)
 INFO_FILE="${WORKTREE_BASE}/.${SLUG}.info"

--- a/claude-notion/bin/task-work
+++ b/claude-notion/bin/task-work
@@ -5,6 +5,8 @@ set -euo pipefail
 AW_ROOT_REAL="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
 # shellcheck source=lib/zellij-tab.sh
 source "$AW_ROOT_REAL/lib/zellij-tab.sh"
+# shellcheck source=lib/worktree-create.sh
+source "$AW_ROOT_REAL/lib/worktree-create.sh"
 
 usage() {
   cat <<'EOF'
@@ -132,12 +134,7 @@ fi
 
 mkdir -p "$WORKTREE_BASE"
 echo "Creating branch $BRANCH and worktree at $WORKTREE_DIR..."
-git worktree add "$WORKTREE_DIR" -b "$BRANCH" 2>/dev/null || {
-  git worktree add "$WORKTREE_DIR" "$BRANCH" 2>/dev/null || {
-    echo "Error: could not create worktree. Check if branch '$BRANCH' exists elsewhere." >&2
-    exit 1
-  }
-}
+aw_create_worktree "$WORKTREE_DIR" "$BRANCH" "$BASE_BRANCH"
 
 # Write task info so the worker and task-done can read it (stored outside the working tree)
 INFO_FILE="${WORKTREE_BASE}/.${SLUG}.info"

--- a/kiro-gh/bin/task-work
+++ b/kiro-gh/bin/task-work
@@ -5,6 +5,8 @@ set -euo pipefail
 AW_ROOT_REAL="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
 # shellcheck source=lib/zellij-tab.sh
 source "$AW_ROOT_REAL/lib/zellij-tab.sh"
+# shellcheck source=lib/worktree-create.sh
+source "$AW_ROOT_REAL/lib/worktree-create.sh"
 
 usage() {
   cat <<'EOF'
@@ -155,12 +157,7 @@ fi
 
 mkdir -p "$WORKTREE_BASE"
 echo "Creating branch $BRANCH and worktree at $WORKTREE_DIR..."
-git worktree add "$WORKTREE_DIR" -b "$BRANCH" 2>/dev/null || {
-  git worktree add "$WORKTREE_DIR" "$BRANCH" 2>/dev/null || {
-    echo "Error: could not create worktree. Check if branch '$BRANCH' exists elsewhere." >&2
-    exit 1
-  }
-}
+aw_create_worktree "$WORKTREE_DIR" "$BRANCH" "$BASE_BRANCH"
 
 # Write task info so the worker and task-done can read it (stored outside the working tree)
 INFO_FILE="${WORKTREE_BASE}/.${SLUG}.info"

--- a/kiro-local/bin/task-work
+++ b/kiro-local/bin/task-work
@@ -5,6 +5,8 @@ set -euo pipefail
 AW_ROOT_REAL="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
 # shellcheck source=lib/zellij-tab.sh
 source "$AW_ROOT_REAL/lib/zellij-tab.sh"
+# shellcheck source=lib/worktree-create.sh
+source "$AW_ROOT_REAL/lib/worktree-create.sh"
 
 usage() {
   cat <<'EOF'
@@ -144,12 +146,7 @@ fi
 
 mkdir -p "$WORKTREE_BASE"
 echo "Creating branch $BRANCH and worktree at $WORKTREE_DIR..."
-git worktree add "$WORKTREE_DIR" -b "$BRANCH" 2>/dev/null || {
-  git worktree add "$WORKTREE_DIR" "$BRANCH" 2>/dev/null || {
-    echo "Error: could not create worktree. Check if branch '$BRANCH' exists elsewhere." >&2
-    exit 1
-  }
-}
+aw_create_worktree "$WORKTREE_DIR" "$BRANCH" "$BASE_BRANCH"
 
 # Write task info so the worker and task-done can read it (stored outside the working tree)
 INFO_FILE="${WORKTREE_BASE}/.${SLUG}.info"

--- a/kiro-notion/bin/task-work
+++ b/kiro-notion/bin/task-work
@@ -5,6 +5,8 @@ set -euo pipefail
 AW_ROOT_REAL="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
 # shellcheck source=lib/zellij-tab.sh
 source "$AW_ROOT_REAL/lib/zellij-tab.sh"
+# shellcheck source=lib/worktree-create.sh
+source "$AW_ROOT_REAL/lib/worktree-create.sh"
 
 usage() {
   cat <<'EOF'
@@ -157,12 +159,7 @@ fi
 
 mkdir -p "$WORKTREE_BASE"
 echo "Creating branch $BRANCH and worktree at $WORKTREE_DIR..."
-git worktree add "$WORKTREE_DIR" -b "$BRANCH" 2>/dev/null || {
-  git worktree add "$WORKTREE_DIR" "$BRANCH" 2>/dev/null || {
-    echo "Error: could not create worktree. Check if branch '$BRANCH' exists elsewhere." >&2
-    exit 1
-  }
-}
+aw_create_worktree "$WORKTREE_DIR" "$BRANCH" "$BASE_BRANCH"
 
 # Write task info so the worker and task-done can read it (stored outside the working tree)
 INFO_FILE="${WORKTREE_BASE}/.${SLUG}.info"

--- a/lib/worktree-create.sh
+++ b/lib/worktree-create.sh
@@ -21,26 +21,31 @@ aw_create_worktree() {
   fi
 
   if ! git show-ref --verify --quiet "refs/heads/$branch"; then
-    echo "Error: could not create worktree. Check if branch '$branch' exists elsewhere." >&2
+    echo "Error: could not create worktree at '$worktree_dir'." >&2
+    echo "       Possibly a stale worktree registration — try: git worktree prune" >&2
     return 1
   fi
 
   if ! git worktree add "$worktree_dir" "$branch" 2>/dev/null; then
-    echo "Error: could not create worktree. Check if branch '$branch' exists elsewhere." >&2
+    echo "Error: could not create worktree at '$worktree_dir'." >&2
+    echo "       Possibly a stale worktree registration — try: git worktree prune" >&2
     return 1
   fi
 
-  local branch_tip branch_subj base_tip base_subj
+  local branch_tip branch_subj base_tip base_subj behind ahead
   branch_tip=$(git rev-parse --short "$branch" 2>/dev/null || echo "?")
   branch_subj=$(git log -1 --format=%s "$branch" 2>/dev/null || echo "?")
   base_tip=$(git rev-parse --short "$base_branch" 2>/dev/null || echo "?")
   base_subj=$(git log -1 --format=%s "$base_branch" 2>/dev/null || echo "?")
+  behind=$(git rev-list --count "$branch..$base_branch" 2>/dev/null || echo "?")
+  ahead=$(git rev-list --count "$base_branch..$branch" 2>/dev/null || echo "?")
 
   {
     echo ""
     echo "⚠ Branch $branch already exists. Reusing it."
     echo "  Branch tip:               $branch_tip ($branch_subj)"
     echo "  Current HEAD on $base_branch: $base_tip ($base_subj)"
+    echo "  Divergence:               $ahead ahead, $behind behind $base_branch"
     echo "  If the branch is stale, exit and run: git branch -D $branch"
     echo ""
   } >&2

--- a/lib/worktree-create.sh
+++ b/lib/worktree-create.sh
@@ -1,0 +1,47 @@
+#!/usr/bin/env bash
+# Shared worktree creation. Sourced by every <impl>/bin/task-work.
+#
+# Exports:
+#   aw_create_worktree <worktree_dir> <branch> <base_branch>
+#
+# Tries to create the worktree on a new branch (-b). If that fails because
+# the branch already exists, reuses it — but emits a loud warning to stderr
+# showing how the branch tip diverges from <base_branch>. This catches the
+# foot-gun of running `task-work` after the worktree was deleted but the
+# branch wasn't, which would otherwise silently base the new worktree on
+# stale code (issue #38).
+
+aw_create_worktree() {
+  local worktree_dir="$1"
+  local branch="$2"
+  local base_branch="$3"
+
+  if git worktree add "$worktree_dir" -b "$branch" 2>/dev/null; then
+    return 0
+  fi
+
+  if ! git show-ref --verify --quiet "refs/heads/$branch"; then
+    echo "Error: could not create worktree. Check if branch '$branch' exists elsewhere." >&2
+    return 1
+  fi
+
+  if ! git worktree add "$worktree_dir" "$branch" 2>/dev/null; then
+    echo "Error: could not create worktree. Check if branch '$branch' exists elsewhere." >&2
+    return 1
+  fi
+
+  local branch_tip branch_subj base_tip base_subj
+  branch_tip=$(git rev-parse --short "$branch" 2>/dev/null || echo "?")
+  branch_subj=$(git log -1 --format=%s "$branch" 2>/dev/null || echo "?")
+  base_tip=$(git rev-parse --short "$base_branch" 2>/dev/null || echo "?")
+  base_subj=$(git log -1 --format=%s "$base_branch" 2>/dev/null || echo "?")
+
+  {
+    echo ""
+    echo "⚠ Branch $branch already exists. Reusing it."
+    echo "  Branch tip:               $branch_tip ($branch_subj)"
+    echo "  Current HEAD on $base_branch: $base_tip ($base_subj)"
+    echo "  If the branch is stale, exit and run: git branch -D $branch"
+    echo ""
+  } >&2
+}

--- a/tests/claude_gh_task_work.bats
+++ b/tests/claude_gh_task_work.bats
@@ -86,6 +86,8 @@ teardown() {
   assert_success
   assert_output --partial "Branch task/stale-feature already exists. Reusing it."
   assert_output --partial "Current HEAD on main"
+  assert_output --partial "Divergence:"
+  assert_output --partial "0 ahead, 1 behind main"
 
   local wt_head main_head
   wt_head=$(git -C "$WORKTREE_BASE/stale-feature" rev-parse HEAD)

--- a/tests/claude_gh_task_work.bats
+++ b/tests/claude_gh_task_work.bats
@@ -76,6 +76,23 @@ teardown() {
   assert_output "2"
 }
 
+@test "branch collision: warns and reuses when task branch already exists" {
+  git -C "$MAIN_REPO" branch task/stale-feature
+  echo "newer" > "$MAIN_REPO/newfile.txt"
+  git -C "$MAIN_REPO" add newfile.txt
+  git -C "$MAIN_REPO" commit -q -m "advance main"
+
+  run "$CLAUDE_GH_TASK_WORK" stale-feature
+  assert_success
+  assert_output --partial "Branch task/stale-feature already exists. Reusing it."
+  assert_output --partial "Current HEAD on main"
+
+  local wt_head main_head
+  wt_head=$(git -C "$WORKTREE_BASE/stale-feature" rev-parse HEAD)
+  main_head=$(git -C "$MAIN_REPO" rev-parse main)
+  [[ "$wt_head" != "$main_head" ]]
+}
+
 # ---------------------------------------------------------------------------
 # .info file
 # ---------------------------------------------------------------------------

--- a/tests/claude_local_task_work.bats
+++ b/tests/claude_local_task_work.bats
@@ -97,6 +97,23 @@ EOF
   assert_output "2"
 }
 
+@test "branch collision: warns and reuses when task branch already exists" {
+  git -C "$MAIN_REPO" branch task/stale-feature
+  echo "newer" > "$MAIN_REPO/newfile.txt"
+  git -C "$MAIN_REPO" add newfile.txt
+  git -C "$MAIN_REPO" commit -q -m "advance main"
+
+  run "$CLAUDE_LOCAL_TASK_WORK" stale-feature
+  assert_success
+  assert_output --partial "Branch task/stale-feature already exists. Reusing it."
+  assert_output --partial "Current HEAD on main"
+
+  local wt_head main_head
+  wt_head=$(git -C "$WORKTREE_BASE/stale-feature" rev-parse HEAD)
+  main_head=$(git -C "$MAIN_REPO" rev-parse main)
+  [[ "$wt_head" != "$main_head" ]]
+}
+
 # ---------------------------------------------------------------------------
 # .info file
 # ---------------------------------------------------------------------------

--- a/tests/claude_local_task_work.bats
+++ b/tests/claude_local_task_work.bats
@@ -107,6 +107,8 @@ EOF
   assert_success
   assert_output --partial "Branch task/stale-feature already exists. Reusing it."
   assert_output --partial "Current HEAD on main"
+  assert_output --partial "Divergence:"
+  assert_output --partial "0 ahead, 1 behind main"
 
   local wt_head main_head
   wt_head=$(git -C "$WORKTREE_BASE/stale-feature" rev-parse HEAD)

--- a/tests/claude_notion_task_work.bats
+++ b/tests/claude_notion_task_work.bats
@@ -86,6 +86,8 @@ teardown() {
   assert_success
   assert_output --partial "Branch task/stale-feature already exists. Reusing it."
   assert_output --partial "Current HEAD on main"
+  assert_output --partial "Divergence:"
+  assert_output --partial "0 ahead, 1 behind main"
 
   local wt_head main_head
   wt_head=$(git -C "$WORKTREE_BASE/stale-feature" rev-parse HEAD)

--- a/tests/claude_notion_task_work.bats
+++ b/tests/claude_notion_task_work.bats
@@ -76,6 +76,23 @@ teardown() {
   assert_output "2"
 }
 
+@test "branch collision: warns and reuses when task branch already exists" {
+  git -C "$MAIN_REPO" branch task/stale-feature
+  echo "newer" > "$MAIN_REPO/newfile.txt"
+  git -C "$MAIN_REPO" add newfile.txt
+  git -C "$MAIN_REPO" commit -q -m "advance main"
+
+  run "$CLAUDE_NOTION_TASK_WORK" stale-feature
+  assert_success
+  assert_output --partial "Branch task/stale-feature already exists. Reusing it."
+  assert_output --partial "Current HEAD on main"
+
+  local wt_head main_head
+  wt_head=$(git -C "$WORKTREE_BASE/stale-feature" rev-parse HEAD)
+  main_head=$(git -C "$MAIN_REPO" rev-parse main)
+  [[ "$wt_head" != "$main_head" ]]
+}
+
 # ---------------------------------------------------------------------------
 # .info file
 # ---------------------------------------------------------------------------

--- a/tests/jira_task_work.bats
+++ b/tests/jira_task_work.bats
@@ -75,6 +75,23 @@ teardown() {
   assert_output "2"
 }
 
+@test "branch collision: warns and reuses when task branch already exists" {
+  git -C "$MAIN_REPO" branch task/stale-feature
+  echo "newer" > "$MAIN_REPO/newfile.txt"
+  git -C "$MAIN_REPO" add newfile.txt
+  git -C "$MAIN_REPO" commit -q -m "advance main"
+
+  run "$JIRA_TASK_WORK" stale-feature
+  assert_success
+  assert_output --partial "Branch task/stale-feature already exists. Reusing it."
+  assert_output --partial "Current HEAD on main"
+
+  local wt_head main_head
+  wt_head=$(git -C "$WORKTREE_BASE/stale-feature" rev-parse HEAD)
+  main_head=$(git -C "$MAIN_REPO" rev-parse main)
+  [[ "$wt_head" != "$main_head" ]]
+}
+
 # ---------------------------------------------------------------------------
 # .info file
 # ---------------------------------------------------------------------------

--- a/tests/jira_task_work.bats
+++ b/tests/jira_task_work.bats
@@ -85,6 +85,8 @@ teardown() {
   assert_success
   assert_output --partial "Branch task/stale-feature already exists. Reusing it."
   assert_output --partial "Current HEAD on main"
+  assert_output --partial "Divergence:"
+  assert_output --partial "0 ahead, 1 behind main"
 
   local wt_head main_head
   wt_head=$(git -C "$WORKTREE_BASE/stale-feature" rev-parse HEAD)

--- a/tests/kiro_gh_task_work.bats
+++ b/tests/kiro_gh_task_work.bats
@@ -80,6 +80,8 @@ teardown() {
   assert_success
   assert_output --partial "Branch task/stale-feature already exists. Reusing it."
   assert_output --partial "Current HEAD on main"
+  assert_output --partial "Divergence:"
+  assert_output --partial "0 ahead, 1 behind main"
 
   local wt_head main_head
   wt_head=$(git -C "$WORKTREE_BASE/stale-feature" rev-parse HEAD)

--- a/tests/kiro_gh_task_work.bats
+++ b/tests/kiro_gh_task_work.bats
@@ -70,6 +70,23 @@ teardown() {
   assert_output "2"
 }
 
+@test "branch collision: warns and reuses when task branch already exists" {
+  git -C "$MAIN_REPO" branch task/stale-feature
+  echo "newer" > "$MAIN_REPO/newfile.txt"
+  git -C "$MAIN_REPO" add newfile.txt
+  git -C "$MAIN_REPO" commit -q -m "advance main"
+
+  run "$KIRO_GH_TASK_WORK" stale-feature
+  assert_success
+  assert_output --partial "Branch task/stale-feature already exists. Reusing it."
+  assert_output --partial "Current HEAD on main"
+
+  local wt_head main_head
+  wt_head=$(git -C "$WORKTREE_BASE/stale-feature" rev-parse HEAD)
+  main_head=$(git -C "$MAIN_REPO" rev-parse main)
+  [[ "$wt_head" != "$main_head" ]]
+}
+
 # ---------------------------------------------------------------------------
 # .info file
 # ---------------------------------------------------------------------------

--- a/tests/kiro_local_task_work.bats
+++ b/tests/kiro_local_task_work.bats
@@ -97,6 +97,23 @@ EOF
   assert_output "2"
 }
 
+@test "branch collision: warns and reuses when task branch already exists" {
+  git -C "$MAIN_REPO" branch task/stale-feature
+  echo "newer" > "$MAIN_REPO/newfile.txt"
+  git -C "$MAIN_REPO" add newfile.txt
+  git -C "$MAIN_REPO" commit -q -m "advance main"
+
+  run "$KIRO_LOCAL_TASK_WORK" stale-feature
+  assert_success
+  assert_output --partial "Branch task/stale-feature already exists. Reusing it."
+  assert_output --partial "Current HEAD on main"
+
+  local wt_head main_head
+  wt_head=$(git -C "$WORKTREE_BASE/stale-feature" rev-parse HEAD)
+  main_head=$(git -C "$MAIN_REPO" rev-parse main)
+  [[ "$wt_head" != "$main_head" ]]
+}
+
 # ---------------------------------------------------------------------------
 # .info file
 # ---------------------------------------------------------------------------

--- a/tests/kiro_local_task_work.bats
+++ b/tests/kiro_local_task_work.bats
@@ -107,6 +107,8 @@ EOF
   assert_success
   assert_output --partial "Branch task/stale-feature already exists. Reusing it."
   assert_output --partial "Current HEAD on main"
+  assert_output --partial "Divergence:"
+  assert_output --partial "0 ahead, 1 behind main"
 
   local wt_head main_head
   wt_head=$(git -C "$WORKTREE_BASE/stale-feature" rev-parse HEAD)

--- a/tests/kiro_task_work.bats
+++ b/tests/kiro_task_work.bats
@@ -87,6 +87,8 @@ teardown() {
   assert_success
   assert_output --partial "Branch task/stale-feature already exists. Reusing it."
   assert_output --partial "Current HEAD on main"
+  assert_output --partial "Divergence:"
+  assert_output --partial "0 ahead, 1 behind main"
 
   local wt_head main_head
   wt_head=$(git -C "$WORKTREE_BASE/stale-feature" rev-parse HEAD)

--- a/tests/kiro_task_work.bats
+++ b/tests/kiro_task_work.bats
@@ -77,6 +77,23 @@ teardown() {
   assert_output "2"
 }
 
+@test "branch collision: warns and reuses when task branch already exists" {
+  git -C "$MAIN_REPO" branch task/stale-feature
+  echo "newer" > "$MAIN_REPO/newfile.txt"
+  git -C "$MAIN_REPO" add newfile.txt
+  git -C "$MAIN_REPO" commit -q -m "advance main"
+
+  run "$KIRO_TASK_WORK" stale-feature
+  assert_success
+  assert_output --partial "Branch task/stale-feature already exists. Reusing it."
+  assert_output --partial "Current HEAD on main"
+
+  local wt_head main_head
+  wt_head=$(git -C "$WORKTREE_BASE/stale-feature" rev-parse HEAD)
+  main_head=$(git -C "$MAIN_REPO" rev-parse main)
+  [[ "$wt_head" != "$main_head" ]]
+}
+
 # ---------------------------------------------------------------------------
 # .info file
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## Summary
- Closes #38.
- Extracts the worktree-create logic into `lib/worktree-create.sh` (sourced by all 7 impl variants) and replaces the silent `git worktree add … || git worktree add …` two-tier fallback with a helper that warns loudly when a pre-existing `task/<slug>` branch is being reused.
- The warning shows the branch tip vs the current HEAD on `$BASE_BRANCH`, plus the exact command to nuke the branch if it's stale — addressing the foot-gun where a freshly-recreated worktree could silently sit on stale code (the same scenario that caused the symlink-replacement near-miss in #36).
- Adds a `branch collision: warns and reuses…` test case to every `<impl>_task_work.bats` suite. Pre-creates the branch, advances `main` forward, runs `task-work`, and asserts both the warning text and that the new worktree's HEAD ≠ `main`'s HEAD.

## Test plan
- [x] `bash run_tests.sh` → 406 tests pass, 0 failures
- [x] New `branch collision` test green in each of the 7 task_work suites