### PR TITLE
Add LICENSE file (MIT or Apache-2.0)

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,0 +1,21 @@
+MIT License
+
+Copyright (c) 2026 Martin Conur
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/README.md
+++ b/README.md
@@ -398,3 +398,9 @@ Add script path variables to `tests/helpers/common.bash`. The runner picks up ev
 - Quote every variable
 - No package managers, no compiled code — pure shell
 - 2-space indentation
+
+---
+
+## License
+
+[MIT](LICENSE) © Martin Conur


### PR DESCRIPTION
## Summary
- Add MIT `LICENSE` at repo root so the project has a clear, redistributable license (required for Homebrew, forks, and standard OSS hygiene).
- Add a `## License` section near the bottom of `README.md` linking to the LICENSE file.

Closes #48

## Test plan
- [ ] `LICENSE` exists at repo root with full MIT text.
- [ ] GitHub repo sidebar shows the license name once the PR merges.
- [ ] `README.md` mentions and links to the license.

🤖 Generated with [Claude Code](https://claude.com/claude-code)