### PR TITLE
CI: widen shellcheck coverage to all loadouts, fix SC2015 in {claude,kiro}-local

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -27,31 +27,7 @@ jobs:
       - name: Run shellcheck
         run: |
           shellcheck -x \
-            install.sh \
-            task-init \
-            run_tests.sh \
-            bin/task-work \
-            bin/task-done \
-            lib/detect-impl.sh \
-            lib/zellij-tab.sh \
-            tests/helpers/common.bash \
-            claude-jira/install.sh \
-            claude-jira/bin/task-work \
-            claude-jira/bin/task-done \
-            claude-jira/bin/task-init \
-            kiro-notion/install.sh \
-            kiro-notion/bin/task-work \
-            kiro-notion/bin/task-done \
-            kiro-notion/bin/task-init \
-            claude-notion/install.sh \
-            claude-notion/bin/task-work \
-            claude-notion/bin/task-done \
-            claude-notion/bin/task-init \
-            claude-gh/install.sh \
-            claude-gh/bin/task-work \
-            claude-gh/bin/task-done \
-            claude-gh/bin/task-init \
-            kiro-gh/install.sh \
-            kiro-gh/bin/task-work \
-            kiro-gh/bin/task-done \
-            kiro-gh/bin/task-init
+            install.sh task-init run_tests.sh \
+            bin/* lib/*.sh \
+            tests/helpers/*.bash \
+            */install.sh */bin/*

--- a/claude-local/bin/task-done
+++ b/claude-local/bin/task-done
@@ -119,7 +119,9 @@ if command -v task-board >/dev/null 2>&1; then
   task-board --repo "$MAIN_WORKTREE" >/dev/null || true
 else
   _BOARD_SCRIPT="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)/task-board"
-  [[ -x "$_BOARD_SCRIPT" ]] && "$_BOARD_SCRIPT" --repo "$MAIN_WORKTREE" >/dev/null || true
+  if [[ -x "$_BOARD_SCRIPT" ]]; then
+    "$_BOARD_SCRIPT" --repo "$MAIN_WORKTREE" >/dev/null || true
+  fi
 fi
 
 if git branch -d "$BRANCH" 2>/dev/null; then

--- a/claude-local/bin/task-work
+++ b/claude-local/bin/task-work
@@ -180,7 +180,9 @@ if command -v task-board >/dev/null 2>&1; then
   task-board --repo "$REPO_ROOT" >/dev/null || true
 else
   _BOARD_SCRIPT="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)/task-board"
-  [[ -x "$_BOARD_SCRIPT" ]] && "$_BOARD_SCRIPT" --repo "$REPO_ROOT" >/dev/null || true
+  if [[ -x "$_BOARD_SCRIPT" ]]; then
+    "$_BOARD_SCRIPT" --repo "$REPO_ROOT" >/dev/null || true
+  fi
 fi
 
 echo "Opening zellij tab '$SLUG'..."

--- a/kiro-local/bin/task-done
+++ b/kiro-local/bin/task-done
@@ -119,7 +119,9 @@ if command -v task-board >/dev/null 2>&1; then
   task-board --repo "$MAIN_WORKTREE" >/dev/null || true
 else
   _BOARD_SCRIPT="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)/task-board"
-  [[ -x "$_BOARD_SCRIPT" ]] && "$_BOARD_SCRIPT" --repo "$MAIN_WORKTREE" >/dev/null || true
+  if [[ -x "$_BOARD_SCRIPT" ]]; then
+    "$_BOARD_SCRIPT" --repo "$MAIN_WORKTREE" >/dev/null || true
+  fi
 fi
 
 if git branch -d "$BRANCH" 2>/dev/null; then

--- a/kiro-local/bin/task-work
+++ b/kiro-local/bin/task-work
@@ -179,7 +179,9 @@ if command -v task-board >/dev/null 2>&1; then
   task-board --repo "$REPO_ROOT" >/dev/null || true
 else
   _BOARD_SCRIPT="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)/task-board"
-  [[ -x "$_BOARD_SCRIPT" ]] && "$_BOARD_SCRIPT" --repo "$REPO_ROOT" >/dev/null || true
+  if [[ -x "$_BOARD_SCRIPT" ]]; then
+    "$_BOARD_SCRIPT" --repo "$REPO_ROOT" >/dev/null || true
+  fi
 fi
 
 echo "Opening zellij tab '$SLUG'..."


### PR DESCRIPTION
## Summary

Combined PR that supersedes #52. Two pieces of work:

- **`.github/workflows/ci.yml`** — replace the explicit 28-file shellcheck list with globs (`bin/* lib/*.sh tests/helpers/*.bash */install.sh */bin/*`) so every loadout is linted automatically, including future ones. Picks up previously-skipped `lib/worktree-create.sh`, `claude-local/bin/*`, and `kiro-local/bin/*` (including the `task-board` scripts).
- **`{claude,kiro}-local/bin/task-{work,done}`** — refactor 4 `[[ -x X ]] && X || true` lines to explicit `if [[ -x X ]]; then X || true; fi`. Same semantics (best-effort `task-board` call, errors suppressed under `set -e`), but unambiguous and SC2015-clean. The findings were latent — exposed only once the widened shellcheck coverage above started scanning these files.

## Test plan

- [x] `shellcheck -x install.sh task-init run_tests.sh bin/* lib/*.sh tests/helpers/*.bash */install.sh */bin/*` — exit 0 (39 files).
- [x] `./run_tests.sh` — 439/439 pass.
- [x] CI green on this PR — both ShellCheck (6s) and Bats tests (1m12s) jobs pass with the widened globs scanning the now-fixed files.

Closes #46
Closes #53

Supersedes #52.