### PR TITLE
task-work: support forking the worktree from an arbitrary ref (--from)

### DIFF
--- a/README.md
+++ b/README.md
@@ -306,7 +306,8 @@ Spawn workers with `task-work tasks/NNN-slug.md`. Same Kiro shortcuts as `kiro-n
 
 Common to every combo:
 
-- `-b, --base BRANCH` — base branch for the eventual PR (default: branch you're on when `task-work` runs)
+- `-b, --base BRANCH` — branch the PR will target (default: branch you're on when `task-work` runs)
+- `-f, --from REF` — git ref to fork the new worktree's branch from (default: current HEAD). Accepts any ref `git` accepts (branches, tags, SHAs, `origin/foo`). Use this to stack a PR on an in-flight branch (`--from task/issue-46 --base main`) or to spike off `origin/main` without checking it out first.
 - `--no-launch` — create the worktree and open the tab at that directory, but don't auto-start the agent (you pick the model/command yourself)
 - `--impl <name>` — force a specific combo, bypassing auto-detection
 

--- a/claude-gh/bin/task-work
+++ b/claude-gh/bin/task-work
@@ -21,7 +21,12 @@ exists, a 5-char hash is appended so multiple agents can work the same
 task in parallel.
 
 Options:
-  -b, --base BRANCH   Base branch for the PR (default: current branch at call time).
+  -b, --base BRANCH   Branch the PR will target (default: current branch at call time).
+  -f, --from REF      Git ref to fork the new worktree's branch from. Defaults
+                      to current HEAD. Use this to stack a PR on top of an
+                      in-flight branch, or to spike off origin/main without
+                      checking it out first. Accepts any ref `git` accepts
+                      (branches, tags, SHAs, origin/foo).
       --no-launch     Create the worktree and open the tab at its directory,
                       but do NOT start claude. Use this when you want to
                       pick the command/model interactively.
@@ -39,6 +44,10 @@ Examples:
   task-work spike-idea --no-launch
   task-work spike-idea --plan
   task-work issue-42 "https://github.com/owner/repo/issues/42" --auto
+  # Stack a follow-up PR on top of an in-flight branch:
+  task-work issue-99 <url> --from task/issue-46 --base main --auto
+  # Spike off origin/main without checking it out:
+  task-work spike --from origin/main
 EOF
   exit "${1:-1}"
 }
@@ -47,6 +56,7 @@ EOF
 POSITIONAL=()
 NO_LAUNCH=""
 BASE_BRANCH_OVERRIDE=""
+FROM_REF_OVERRIDE=""
 AUTO_MODE=""
 PLAN_MODE=""
 
@@ -56,6 +66,9 @@ while [[ $# -gt 0 ]]; do
     -b|--base)
       [[ $# -ge 2 ]] || { echo "Error: --base requires a value" >&2; exit 1; }
       BASE_BRANCH_OVERRIDE="$2"; shift 2 ;;
+    -f|--from)
+      [[ $# -ge 2 ]] || { echo "Error: --from requires a value" >&2; exit 1; }
+      FROM_REF_OVERRIDE="$2"; shift 2 ;;
     --no-launch) NO_LAUNCH="1"; shift ;;
     --auto) AUTO_MODE="1"; shift ;;
     --plan|-p) PLAN_MODE="1"; shift ;;
@@ -123,6 +136,12 @@ WORKTREE_BASE="${REPO_ROOT}/../${REPO_NAME}-worktrees"
 
 # Capture base branch now, before the worktree is created
 BASE_BRANCH="${BASE_BRANCH_OVERRIDE:-$(git rev-parse --abbrev-ref HEAD)}"
+FROM_REF="${FROM_REF_OVERRIDE:-HEAD}"
+
+if ! git rev-parse --verify --quiet "${FROM_REF}^{commit}" >/dev/null 2>&1; then
+  echo "Error: --from ref '$FROM_REF' does not resolve to a commit" >&2
+  exit 1
+fi
 
 BRANCH="task/${SLUG}"
 WORKTREE_DIR="${WORKTREE_BASE}/${SLUG}"
@@ -160,7 +179,7 @@ fi
 
 mkdir -p "$WORKTREE_BASE"
 echo "Creating branch $BRANCH and worktree at $WORKTREE_DIR..."
-aw_create_worktree "$WORKTREE_DIR" "$BRANCH" "$BASE_BRANCH"
+aw_create_worktree "$WORKTREE_DIR" "$BRANCH" "$BASE_BRANCH" "$FROM_REF"
 
 # Write task info so the worker and task-done can read it (stored outside the working tree)
 INFO_FILE="${WORKTREE_BASE}/.${SLUG}.info"

--- a/claude-gh/bin/task-work
+++ b/claude-gh/bin/task-work
@@ -179,7 +179,7 @@ fi
 
 mkdir -p "$WORKTREE_BASE"
 echo "Creating branch $BRANCH and worktree at $WORKTREE_DIR..."
-aw_create_worktree "$WORKTREE_DIR" "$BRANCH" "$BASE_BRANCH" "$FROM_REF"
+aw_create_worktree "$WORKTREE_DIR" "$BRANCH" "$FROM_REF"
 
 # Write task info so the worker and task-done can read it (stored outside the working tree)
 INFO_FILE="${WORKTREE_BASE}/.${SLUG}.info"

--- a/claude-jira/bin/task-work
+++ b/claude-jira/bin/task-work
@@ -15,7 +15,9 @@ usage() {
   echo "with a Claude Code worker session."
   echo ""
   echo "Options:"
-  echo "  -b, --base BRANCH   Base branch for the PR (default: current branch)"
+  echo "  -b, --base BRANCH   Branch the PR will target (default: current branch)"
+  echo "  -f, --from REF      Git ref to fork the new worktree's branch from (default: HEAD)."
+  echo "                      Accepts branches, tags, SHAs, or remote refs (e.g. origin/main)."
   echo "  -p, --plan          Launch claude with --permission-mode plan, running"
   echo "                      /planner instead of /worker. Mutually exclusive with --auto."
   echo "      --auto          Launch claude with --permission-mode auto (auto-accept"
@@ -28,10 +30,13 @@ usage() {
   echo "  task-work add-store-filtering"
   echo "  task-work --base develop PROJ-456"
   echo "  task-work --plan PROJ-123"
+  echo "  # Stack a follow-up on top of an in-flight branch:"
+  echo "  task-work PROJ-789 --from task/proj-456 --base main"
   exit 1
 }
 
 BASE_BRANCH_OVERRIDE=""
+FROM_REF_OVERRIDE=""
 POSITIONAL=()
 AUTO_MODE=""
 PLAN_MODE=""
@@ -42,6 +47,9 @@ while [[ $# -gt 0 ]]; do
     -b|--base)
       [[ $# -ge 2 ]] || { echo "Error: --base requires a value" >&2; exit 1; }
       BASE_BRANCH_OVERRIDE="$2"; shift 2 ;;
+    -f|--from)
+      [[ $# -ge 2 ]] || { echo "Error: --from requires a value" >&2; exit 1; }
+      FROM_REF_OVERRIDE="$2"; shift 2 ;;
     --auto) AUTO_MODE="1"; shift ;;
     --plan|-p) PLAN_MODE="1"; shift ;;
     -*) echo "Error: unknown flag '$1'" >&2; usage ;;
@@ -63,6 +71,12 @@ WORKTREE_BASE="${REPO_ROOT}/../${REPO_NAME}-worktrees"
 
 # Capture base branch before any git operations
 BASE_BRANCH="${BASE_BRANCH_OVERRIDE:-$(git rev-parse --abbrev-ref HEAD)}"
+FROM_REF="${FROM_REF_OVERRIDE:-HEAD}"
+
+if ! git rev-parse --verify --quiet "${FROM_REF}^{commit}" >/dev/null 2>&1; then
+  echo "Error: --from ref '$FROM_REF' does not resolve to a commit" >&2
+  exit 1
+fi
 
 # Extract Jira key (if any) and the reference string we'll pass to the worker
 JIRA_REF=""
@@ -113,7 +127,7 @@ fi
 
 mkdir -p "$WORKTREE_BASE"
 echo "Creating branch $BRANCH and worktree at $WORKTREE_DIR..."
-aw_create_worktree "$WORKTREE_DIR" "$BRANCH" "$BASE_BRANCH"
+aw_create_worktree "$WORKTREE_DIR" "$BRANCH" "$BASE_BRANCH" "$FROM_REF"
 
 # Write task info so the worker and task-done can read it (stored outside the working tree)
 INFO_FILE="${WORKTREE_BASE}/.${SLUG}.info"

--- a/claude-jira/bin/task-work
+++ b/claude-jira/bin/task-work
@@ -127,7 +127,7 @@ fi
 
 mkdir -p "$WORKTREE_BASE"
 echo "Creating branch $BRANCH and worktree at $WORKTREE_DIR..."
-aw_create_worktree "$WORKTREE_DIR" "$BRANCH" "$BASE_BRANCH" "$FROM_REF"
+aw_create_worktree "$WORKTREE_DIR" "$BRANCH" "$FROM_REF"
 
 # Write task info so the worker and task-done can read it (stored outside the working tree)
 INFO_FILE="${WORKTREE_BASE}/.${SLUG}.info"

--- a/claude-local/bin/task-work
+++ b/claude-local/bin/task-work
@@ -164,7 +164,7 @@ fi
 
 mkdir -p "$WORKTREE_BASE"
 echo "Creating branch $BRANCH and worktree at $WORKTREE_DIR..."
-aw_create_worktree "$WORKTREE_DIR" "$BRANCH" "$BASE_BRANCH" "$FROM_REF"
+aw_create_worktree "$WORKTREE_DIR" "$BRANCH" "$FROM_REF"
 
 # Write task info so the worker and task-done can read it (stored outside the working tree)
 INFO_FILE="${WORKTREE_BASE}/.${SLUG}.info"

--- a/claude-local/bin/task-work
+++ b/claude-local/bin/task-work
@@ -23,7 +23,12 @@ After creating the worktree, writes a sidecar entry to
 `.git/task-force/state.json` and regenerates `tasks/_board.md`.
 
 Options:
-  -b, --base BRANCH   Base branch for the PR (default: current branch at call time).
+  -b, --base BRANCH   Branch the PR will target (default: current branch at call time).
+  -f, --from REF      Git ref to fork the new worktree's branch from. Defaults
+                      to current HEAD. Use this to stack a PR on top of an
+                      in-flight branch, or to spike off origin/main without
+                      checking it out first. Accepts any ref `git` accepts
+                      (branches, tags, SHAs, origin/foo).
       --no-launch     Create the worktree and open the tab at its directory,
                       but do NOT start claude. Use this when you want to
                       pick the command/model interactively.
@@ -39,6 +44,8 @@ Examples:
   task-work tasks/042-refactor-auth.md --base develop
   task-work spike-idea --no-launch
   task-work tasks/001-add-login-flow.md --plan
+  # Stack a follow-up on top of an in-flight branch:
+  task-work tasks/099-followup.md --from task/042-refactor-auth --base main
 EOF
   exit "${1:-1}"
 }
@@ -47,6 +54,7 @@ EOF
 POSITIONAL=()
 NO_LAUNCH=""
 BASE_BRANCH_OVERRIDE=""
+FROM_REF_OVERRIDE=""
 AUTO_MODE=""
 PLAN_MODE=""
 
@@ -56,6 +64,9 @@ while [[ $# -gt 0 ]]; do
     -b|--base)
       [[ $# -ge 2 ]] || { echo "Error: --base requires a value" >&2; exit 1; }
       BASE_BRANCH_OVERRIDE="$2"; shift 2 ;;
+    -f|--from)
+      [[ $# -ge 2 ]] || { echo "Error: --from requires a value" >&2; exit 1; }
+      FROM_REF_OVERRIDE="$2"; shift 2 ;;
     --no-launch) NO_LAUNCH="1"; shift ;;
     --auto) AUTO_MODE="1"; shift ;;
     --plan|-p) PLAN_MODE="1"; shift ;;
@@ -113,6 +124,12 @@ WORKTREE_BASE="${REPO_ROOT}/../${REPO_NAME}-worktrees"
 
 # Capture base branch now, before the worktree is created
 BASE_BRANCH="${BASE_BRANCH_OVERRIDE:-$(git rev-parse --abbrev-ref HEAD)}"
+FROM_REF="${FROM_REF_OVERRIDE:-HEAD}"
+
+if ! git rev-parse --verify --quiet "${FROM_REF}^{commit}" >/dev/null 2>&1; then
+  echo "Error: --from ref '$FROM_REF' does not resolve to a commit" >&2
+  exit 1
+fi
 
 BRANCH="task/${SLUG}"
 WORKTREE_DIR="${WORKTREE_BASE}/${SLUG}"
@@ -147,7 +164,7 @@ fi
 
 mkdir -p "$WORKTREE_BASE"
 echo "Creating branch $BRANCH and worktree at $WORKTREE_DIR..."
-aw_create_worktree "$WORKTREE_DIR" "$BRANCH" "$BASE_BRANCH"
+aw_create_worktree "$WORKTREE_DIR" "$BRANCH" "$BASE_BRANCH" "$FROM_REF"
 
 # Write task info so the worker and task-done can read it (stored outside the working tree)
 INFO_FILE="${WORKTREE_BASE}/.${SLUG}.info"

--- a/claude-notion/bin/task-work
+++ b/claude-notion/bin/task-work
@@ -21,7 +21,12 @@ exists, a 5-char hash is appended so multiple agents can work the same
 task in parallel.
 
 Options:
-  -b, --base BRANCH   Base branch for the PR (default: current branch at call time).
+  -b, --base BRANCH   Branch the PR will target (default: current branch at call time).
+  -f, --from REF      Git ref to fork the new worktree's branch from. Defaults
+                      to current HEAD. Use this to stack a PR on top of an
+                      in-flight branch, or to spike off origin/main without
+                      checking it out first. Accepts any ref `git` accepts
+                      (branches, tags, SHAs, origin/foo).
       --no-launch     Create the worktree and open the tab at its directory,
                       but do NOT start claude. Use this when you want to
                       pick the command/model interactively.
@@ -38,6 +43,8 @@ Examples:
   task-work refactor-auth
   task-work spike-idea --no-launch
   task-work spike-idea --plan
+  # Stack a follow-up on top of an in-flight branch:
+  task-work followup <notion-url> --from task/refactor-auth --base main
 EOF
   exit "${1:-1}"
 }
@@ -46,6 +53,7 @@ EOF
 POSITIONAL=()
 NO_LAUNCH=""
 BASE_BRANCH_OVERRIDE=""
+FROM_REF_OVERRIDE=""
 AUTO_MODE=""
 PLAN_MODE=""
 
@@ -55,6 +63,9 @@ while [[ $# -gt 0 ]]; do
     -b|--base)
       [[ $# -ge 2 ]] || { echo "Error: --base requires a value" >&2; exit 1; }
       BASE_BRANCH_OVERRIDE="$2"; shift 2 ;;
+    -f|--from)
+      [[ $# -ge 2 ]] || { echo "Error: --from requires a value" >&2; exit 1; }
+      FROM_REF_OVERRIDE="$2"; shift 2 ;;
     --no-launch) NO_LAUNCH="1"; shift ;;
     --auto) AUTO_MODE="1"; shift ;;
     --plan|-p) PLAN_MODE="1"; shift ;;
@@ -122,6 +133,12 @@ WORKTREE_BASE="${REPO_ROOT}/../${REPO_NAME}-worktrees"
 
 # Capture base branch now, before the worktree is created
 BASE_BRANCH="${BASE_BRANCH_OVERRIDE:-$(git rev-parse --abbrev-ref HEAD)}"
+FROM_REF="${FROM_REF_OVERRIDE:-HEAD}"
+
+if ! git rev-parse --verify --quiet "${FROM_REF}^{commit}" >/dev/null 2>&1; then
+  echo "Error: --from ref '$FROM_REF' does not resolve to a commit" >&2
+  exit 1
+fi
 
 BRANCH="task/${SLUG}"
 WORKTREE_DIR="${WORKTREE_BASE}/${SLUG}"
@@ -159,7 +176,7 @@ fi
 
 mkdir -p "$WORKTREE_BASE"
 echo "Creating branch $BRANCH and worktree at $WORKTREE_DIR..."
-aw_create_worktree "$WORKTREE_DIR" "$BRANCH" "$BASE_BRANCH"
+aw_create_worktree "$WORKTREE_DIR" "$BRANCH" "$BASE_BRANCH" "$FROM_REF"
 
 # Write task info so the worker and task-done can read it (stored outside the working tree)
 INFO_FILE="${WORKTREE_BASE}/.${SLUG}.info"

--- a/claude-notion/bin/task-work
+++ b/claude-notion/bin/task-work
@@ -176,7 +176,7 @@ fi
 
 mkdir -p "$WORKTREE_BASE"
 echo "Creating branch $BRANCH and worktree at $WORKTREE_DIR..."
-aw_create_worktree "$WORKTREE_DIR" "$BRANCH" "$BASE_BRANCH" "$FROM_REF"
+aw_create_worktree "$WORKTREE_DIR" "$BRANCH" "$FROM_REF"
 
 # Write task info so the worker and task-done can read it (stored outside the working tree)
 INFO_FILE="${WORKTREE_BASE}/.${SLUG}.info"

--- a/kiro-gh/bin/task-work
+++ b/kiro-gh/bin/task-work
@@ -174,7 +174,7 @@ fi
 
 mkdir -p "$WORKTREE_BASE"
 echo "Creating branch $BRANCH and worktree at $WORKTREE_DIR..."
-aw_create_worktree "$WORKTREE_DIR" "$BRANCH" "$BASE_BRANCH" "$FROM_REF"
+aw_create_worktree "$WORKTREE_DIR" "$BRANCH" "$FROM_REF"
 
 # Write task info so the worker and task-done can read it (stored outside the working tree)
 INFO_FILE="${WORKTREE_BASE}/.${SLUG}.info"

--- a/kiro-gh/bin/task-work
+++ b/kiro-gh/bin/task-work
@@ -26,7 +26,12 @@ Options:
   -a, --trust-all     Pass --trust-all-tools to kiro-cli so the worker can run
                       commands without per-tool confirmation. Defaults to
                       $TASK_WORK_TRUST_ALL=1 if set.
-  -b, --base BRANCH   Base branch for the PR (default: current branch at call time).
+  -b, --base BRANCH   Branch the PR will target (default: current branch at call time).
+  -f, --from REF      Git ref to fork the new worktree's branch from. Defaults
+                      to current HEAD. Use this to stack a PR on top of an
+                      in-flight branch, or to spike off origin/main without
+                      checking it out first. Accepts any ref `git` accepts
+                      (branches, tags, SHAs, origin/foo).
       --no-launch     Create the worktree and open the tab at its directory,
                       but do NOT start kiro-cli. Use this when you want to
                       pick the command/model interactively.
@@ -42,6 +47,8 @@ Examples:
   task-work refactor-auth -m claude-opus-4.6 --trust-all
   task-work spike-idea --no-launch
   TASK_WORK_MODEL=claude-sonnet-4.6 task-work new-thing https://github.com/owner/repo/issues/5
+  # Stack a follow-up PR on top of an in-flight branch:
+  task-work issue-99 <url> --from task/issue-46 --base main
 EOF
   exit "${1:-1}"
 }
@@ -52,6 +59,7 @@ MODEL="${TASK_WORK_MODEL:-}"
 TRUST_ALL=""
 NO_LAUNCH=""
 BASE_BRANCH_OVERRIDE=""
+FROM_REF_OVERRIDE=""
 
 # Treat TASK_WORK_TRUST_ALL=1 / true / yes as enabled
 case "${TASK_WORK_TRUST_ALL:-}" in
@@ -68,6 +76,9 @@ while [[ $# -gt 0 ]]; do
     -b|--base)
       [[ $# -ge 2 ]] || { echo "Error: --base requires a value" >&2; exit 1; }
       BASE_BRANCH_OVERRIDE="$2"; shift 2 ;;
+    -f|--from)
+      [[ $# -ge 2 ]] || { echo "Error: --from requires a value" >&2; exit 1; }
+      FROM_REF_OVERRIDE="$2"; shift 2 ;;
     --no-launch) NO_LAUNCH="1"; shift ;;
     --) shift; while [[ $# -gt 0 ]]; do POSITIONAL+=("$1"); shift; done ;;
     -*) echo "Error: unknown flag '$1'" >&2; usage 1 ;;
@@ -128,6 +139,12 @@ WORKTREE_BASE="${REPO_ROOT}/../${REPO_NAME}-worktrees"
 
 # Capture base branch now, before the worktree is created
 BASE_BRANCH="${BASE_BRANCH_OVERRIDE:-$(git rev-parse --abbrev-ref HEAD)}"
+FROM_REF="${FROM_REF_OVERRIDE:-HEAD}"
+
+if ! git rev-parse --verify --quiet "${FROM_REF}^{commit}" >/dev/null 2>&1; then
+  echo "Error: --from ref '$FROM_REF' does not resolve to a commit" >&2
+  exit 1
+fi
 
 BRANCH="task/${SLUG}"
 WORKTREE_DIR="${WORKTREE_BASE}/${SLUG}"
@@ -157,7 +174,7 @@ fi
 
 mkdir -p "$WORKTREE_BASE"
 echo "Creating branch $BRANCH and worktree at $WORKTREE_DIR..."
-aw_create_worktree "$WORKTREE_DIR" "$BRANCH" "$BASE_BRANCH"
+aw_create_worktree "$WORKTREE_DIR" "$BRANCH" "$BASE_BRANCH" "$FROM_REF"
 
 # Write task info so the worker and task-done can read it (stored outside the working tree)
 INFO_FILE="${WORKTREE_BASE}/.${SLUG}.info"

--- a/kiro-local/bin/task-work
+++ b/kiro-local/bin/task-work
@@ -163,7 +163,7 @@ fi
 
 mkdir -p "$WORKTREE_BASE"
 echo "Creating branch $BRANCH and worktree at $WORKTREE_DIR..."
-aw_create_worktree "$WORKTREE_DIR" "$BRANCH" "$BASE_BRANCH" "$FROM_REF"
+aw_create_worktree "$WORKTREE_DIR" "$BRANCH" "$FROM_REF"
 
 # Write task info so the worker and task-done can read it (stored outside the working tree)
 INFO_FILE="${WORKTREE_BASE}/.${SLUG}.info"

--- a/kiro-local/bin/task-work
+++ b/kiro-local/bin/task-work
@@ -29,7 +29,12 @@ Options:
   -a, --trust-all     Pass --trust-all-tools to kiro-cli so the worker can run
                       commands without per-tool confirmation. Defaults to
                       $TASK_WORK_TRUST_ALL=1 if set.
-  -b, --base BRANCH   Base branch for the PR (default: current branch at call time).
+  -b, --base BRANCH   Branch the PR will target (default: current branch at call time).
+  -f, --from REF      Git ref to fork the new worktree's branch from. Defaults
+                      to current HEAD. Use this to stack a PR on top of an
+                      in-flight branch, or to spike off origin/main without
+                      checking it out first. Accepts any ref `git` accepts
+                      (branches, tags, SHAs, origin/foo).
       --no-launch     Create the worktree and open the tab at its directory,
                       but do NOT start kiro-cli. Use this when you want to
                       pick the command/model interactively.
@@ -44,6 +49,8 @@ Examples:
   task-work tasks/042-refactor-auth.md --base develop
   task-work tasks/007-spike-idea.md --no-launch
   task-work spike-idea -m claude-opus-4.6 --trust-all
+  # Stack a follow-up on top of an in-flight branch:
+  task-work tasks/099-followup.md --from task/042-refactor-auth --base main
 EOF
   exit "${1:-1}"
 }
@@ -54,6 +61,7 @@ MODEL="${TASK_WORK_MODEL:-}"
 TRUST_ALL=""
 NO_LAUNCH=""
 BASE_BRANCH_OVERRIDE=""
+FROM_REF_OVERRIDE=""
 
 # Treat TASK_WORK_TRUST_ALL=1 / true / yes as enabled
 case "${TASK_WORK_TRUST_ALL:-}" in
@@ -70,6 +78,9 @@ while [[ $# -gt 0 ]]; do
     -b|--base)
       [[ $# -ge 2 ]] || { echo "Error: --base requires a value" >&2; exit 1; }
       BASE_BRANCH_OVERRIDE="$2"; shift 2 ;;
+    -f|--from)
+      [[ $# -ge 2 ]] || { echo "Error: --from requires a value" >&2; exit 1; }
+      FROM_REF_OVERRIDE="$2"; shift 2 ;;
     --no-launch) NO_LAUNCH="1"; shift ;;
     --) shift; while [[ $# -gt 0 ]]; do POSITIONAL+=("$1"); shift; done ;;
     -*) echo "Error: unknown flag '$1'" >&2; usage 1 ;;
@@ -120,6 +131,12 @@ WORKTREE_BASE="${REPO_ROOT}/../${REPO_NAME}-worktrees"
 
 # Capture base branch now, before the worktree is created
 BASE_BRANCH="${BASE_BRANCH_OVERRIDE:-$(git rev-parse --abbrev-ref HEAD)}"
+FROM_REF="${FROM_REF_OVERRIDE:-HEAD}"
+
+if ! git rev-parse --verify --quiet "${FROM_REF}^{commit}" >/dev/null 2>&1; then
+  echo "Error: --from ref '$FROM_REF' does not resolve to a commit" >&2
+  exit 1
+fi
 
 BRANCH="task/${SLUG}"
 WORKTREE_DIR="${WORKTREE_BASE}/${SLUG}"
@@ -146,7 +163,7 @@ fi
 
 mkdir -p "$WORKTREE_BASE"
 echo "Creating branch $BRANCH and worktree at $WORKTREE_DIR..."
-aw_create_worktree "$WORKTREE_DIR" "$BRANCH" "$BASE_BRANCH"
+aw_create_worktree "$WORKTREE_DIR" "$BRANCH" "$BASE_BRANCH" "$FROM_REF"
 
 # Write task info so the worker and task-done can read it (stored outside the working tree)
 INFO_FILE="${WORKTREE_BASE}/.${SLUG}.info"

--- a/kiro-notion/bin/task-work
+++ b/kiro-notion/bin/task-work
@@ -176,7 +176,7 @@ fi
 
 mkdir -p "$WORKTREE_BASE"
 echo "Creating branch $BRANCH and worktree at $WORKTREE_DIR..."
-aw_create_worktree "$WORKTREE_DIR" "$BRANCH" "$BASE_BRANCH" "$FROM_REF"
+aw_create_worktree "$WORKTREE_DIR" "$BRANCH" "$FROM_REF"
 
 # Write task info so the worker and task-done can read it (stored outside the working tree)
 INFO_FILE="${WORKTREE_BASE}/.${SLUG}.info"

--- a/kiro-notion/bin/task-work
+++ b/kiro-notion/bin/task-work
@@ -26,7 +26,12 @@ Options:
   -a, --trust-all     Pass --trust-all-tools to kiro-cli so the worker can run
                       commands without per-tool confirmation. Defaults to
                       $TASK_WORK_TRUST_ALL=1 if set.
-  -b, --base BRANCH   Base branch for the PR (default: current branch at call time).
+  -b, --base BRANCH   Branch the PR will target (default: current branch at call time).
+  -f, --from REF      Git ref to fork the new worktree's branch from. Defaults
+                      to current HEAD. Use this to stack a PR on top of an
+                      in-flight branch, or to spike off origin/main without
+                      checking it out first. Accepts any ref `git` accepts
+                      (branches, tags, SHAs, origin/foo).
       --no-launch     Create the worktree and open the tab at its directory,
                       but do NOT start kiro-cli. Use this when you want to
                       pick the command/model interactively.
@@ -42,6 +47,8 @@ Examples:
   task-work refactor-auth -m claude-opus-4.6 --trust-all
   task-work spike-idea --no-launch
   TASK_WORK_MODEL=claude-sonnet-4.6 task-work new-thing https://...
+  # Stack a follow-up on top of an in-flight branch:
+  task-work followup <notion-url> --from task/refactor-auth --base main
 EOF
   exit "${1:-1}"
 }
@@ -52,6 +59,7 @@ MODEL="${TASK_WORK_MODEL:-}"
 TRUST_ALL=""
 NO_LAUNCH=""
 BASE_BRANCH_OVERRIDE=""
+FROM_REF_OVERRIDE=""
 
 # Treat TASK_WORK_TRUST_ALL=1 / true / yes as enabled
 case "${TASK_WORK_TRUST_ALL:-}" in
@@ -68,6 +76,9 @@ while [[ $# -gt 0 ]]; do
     -b|--base)
       [[ $# -ge 2 ]] || { echo "Error: --base requires a value" >&2; exit 1; }
       BASE_BRANCH_OVERRIDE="$2"; shift 2 ;;
+    -f|--from)
+      [[ $# -ge 2 ]] || { echo "Error: --from requires a value" >&2; exit 1; }
+      FROM_REF_OVERRIDE="$2"; shift 2 ;;
     --no-launch) NO_LAUNCH="1"; shift ;;
     --) shift; while [[ $# -gt 0 ]]; do POSITIONAL+=("$1"); shift; done ;;
     -*) echo "Error: unknown flag '$1'" >&2; usage 1 ;;
@@ -128,6 +139,12 @@ WORKTREE_BASE="${REPO_ROOT}/../${REPO_NAME}-worktrees"
 
 # Capture base branch now, before the worktree is created
 BASE_BRANCH="${BASE_BRANCH_OVERRIDE:-$(git rev-parse --abbrev-ref HEAD)}"
+FROM_REF="${FROM_REF_OVERRIDE:-HEAD}"
+
+if ! git rev-parse --verify --quiet "${FROM_REF}^{commit}" >/dev/null 2>&1; then
+  echo "Error: --from ref '$FROM_REF' does not resolve to a commit" >&2
+  exit 1
+fi
 
 BRANCH="task/${SLUG}"
 WORKTREE_DIR="${WORKTREE_BASE}/${SLUG}"
@@ -159,7 +176,7 @@ fi
 
 mkdir -p "$WORKTREE_BASE"
 echo "Creating branch $BRANCH and worktree at $WORKTREE_DIR..."
-aw_create_worktree "$WORKTREE_DIR" "$BRANCH" "$BASE_BRANCH"
+aw_create_worktree "$WORKTREE_DIR" "$BRANCH" "$BASE_BRANCH" "$FROM_REF"
 
 # Write task info so the worker and task-done can read it (stored outside the working tree)
 INFO_FILE="${WORKTREE_BASE}/.${SLUG}.info"

--- a/lib/worktree-create.sh
+++ b/lib/worktree-create.sh
@@ -2,11 +2,14 @@
 # Shared worktree creation. Sourced by every <impl>/bin/task-work.
 #
 # Exports:
-#   aw_create_worktree <worktree_dir> <branch> <base_branch>
+#   aw_create_worktree <worktree_dir> <branch> <base_branch> [from_ref]
+#
+# Forks the new branch from <from_ref> (defaults to HEAD). <base_branch> is
+# only used as the label in the divergence warning emitted below.
 #
 # Tries to create the worktree on a new branch (-b). If that fails because
 # the branch already exists, reuses it — but emits a loud warning to stderr
-# showing how the branch tip diverges from <base_branch>. This catches the
+# showing how the branch tip diverges from <from_ref>. This catches the
 # foot-gun of running `task-work` after the worktree was deleted but the
 # branch wasn't, which would otherwise silently base the new worktree on
 # stale code (issue #38).
@@ -15,8 +18,9 @@ aw_create_worktree() {
   local worktree_dir="$1"
   local branch="$2"
   local base_branch="$3"
+  local from_ref="${4:-HEAD}"
 
-  if git worktree add "$worktree_dir" -b "$branch" 2>/dev/null; then
+  if git worktree add "$worktree_dir" -b "$branch" "$from_ref" 2>/dev/null; then
     return 0
   fi
 
@@ -32,20 +36,25 @@ aw_create_worktree() {
     return 1
   fi
 
-  local branch_tip branch_subj base_tip base_subj behind ahead
+  local from_label="$from_ref"
+  if [[ "$from_label" = "HEAD" ]]; then
+    from_label=$(git rev-parse --abbrev-ref HEAD 2>/dev/null || echo "HEAD")
+  fi
+
+  local branch_tip branch_subj from_tip from_subj behind ahead
   branch_tip=$(git rev-parse --short "$branch" 2>/dev/null || echo "?")
   branch_subj=$(git log -1 --format=%s "$branch" 2>/dev/null || echo "?")
-  base_tip=$(git rev-parse --short "$base_branch" 2>/dev/null || echo "?")
-  base_subj=$(git log -1 --format=%s "$base_branch" 2>/dev/null || echo "?")
-  behind=$(git rev-list --count "$branch..$base_branch" 2>/dev/null || echo "?")
-  ahead=$(git rev-list --count "$base_branch..$branch" 2>/dev/null || echo "?")
+  from_tip=$(git rev-parse --short "$from_ref" 2>/dev/null || echo "?")
+  from_subj=$(git log -1 --format=%s "$from_ref" 2>/dev/null || echo "?")
+  behind=$(git rev-list --count "$branch..$from_ref" 2>/dev/null || echo "?")
+  ahead=$(git rev-list --count "$from_ref..$branch" 2>/dev/null || echo "?")
 
   {
     echo ""
     echo "⚠ Branch $branch already exists. Reusing it."
     echo "  Branch tip:               $branch_tip ($branch_subj)"
-    echo "  Current HEAD on $base_branch: $base_tip ($base_subj)"
-    echo "  Divergence:               $ahead ahead, $behind behind $base_branch"
+    echo "  Current HEAD on $from_label: $from_tip ($from_subj)"
+    echo "  Divergence:               $ahead ahead, $behind behind $from_label"
     echo "  If the branch is stale, exit and run: git branch -D $branch"
     echo ""
   } >&2

--- a/lib/worktree-create.sh
+++ b/lib/worktree-create.sh
@@ -2,10 +2,9 @@
 # Shared worktree creation. Sourced by every <impl>/bin/task-work.
 #
 # Exports:
-#   aw_create_worktree <worktree_dir> <branch> <base_branch> [from_ref]
+#   aw_create_worktree <worktree_dir> <branch> [from_ref]
 #
-# Forks the new branch from <from_ref> (defaults to HEAD). <base_branch> is
-# only used as the label in the divergence warning emitted below.
+# Forks the new branch from <from_ref> (defaults to HEAD).
 #
 # Tries to create the worktree on a new branch (-b). If that fails because
 # the branch already exists, reuses it — but emits a loud warning to stderr
@@ -17,8 +16,7 @@
 aw_create_worktree() {
   local worktree_dir="$1"
   local branch="$2"
-  local base_branch="$3"
-  local from_ref="${4:-HEAD}"
+  local from_ref="${3:-HEAD}"
 
   if git worktree add "$worktree_dir" -b "$branch" "$from_ref" 2>/dev/null; then
     return 0

--- a/tests/claude_gh_task_work.bats
+++ b/tests/claude_gh_task_work.bats
@@ -96,6 +96,119 @@ teardown() {
 }
 
 # ---------------------------------------------------------------------------
+# --from: fork point override
+# ---------------------------------------------------------------------------
+
+@test "no --from: regression — forks from current HEAD (default behavior)" {
+  # Advance main by one commit, then ensure the new worktree's HEAD matches main's HEAD.
+  echo "advance" > "$MAIN_REPO/advance.txt"
+  git -C "$MAIN_REPO" add advance.txt
+  git -C "$MAIN_REPO" commit -q -m "advance main"
+  local main_head
+  main_head=$(git -C "$MAIN_REPO" rev-parse HEAD)
+
+  run "$CLAUDE_GH_TASK_WORK" my-feature
+  assert_success
+  local wt_head
+  wt_head=$(git -C "$WORKTREE_BASE/my-feature" rev-parse HEAD)
+  assert_equal "$wt_head" "$main_head"
+}
+
+@test "--from <local-branch>: forks new branch from that branch's tip" {
+  # Create a feature branch one commit ahead of main, then check out main again.
+  git -C "$MAIN_REPO" checkout -q -b feature-x
+  echo "feature work" > "$MAIN_REPO/feature.txt"
+  git -C "$MAIN_REPO" add feature.txt
+  git -C "$MAIN_REPO" commit -q -m "feature commit"
+  local feature_head
+  feature_head=$(git -C "$MAIN_REPO" rev-parse HEAD)
+  git -C "$MAIN_REPO" checkout -q main
+
+  run "$CLAUDE_GH_TASK_WORK" --from feature-x stacked-feature
+  assert_success
+  local wt_head
+  wt_head=$(git -C "$WORKTREE_BASE/stacked-feature" rev-parse HEAD)
+  assert_equal "$wt_head" "$feature_head"
+}
+
+@test "--from <local-branch>: --base is independent from --from" {
+  git -C "$MAIN_REPO" checkout -q -b feature-y
+  echo "feature y" > "$MAIN_REPO/y.txt"
+  git -C "$MAIN_REPO" add y.txt
+  git -C "$MAIN_REPO" commit -q -m "y"
+  git -C "$MAIN_REPO" checkout -q main
+
+  run "$CLAUDE_GH_TASK_WORK" --from feature-y --base main stacked
+  assert_success
+  source "$WORKTREE_BASE/.stacked.info"
+  assert_equal "$BASE_BRANCH" "main"
+  # And the worktree HEAD is feature-y's tip, not main's
+  local wt_head feat_head
+  wt_head=$(git -C "$WORKTREE_BASE/stacked" rev-parse HEAD)
+  feat_head=$(git -C "$MAIN_REPO" rev-parse feature-y)
+  assert_equal "$wt_head" "$feat_head"
+}
+
+@test "--from <remote-ref>: forks from a remote-only branch" {
+  # Set up a second repo to act as a remote with a branch not present locally.
+  local upstream
+  upstream=$(mktemp -d)
+  git -C "$upstream" init -q -b main
+  git -C "$upstream" config user.email "u@u.local"
+  git -C "$upstream" config user.name "U"
+  cp "$MAIN_REPO/README.md" "$upstream/README.md"
+  git -C "$upstream" add README.md
+  git -C "$upstream" commit -q -m "init upstream"
+  git -C "$upstream" checkout -q -b upstream-feature
+  echo "upstream feature" > "$upstream/u.txt"
+  git -C "$upstream" add u.txt
+  git -C "$upstream" commit -q -m "upstream feature"
+  local upstream_feat_head
+  upstream_feat_head=$(git -C "$upstream" rev-parse HEAD)
+
+  git -C "$MAIN_REPO" remote add origin "$upstream"
+  git -C "$MAIN_REPO" fetch -q origin
+
+  run "$CLAUDE_GH_TASK_WORK" --from origin/upstream-feature spike
+  assert_success
+  local wt_head
+  wt_head=$(git -C "$WORKTREE_BASE/spike" rev-parse HEAD)
+  assert_equal "$wt_head" "$upstream_feat_head"
+
+  rm -rf "$upstream"
+}
+
+@test "--from <unknown-ref>: errors out" {
+  run "$CLAUDE_GH_TASK_WORK" --from no-such-ref my-feature
+  assert_failure
+  assert_output --partial "does not resolve to a commit"
+  # No worktree should have been created.
+  assert [ ! -d "$WORKTREE_BASE/my-feature" ]
+}
+
+@test "--from missing value: errors out" {
+  run "$CLAUDE_GH_TASK_WORK" --from
+  assert_failure
+  assert_output --partial "--from requires a value"
+}
+
+@test "-f alias works the same as --from" {
+  git -C "$MAIN_REPO" checkout -q -b feature-z
+  echo "z" > "$MAIN_REPO/z.txt"
+  git -C "$MAIN_REPO" add z.txt
+  git -C "$MAIN_REPO" commit -q -m "z"
+  local feat_head
+  feat_head=$(git -C "$MAIN_REPO" rev-parse HEAD)
+  git -C "$MAIN_REPO" checkout -q main
+
+  run "$CLAUDE_GH_TASK_WORK" -f feature-z forked
+  assert_success
+  local wt_head
+  wt_head=$(git -C "$WORKTREE_BASE/forked" rev-parse HEAD)
+  assert_equal "$wt_head" "$feat_head"
+}
+
+# ---------------------------------------------------------------------------
 # .info file
 # ---------------------------------------------------------------------------
 


### PR DESCRIPTION
## Summary

Closes #54.

Adds a `--from <ref>` (also `-f`) flag to `task-work`, distinct from `--base`:

| Flag | Meaning |
|---|---|
| `--from <ref>` | Git ref to **fork the new worktree's branch from**. Defaults to current HEAD (today's behaviour). |
| `--base <branch>` | Branch the PR will **target**. Defaults to current branch at call time. |

The two usually coincide, but they're now independently settable so stacked PRs are first-class. Examples:

\`\`\`bash
# Stack a follow-up PR on top of an in-flight branch
task-work issue-99 <url> --from task/issue-46 --base main --auto

# Spike off origin/main without checking it out first
task-work spike --from origin/main
\`\`\`

### Changes

- \`lib/worktree-create.sh\` — \`aw_create_worktree\` accepts an optional 4th \`from_ref\` arg and forwards it to \`git worktree add -b\`. The divergence-warning block now compares against \`$from_ref\` rather than \`$base_branch\` (when no \`--from\` is given, that resolves to current HEAD / current branch, so existing messages still read \"Current HEAD on main\").
- All 7 \`<impl>/bin/task-work\` files — parse \`-f/--from\`, validate the ref with \`git rev-parse --verify "$ref^{commit}"\`, and pass it through.
- README + per-script help text updated with the new flag and stacked-PR examples.

### Tests

\`tests/claude_gh_task_work.bats\` gets 7 new cases covering: regression (no \`--from\` → forks from HEAD), \`--from\` with a local branch, \`--base\`/\`--from\` independence, \`--from\` with a remote-only ref, unknown ref → error, missing value → error, \`-f\` alias. Full suite (446 tests) green.

## Test plan

- [x] \`./run_tests.sh\` — all 446 tests pass locally
- [x] \`./run_tests.sh claude_gh_task_work\` — 33 tests including the 7 new \`--from\` cases
- [ ] Existing invocations without \`--from\` behave identically (regression check covered by tests)

🤖 Generated with [Claude Code](https://claude.com/claude-code)