### PR TITLE
Guard against cross-loadout drift: add tools/check-drift.sh + sentinel regions

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -32,6 +32,15 @@ jobs:
         run: |
           shellcheck -x \
             install.sh task-init run_tests.sh \
-            bin/* lib/*.sh \
+            bin/* lib/*.sh tools/*.sh \
             tests/helpers/*.bash \
             */install.sh */bin/*
+
+  drift-check:
+    name: Loadout drift check
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Check loadout drift
+        run: bash tools/check-drift.sh

--- a/claude-gh/bin/task-done
+++ b/claude-gh/bin/task-done
@@ -1,6 +1,7 @@
 #!/usr/bin/env bash
 set -euo pipefail
 
+# region:flag-parsing
 usage() {
   echo "Usage: task-done [--force] [--remove-worktree]"
   echo ""
@@ -27,7 +28,9 @@ while [[ $# -gt 0 ]]; do
     *) echo "Unknown option: $1"; usage ;;
   esac
 done
+# endregion:flag-parsing
 
+# region:worktree-context
 # Detect worktree context
 WORKTREE_DIR=$(pwd)
 REPO_ROOT=$(git rev-parse --show-toplevel 2>/dev/null) || { echo "Error: not in a git repo"; exit 1; }
@@ -49,7 +52,9 @@ INFO_FILE="${WORKTREE_BASE}/.${SLUG}.info"
 BASE_BRANCH="main"
 # shellcheck source=/dev/null
 [[ -f "$INFO_FILE" ]] && source "$INFO_FILE"
+# endregion:worktree-context
 
+# region:diff-summary
 echo "Worktree: $WORKTREE_DIR"
 echo "Branch:   $BRANCH"
 echo "Base:     $BASE_BRANCH"
@@ -72,6 +77,7 @@ echo "Commits ahead of ${BASE_BRANCH}: $COMMIT_COUNT"
 DIFF_STAT=$(git diff --shortstat "${BASE_BRANCH}..HEAD" 2>/dev/null || true)
 [[ -n "$DIFF_STAT" ]] && echo "Changes: $DIFF_STAT"
 echo ""
+# endregion:diff-summary
 
 if [[ "$REMOVE_ONLY" != true ]]; then
   # Show existing PR URL, or print the creation command
@@ -85,6 +91,7 @@ if [[ "$REMOVE_ONLY" != true ]]; then
   echo ""
 fi
 
+# region:confirm-and-cleanup
 if [[ "$FORCE" != true && "$REMOVE_ONLY" != true ]]; then
   read -rp "Remove worktree and close tab? (y/N) " confirm
   [[ "$confirm" != "y" && "$confirm" != "Y" ]] && exit 0
@@ -113,3 +120,4 @@ fi
 # Close current zellij tab
 echo "Closing zellij tab..."
 zellij action close-tab
+# endregion:confirm-and-cleanup

--- a/claude-gh/bin/task-work
+++ b/claude-gh/bin/task-work
@@ -1,12 +1,14 @@
 #!/usr/bin/env bash
 set -euo pipefail
 
+# region:lib-source-header
 # Source shared zellij tab launcher.
 AW_ROOT_REAL="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
 # shellcheck source=lib/zellij-tab.sh
 source "$AW_ROOT_REAL/lib/zellij-tab.sh"
 # shellcheck source=lib/worktree-create.sh
 source "$AW_ROOT_REAL/lib/worktree-create.sh"
+# endregion:lib-source-header
 
 usage() {
   cat <<'EOF'
@@ -169,6 +171,7 @@ build_claude_cmd() {
 # Shared logic lives in lib/zellij-tab.sh (aw_launch_tab).
 
 # ---------------- worktree creation ----------------
+# region:worktree-creation-pre-info
 if [[ -d "$WORKTREE_DIR" ]]; then
   HASH=$(LC_ALL=C head -c 256 /dev/urandom | LC_ALL=C tr -dc 'a-z0-9' | head -c 5)
   SLUG="${SLUG}-${HASH}"
@@ -180,11 +183,13 @@ fi
 mkdir -p "$WORKTREE_BASE"
 echo "Creating branch $BRANCH and worktree at $WORKTREE_DIR..."
 aw_create_worktree "$WORKTREE_DIR" "$BRANCH" "$FROM_REF"
+# endregion:worktree-creation-pre-info
 
 # Write task info so the worker and task-done can read it (stored outside the working tree)
 INFO_FILE="${WORKTREE_BASE}/.${SLUG}.info"
 printf 'BASE_BRANCH=%s\nSLUG=%s\nGH_URL=%s\n' "$BASE_BRANCH" "$SLUG" "$GH_URL" > "$INFO_FILE"
 
+# region:worktree-creation-post-info
 echo "Opening zellij tab '$SLUG'..."
 if [[ -n "$NO_LAUNCH" ]]; then
   aw_launch_tab "$SLUG" "$WORKTREE_DIR" ""
@@ -197,3 +202,4 @@ if [[ -n "$NO_LAUNCH" ]]; then
 else
   echo "Started worker in $WORKTREE_DIR (branch: $BRANCH, base: $BASE_BRANCH)"
 fi
+# endregion:worktree-creation-post-info

--- a/claude-jira/bin/task-done
+++ b/claude-jira/bin/task-done
@@ -1,6 +1,7 @@
 #!/usr/bin/env bash
 set -euo pipefail
 
+# region:flag-parsing
 usage() {
   echo "Usage: task-done [--force] [--remove-worktree]"
   echo ""
@@ -27,7 +28,10 @@ while [[ $# -gt 0 ]]; do
     *) echo "Unknown option: $1"; usage ;;
   esac
 done
+# endregion:flag-parsing
 
+# region:worktree-context
+# Detect worktree context
 WORKTREE_DIR=$(pwd)
 REPO_ROOT=$(git rev-parse --show-toplevel 2>/dev/null) || { echo "Error: not in a git repo"; exit 1; }
 
@@ -48,13 +52,15 @@ INFO_FILE="${WORKTREE_BASE}/.${SLUG}.info"
 BASE_BRANCH="main"
 # shellcheck source=/dev/null
 [[ -f "$INFO_FILE" ]] && source "$INFO_FILE"
+# endregion:worktree-context
 
+# region:diff-summary
 echo "Worktree: $WORKTREE_DIR"
 echo "Branch:   $BRANCH"
 echo "Base:     $BASE_BRANCH"
 echo ""
 
-# Uncommitted changes?
+# Check for uncommitted changes
 if ! git diff --quiet || ! git diff --cached --quiet; then
   echo "⚠ Uncommitted changes detected:"
   git status --short
@@ -65,11 +71,13 @@ if ! git diff --quiet || ! git diff --cached --quiet; then
   fi
 fi
 
+# Show summary
 COMMIT_COUNT=$(git rev-list --count "${BASE_BRANCH}..HEAD" 2>/dev/null || echo "?")
 echo "Commits ahead of ${BASE_BRANCH}: $COMMIT_COUNT"
 DIFF_STAT=$(git diff --shortstat "${BASE_BRANCH}..HEAD" 2>/dev/null || true)
 [[ -n "$DIFF_STAT" ]] && echo "Changes: $DIFF_STAT"
 echo ""
+# endregion:diff-summary
 
 if [[ "$REMOVE_ONLY" != true ]]; then
   # Show existing PR URL, or print the creation command
@@ -89,13 +97,16 @@ if [[ "$REMOVE_ONLY" != true ]]; then
   echo ""
 fi
 
+# region:confirm-and-cleanup
 if [[ "$FORCE" != true && "$REMOVE_ONLY" != true ]]; then
   read -rp "Remove worktree and close tab? (y/N) " confirm
   [[ "$confirm" != "y" && "$confirm" != "Y" ]] && exit 0
 fi
 
+# Move out of worktree before removing it
 cd "$MAIN_WORKTREE"
 
+# Remove worktree
 echo "Removing worktree..."
 git worktree remove "$WORKTREE_DIR" --force 2>/dev/null || {
   echo "Warning: could not remove worktree cleanly. Trying prune..."
@@ -112,5 +123,7 @@ else
   echo "Done. Branch '$BRANCH' still has unmerged commits — delete manually after PR merge: git branch -D $BRANCH"
 fi
 
+# Close current zellij tab
 echo "Closing zellij tab..."
 zellij action close-tab
+# endregion:confirm-and-cleanup

--- a/claude-jira/bin/task-work
+++ b/claude-jira/bin/task-work
@@ -1,12 +1,14 @@
 #!/usr/bin/env bash
 set -euo pipefail
 
+# region:lib-source-header
 # Source shared zellij tab launcher.
 AW_ROOT_REAL="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
 # shellcheck source=lib/zellij-tab.sh
 source "$AW_ROOT_REAL/lib/zellij-tab.sh"
 # shellcheck source=lib/worktree-create.sh
 source "$AW_ROOT_REAL/lib/worktree-create.sh"
+# endregion:lib-source-header
 
 usage() {
   echo "Usage: task-work [options] <jira-key-or-url-or-slug>"

--- a/claude-local/bin/task-done
+++ b/claude-local/bin/task-done
@@ -1,6 +1,7 @@
 #!/usr/bin/env bash
 set -euo pipefail
 
+# region:flag-parsing
 usage() {
   echo "Usage: task-done [--force] [--remove-worktree]"
   echo ""
@@ -29,7 +30,9 @@ while [[ $# -gt 0 ]]; do
     *) echo "Unknown option: $1"; usage ;;
   esac
 done
+# endregion:flag-parsing
 
+# region:worktree-context
 # Detect worktree context
 WORKTREE_DIR=$(pwd)
 REPO_ROOT=$(git rev-parse --show-toplevel 2>/dev/null) || { echo "Error: not in a git repo"; exit 1; }
@@ -51,7 +54,9 @@ INFO_FILE="${WORKTREE_BASE}/.${SLUG}.info"
 BASE_BRANCH="main"
 # shellcheck source=/dev/null
 [[ -f "$INFO_FILE" ]] && source "$INFO_FILE"
+# endregion:worktree-context
 
+# region:diff-summary
 echo "Worktree: $WORKTREE_DIR"
 echo "Branch:   $BRANCH"
 echo "Base:     $BASE_BRANCH"
@@ -74,6 +79,7 @@ echo "Commits ahead of ${BASE_BRANCH}: $COMMIT_COUNT"
 DIFF_STAT=$(git diff --shortstat "${BASE_BRANCH}..HEAD" 2>/dev/null || true)
 [[ -n "$DIFF_STAT" ]] && echo "Changes: $DIFF_STAT"
 echo ""
+# endregion:diff-summary
 
 if [[ "$REMOVE_ONLY" != true ]]; then
   # Show existing PR URL, or print the creation command
@@ -87,6 +93,7 @@ if [[ "$REMOVE_ONLY" != true ]]; then
   echo ""
 fi
 
+# region:confirm-and-cleanup
 if [[ "$FORCE" != true && "$REMOVE_ONLY" != true ]]; then
   read -rp "Remove worktree and close tab? (y/N) " confirm
   [[ "$confirm" != "y" && "$confirm" != "Y" ]] && exit 0
@@ -133,3 +140,4 @@ fi
 # Close current zellij tab
 echo "Closing zellij tab..."
 zellij action close-tab
+# endregion:confirm-and-cleanup

--- a/claude-local/bin/task-work
+++ b/claude-local/bin/task-work
@@ -1,12 +1,14 @@
 #!/usr/bin/env bash
 set -euo pipefail
 
+# region:lib-source-header
 # Source shared zellij tab launcher.
 AW_ROOT_REAL="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
 # shellcheck source=lib/zellij-tab.sh
 source "$AW_ROOT_REAL/lib/zellij-tab.sh"
 # shellcheck source=lib/worktree-create.sh
 source "$AW_ROOT_REAL/lib/worktree-create.sh"
+# endregion:lib-source-header
 
 usage() {
   cat <<'EOF'
@@ -154,6 +156,7 @@ build_claude_cmd() {
 }
 
 # ---------------- worktree creation ----------------
+# region:worktree-creation-pre-info
 if [[ -d "$WORKTREE_DIR" ]]; then
   HASH=$(LC_ALL=C head -c 256 /dev/urandom | LC_ALL=C tr -dc 'a-z0-9' | head -c 5)
   SLUG="${SLUG}-${HASH}"
@@ -165,6 +168,7 @@ fi
 mkdir -p "$WORKTREE_BASE"
 echo "Creating branch $BRANCH and worktree at $WORKTREE_DIR..."
 aw_create_worktree "$WORKTREE_DIR" "$BRANCH" "$FROM_REF"
+# endregion:worktree-creation-pre-info
 
 # Write task info so the worker and task-done can read it (stored outside the working tree)
 INFO_FILE="${WORKTREE_BASE}/.${SLUG}.info"
@@ -202,6 +206,7 @@ else
   fi
 fi
 
+# region:worktree-creation-post-info
 echo "Opening zellij tab '$SLUG'..."
 if [[ -n "$NO_LAUNCH" ]]; then
   aw_launch_tab "$SLUG" "$WORKTREE_DIR" ""
@@ -214,3 +219,4 @@ if [[ -n "$NO_LAUNCH" ]]; then
 else
   echo "Started worker in $WORKTREE_DIR (branch: $BRANCH, base: $BASE_BRANCH)"
 fi
+# endregion:worktree-creation-post-info

--- a/claude-notion/bin/task-done
+++ b/claude-notion/bin/task-done
@@ -1,6 +1,7 @@
 #!/usr/bin/env bash
 set -euo pipefail
 
+# region:flag-parsing
 usage() {
   echo "Usage: task-done [--force] [--remove-worktree]"
   echo ""
@@ -27,7 +28,9 @@ while [[ $# -gt 0 ]]; do
     *) echo "Unknown option: $1"; usage ;;
   esac
 done
+# endregion:flag-parsing
 
+# region:worktree-context
 # Detect worktree context
 WORKTREE_DIR=$(pwd)
 REPO_ROOT=$(git rev-parse --show-toplevel 2>/dev/null) || { echo "Error: not in a git repo"; exit 1; }
@@ -49,7 +52,9 @@ INFO_FILE="${WORKTREE_BASE}/.${SLUG}.info"
 BASE_BRANCH="main"
 # shellcheck source=/dev/null
 [[ -f "$INFO_FILE" ]] && source "$INFO_FILE"
+# endregion:worktree-context
 
+# region:diff-summary
 echo "Worktree: $WORKTREE_DIR"
 echo "Branch:   $BRANCH"
 echo "Base:     $BASE_BRANCH"
@@ -72,6 +77,7 @@ echo "Commits ahead of ${BASE_BRANCH}: $COMMIT_COUNT"
 DIFF_STAT=$(git diff --shortstat "${BASE_BRANCH}..HEAD" 2>/dev/null || true)
 [[ -n "$DIFF_STAT" ]] && echo "Changes: $DIFF_STAT"
 echo ""
+# endregion:diff-summary
 
 if [[ "$REMOVE_ONLY" != true ]]; then
   # Show existing PR URL, or print the creation command
@@ -85,6 +91,7 @@ if [[ "$REMOVE_ONLY" != true ]]; then
   echo ""
 fi
 
+# region:confirm-and-cleanup
 if [[ "$FORCE" != true && "$REMOVE_ONLY" != true ]]; then
   read -rp "Remove worktree and close tab? (y/N) " confirm
   [[ "$confirm" != "y" && "$confirm" != "Y" ]] && exit 0
@@ -113,3 +120,4 @@ fi
 # Close current zellij tab
 echo "Closing zellij tab..."
 zellij action close-tab
+# endregion:confirm-and-cleanup

--- a/claude-notion/bin/task-work
+++ b/claude-notion/bin/task-work
@@ -1,12 +1,14 @@
 #!/usr/bin/env bash
 set -euo pipefail
 
+# region:lib-source-header
 # Source shared zellij tab launcher.
 AW_ROOT_REAL="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
 # shellcheck source=lib/zellij-tab.sh
 source "$AW_ROOT_REAL/lib/zellij-tab.sh"
 # shellcheck source=lib/worktree-create.sh
 source "$AW_ROOT_REAL/lib/worktree-create.sh"
+# endregion:lib-source-header
 
 usage() {
   cat <<'EOF'
@@ -166,6 +168,7 @@ build_claude_cmd() {
 # Shared logic lives in lib/zellij-tab.sh (aw_launch_tab).
 
 # ---------------- worktree creation ----------------
+# region:worktree-creation-pre-info
 if [[ -d "$WORKTREE_DIR" ]]; then
   HASH=$(LC_ALL=C head -c 256 /dev/urandom | LC_ALL=C tr -dc 'a-z0-9' | head -c 5)
   SLUG="${SLUG}-${HASH}"
@@ -177,11 +180,13 @@ fi
 mkdir -p "$WORKTREE_BASE"
 echo "Creating branch $BRANCH and worktree at $WORKTREE_DIR..."
 aw_create_worktree "$WORKTREE_DIR" "$BRANCH" "$FROM_REF"
+# endregion:worktree-creation-pre-info
 
 # Write task info so the worker and task-done can read it (stored outside the working tree)
 INFO_FILE="${WORKTREE_BASE}/.${SLUG}.info"
 printf 'BASE_BRANCH=%s\nSLUG=%s\nNOTION_URL=%s\n' "$BASE_BRANCH" "$SLUG" "$NOTION_URL" > "$INFO_FILE"
 
+# region:worktree-creation-post-info
 echo "Opening zellij tab '$SLUG'..."
 if [[ -n "$NO_LAUNCH" ]]; then
   aw_launch_tab "$SLUG" "$WORKTREE_DIR" ""
@@ -194,3 +199,4 @@ if [[ -n "$NO_LAUNCH" ]]; then
 else
   echo "Started worker in $WORKTREE_DIR (branch: $BRANCH, base: $BASE_BRANCH)"
 fi
+# endregion:worktree-creation-post-info

--- a/kiro-gh/bin/task-done
+++ b/kiro-gh/bin/task-done
@@ -1,6 +1,7 @@
 #!/usr/bin/env bash
 set -euo pipefail
 
+# region:flag-parsing
 usage() {
   echo "Usage: task-done [--force] [--remove-worktree]"
   echo ""
@@ -27,7 +28,9 @@ while [[ $# -gt 0 ]]; do
     *) echo "Unknown option: $1"; usage ;;
   esac
 done
+# endregion:flag-parsing
 
+# region:worktree-context
 # Detect worktree context
 WORKTREE_DIR=$(pwd)
 REPO_ROOT=$(git rev-parse --show-toplevel 2>/dev/null) || { echo "Error: not in a git repo"; exit 1; }
@@ -49,7 +52,9 @@ INFO_FILE="${WORKTREE_BASE}/.${SLUG}.info"
 BASE_BRANCH="main"
 # shellcheck source=/dev/null
 [[ -f "$INFO_FILE" ]] && source "$INFO_FILE"
+# endregion:worktree-context
 
+# region:diff-summary
 echo "Worktree: $WORKTREE_DIR"
 echo "Branch:   $BRANCH"
 echo "Base:     $BASE_BRANCH"
@@ -72,6 +77,7 @@ echo "Commits ahead of ${BASE_BRANCH}: $COMMIT_COUNT"
 DIFF_STAT=$(git diff --shortstat "${BASE_BRANCH}..HEAD" 2>/dev/null || true)
 [[ -n "$DIFF_STAT" ]] && echo "Changes: $DIFF_STAT"
 echo ""
+# endregion:diff-summary
 
 if [[ "$REMOVE_ONLY" != true ]]; then
   # Show existing PR URL, or print the creation command
@@ -85,6 +91,7 @@ if [[ "$REMOVE_ONLY" != true ]]; then
   echo ""
 fi
 
+# region:confirm-and-cleanup
 if [[ "$FORCE" != true && "$REMOVE_ONLY" != true ]]; then
   read -rp "Remove worktree and close tab? (y/N) " confirm
   [[ "$confirm" != "y" && "$confirm" != "Y" ]] && exit 0
@@ -113,3 +120,4 @@ fi
 # Close current zellij tab
 echo "Closing zellij tab..."
 zellij action close-tab
+# endregion:confirm-and-cleanup

--- a/kiro-gh/bin/task-work
+++ b/kiro-gh/bin/task-work
@@ -1,12 +1,14 @@
 #!/usr/bin/env bash
 set -euo pipefail
 
+# region:lib-source-header
 # Source shared zellij tab launcher.
 AW_ROOT_REAL="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
 # shellcheck source=lib/zellij-tab.sh
 source "$AW_ROOT_REAL/lib/zellij-tab.sh"
 # shellcheck source=lib/worktree-create.sh
 source "$AW_ROOT_REAL/lib/worktree-create.sh"
+# endregion:lib-source-header
 
 usage() {
   cat <<'EOF'
@@ -164,6 +166,7 @@ build_kiro_cmd() {
 # Shared logic lives in lib/zellij-tab.sh (aw_launch_tab).
 
 # ---------------- worktree creation ----------------
+# region:worktree-creation-pre-info
 if [[ -d "$WORKTREE_DIR" ]]; then
   HASH=$(LC_ALL=C head -c 256 /dev/urandom | LC_ALL=C tr -dc 'a-z0-9' | head -c 5)
   SLUG="${SLUG}-${HASH}"
@@ -175,11 +178,13 @@ fi
 mkdir -p "$WORKTREE_BASE"
 echo "Creating branch $BRANCH and worktree at $WORKTREE_DIR..."
 aw_create_worktree "$WORKTREE_DIR" "$BRANCH" "$FROM_REF"
+# endregion:worktree-creation-pre-info
 
 # Write task info so the worker and task-done can read it (stored outside the working tree)
 INFO_FILE="${WORKTREE_BASE}/.${SLUG}.info"
 printf 'BASE_BRANCH=%s\nSLUG=%s\nGH_URL=%s\n' "$BASE_BRANCH" "$SLUG" "$GH_URL" > "$INFO_FILE"
 
+# region:worktree-creation-post-info
 echo "Opening zellij tab '$SLUG'..."
 if [[ -n "$NO_LAUNCH" ]]; then
   aw_launch_tab "$SLUG" "$WORKTREE_DIR" ""
@@ -195,3 +200,4 @@ else
   [[ -n "$TRUST_ALL" ]] && desc+=" [trust-all]"
   echo "Started $desc in $WORKTREE_DIR (branch: $BRANCH, base: $BASE_BRANCH)"
 fi
+# endregion:worktree-creation-post-info

--- a/kiro-local/bin/task-done
+++ b/kiro-local/bin/task-done
@@ -1,6 +1,7 @@
 #!/usr/bin/env bash
 set -euo pipefail
 
+# region:flag-parsing
 usage() {
   echo "Usage: task-done [--force] [--remove-worktree]"
   echo ""
@@ -29,7 +30,9 @@ while [[ $# -gt 0 ]]; do
     *) echo "Unknown option: $1"; usage ;;
   esac
 done
+# endregion:flag-parsing
 
+# region:worktree-context
 # Detect worktree context
 WORKTREE_DIR=$(pwd)
 REPO_ROOT=$(git rev-parse --show-toplevel 2>/dev/null) || { echo "Error: not in a git repo"; exit 1; }
@@ -51,7 +54,9 @@ INFO_FILE="${WORKTREE_BASE}/.${SLUG}.info"
 BASE_BRANCH="main"
 # shellcheck source=/dev/null
 [[ -f "$INFO_FILE" ]] && source "$INFO_FILE"
+# endregion:worktree-context
 
+# region:diff-summary
 echo "Worktree: $WORKTREE_DIR"
 echo "Branch:   $BRANCH"
 echo "Base:     $BASE_BRANCH"
@@ -74,6 +79,7 @@ echo "Commits ahead of ${BASE_BRANCH}: $COMMIT_COUNT"
 DIFF_STAT=$(git diff --shortstat "${BASE_BRANCH}..HEAD" 2>/dev/null || true)
 [[ -n "$DIFF_STAT" ]] && echo "Changes: $DIFF_STAT"
 echo ""
+# endregion:diff-summary
 
 if [[ "$REMOVE_ONLY" != true ]]; then
   # Show existing PR URL, or print the creation command
@@ -87,6 +93,7 @@ if [[ "$REMOVE_ONLY" != true ]]; then
   echo ""
 fi
 
+# region:confirm-and-cleanup
 if [[ "$FORCE" != true && "$REMOVE_ONLY" != true ]]; then
   read -rp "Remove worktree and close tab? (y/N) " confirm
   [[ "$confirm" != "y" && "$confirm" != "Y" ]] && exit 0
@@ -133,3 +140,4 @@ fi
 # Close current zellij tab
 echo "Closing zellij tab..."
 zellij action close-tab
+# endregion:confirm-and-cleanup

--- a/kiro-local/bin/task-work
+++ b/kiro-local/bin/task-work
@@ -1,12 +1,14 @@
 #!/usr/bin/env bash
 set -euo pipefail
 
+# region:lib-source-header
 # Source shared zellij tab launcher.
 AW_ROOT_REAL="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
 # shellcheck source=lib/zellij-tab.sh
 source "$AW_ROOT_REAL/lib/zellij-tab.sh"
 # shellcheck source=lib/worktree-create.sh
 source "$AW_ROOT_REAL/lib/worktree-create.sh"
+# endregion:lib-source-header
 
 usage() {
   cat <<'EOF'
@@ -153,6 +155,7 @@ build_kiro_cmd() {
 }
 
 # ---------------- worktree creation ----------------
+# region:worktree-creation-pre-info
 if [[ -d "$WORKTREE_DIR" ]]; then
   HASH=$(LC_ALL=C head -c 256 /dev/urandom | LC_ALL=C tr -dc 'a-z0-9' | head -c 5)
   SLUG="${SLUG}-${HASH}"
@@ -164,6 +167,7 @@ fi
 mkdir -p "$WORKTREE_BASE"
 echo "Creating branch $BRANCH and worktree at $WORKTREE_DIR..."
 aw_create_worktree "$WORKTREE_DIR" "$BRANCH" "$FROM_REF"
+# endregion:worktree-creation-pre-info
 
 # Write task info so the worker and task-done can read it (stored outside the working tree)
 INFO_FILE="${WORKTREE_BASE}/.${SLUG}.info"
@@ -201,6 +205,7 @@ else
   fi
 fi
 
+# region:worktree-creation-post-info
 echo "Opening zellij tab '$SLUG'..."
 if [[ -n "$NO_LAUNCH" ]]; then
   aw_launch_tab "$SLUG" "$WORKTREE_DIR" ""
@@ -216,3 +221,4 @@ else
   [[ -n "$TRUST_ALL" ]] && desc+=" [trust-all]"
   echo "Started $desc in $WORKTREE_DIR (branch: $BRANCH, base: $BASE_BRANCH)"
 fi
+# endregion:worktree-creation-post-info

--- a/kiro-notion/bin/task-done
+++ b/kiro-notion/bin/task-done
@@ -1,6 +1,7 @@
 #!/usr/bin/env bash
 set -euo pipefail
 
+# region:flag-parsing
 usage() {
   echo "Usage: task-done [--force] [--remove-worktree]"
   echo ""
@@ -27,7 +28,9 @@ while [[ $# -gt 0 ]]; do
     *) echo "Unknown option: $1"; usage ;;
   esac
 done
+# endregion:flag-parsing
 
+# region:worktree-context
 # Detect worktree context
 WORKTREE_DIR=$(pwd)
 REPO_ROOT=$(git rev-parse --show-toplevel 2>/dev/null) || { echo "Error: not in a git repo"; exit 1; }
@@ -49,7 +52,9 @@ INFO_FILE="${WORKTREE_BASE}/.${SLUG}.info"
 BASE_BRANCH="main"
 # shellcheck source=/dev/null
 [[ -f "$INFO_FILE" ]] && source "$INFO_FILE"
+# endregion:worktree-context
 
+# region:diff-summary
 echo "Worktree: $WORKTREE_DIR"
 echo "Branch:   $BRANCH"
 echo "Base:     $BASE_BRANCH"
@@ -72,6 +77,7 @@ echo "Commits ahead of ${BASE_BRANCH}: $COMMIT_COUNT"
 DIFF_STAT=$(git diff --shortstat "${BASE_BRANCH}..HEAD" 2>/dev/null || true)
 [[ -n "$DIFF_STAT" ]] && echo "Changes: $DIFF_STAT"
 echo ""
+# endregion:diff-summary
 
 if [[ "$REMOVE_ONLY" != true ]]; then
   # Show existing PR URL, or print the creation command
@@ -85,6 +91,7 @@ if [[ "$REMOVE_ONLY" != true ]]; then
   echo ""
 fi
 
+# region:confirm-and-cleanup
 if [[ "$FORCE" != true && "$REMOVE_ONLY" != true ]]; then
   read -rp "Remove worktree and close tab? (y/N) " confirm
   [[ "$confirm" != "y" && "$confirm" != "Y" ]] && exit 0
@@ -113,3 +120,4 @@ fi
 # Close current zellij tab
 echo "Closing zellij tab..."
 zellij action close-tab
+# endregion:confirm-and-cleanup

--- a/kiro-notion/bin/task-work
+++ b/kiro-notion/bin/task-work
@@ -1,12 +1,14 @@
 #!/usr/bin/env bash
 set -euo pipefail
 
+# region:lib-source-header
 # Source shared zellij tab launcher.
 AW_ROOT_REAL="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
 # shellcheck source=lib/zellij-tab.sh
 source "$AW_ROOT_REAL/lib/zellij-tab.sh"
 # shellcheck source=lib/worktree-create.sh
 source "$AW_ROOT_REAL/lib/worktree-create.sh"
+# endregion:lib-source-header
 
 usage() {
   cat <<'EOF'
@@ -166,6 +168,7 @@ build_kiro_cmd() {
 # ---------------- worktree creation ----------------
 # Worktree already exists? Spin up a parallel session with a hash suffix
 # so multiple agents can iterate on the same task at the same time.
+# region:worktree-creation-pre-info
 if [[ -d "$WORKTREE_DIR" ]]; then
   HASH=$(LC_ALL=C head -c 256 /dev/urandom | LC_ALL=C tr -dc 'a-z0-9' | head -c 5)
   SLUG="${SLUG}-${HASH}"
@@ -177,11 +180,13 @@ fi
 mkdir -p "$WORKTREE_BASE"
 echo "Creating branch $BRANCH and worktree at $WORKTREE_DIR..."
 aw_create_worktree "$WORKTREE_DIR" "$BRANCH" "$FROM_REF"
+# endregion:worktree-creation-pre-info
 
 # Write task info so the worker and task-done can read it (stored outside the working tree)
 INFO_FILE="${WORKTREE_BASE}/.${SLUG}.info"
 printf 'BASE_BRANCH=%s\nSLUG=%s\nNOTION_URL=%s\n' "$BASE_BRANCH" "$SLUG" "$NOTION_URL" > "$INFO_FILE"
 
+# region:worktree-creation-post-info
 echo "Opening zellij tab '$SLUG'..."
 if [[ -n "$NO_LAUNCH" ]]; then
   aw_launch_tab "$SLUG" "$WORKTREE_DIR" ""
@@ -197,3 +202,4 @@ else
   [[ -n "$TRUST_ALL" ]] && desc+=" [trust-all]"
   echo "Started $desc in $WORKTREE_DIR (branch: $BRANCH, base: $BASE_BRANCH)"
 fi
+# endregion:worktree-creation-post-info

--- a/tests/drift_check.bats
+++ b/tests/drift_check.bats
@@ -1,0 +1,126 @@
+#!/usr/bin/env bats
+# Tests for tools/check-drift.sh.
+#
+# Verifies the drift checker passes on a synthetic repo whose regions match,
+# and fails (with a readable diff) when one file diverges. Also runs the real
+# manifest against the live repo as a regression guard.
+
+bats_load_library bats-support
+bats_load_library bats-assert
+
+load helpers/common
+
+CHECK_DRIFT="$REPO_ROOT_REAL/tools/check-drift.sh"
+
+setup() {
+  TMP_DIR=$(mktemp -d)
+  export TMP_DIR
+}
+
+teardown() {
+  [[ -n "${TMP_DIR:-}" && -d "$TMP_DIR" ]] && rm -rf "$TMP_DIR"
+}
+
+# Build a pair of stub scripts with identical sentinel regions.
+make_pair() {
+  local a="$1" b="$2" extra_in_b="${3-}"
+  cat >"$a" <<'EOF'
+#!/usr/bin/env bash
+# region:shared
+echo "hello"
+echo "world"
+# endregion:shared
+EOF
+  if [[ -n "$extra_in_b" ]]; then
+    cat >"$b" <<EOF
+#!/usr/bin/env bash
+# region:shared
+echo "hello"
+echo "$extra_in_b"
+# endregion:shared
+EOF
+  else
+    cp "$a" "$b"
+  fi
+}
+
+@test "check-drift passes when sentinel regions match" {
+  make_pair "$TMP_DIR/a.sh" "$TMP_DIR/b.sh"
+  cat >"$TMP_DIR/manifest" <<EOF
+demo|shared|$TMP_DIR/a.sh $TMP_DIR/b.sh
+EOF
+  CHECK_DRIFT_MANIFEST="$TMP_DIR/manifest" run bash "$CHECK_DRIFT"
+  assert_success
+  assert_output --partial "1 group(s) checked"
+}
+
+@test "check-drift fails with a diff when a region diverges" {
+  make_pair "$TMP_DIR/a.sh" "$TMP_DIR/b.sh" "DRIFTED"
+  cat >"$TMP_DIR/manifest" <<EOF
+demo|shared|$TMP_DIR/a.sh $TMP_DIR/b.sh
+EOF
+  CHECK_DRIFT_MANIFEST="$TMP_DIR/manifest" run bash "$CHECK_DRIFT"
+  assert_failure
+  assert_output --partial "DRIFT [demo/shared]"
+  assert_output --partial "a.sh"
+  assert_output --partial "b.sh"
+}
+
+@test "check-drift fails when a file is missing the region entirely" {
+  cat >"$TMP_DIR/a.sh" <<'EOF'
+#!/usr/bin/env bash
+# region:shared
+echo "hello"
+# endregion:shared
+EOF
+  cat >"$TMP_DIR/b.sh" <<'EOF'
+#!/usr/bin/env bash
+echo "no region here"
+EOF
+  cat >"$TMP_DIR/manifest" <<EOF
+demo|shared|$TMP_DIR/a.sh $TMP_DIR/b.sh
+EOF
+  CHECK_DRIFT_MANIFEST="$TMP_DIR/manifest" run bash "$CHECK_DRIFT"
+  assert_failure
+  assert_output --partial "region missing in"
+  assert_output --partial "b.sh"
+}
+
+@test "check-drift fails (with a distinct message) when sentinels bracket an empty body" {
+  cat >"$TMP_DIR/a.sh" <<'EOF'
+#!/usr/bin/env bash
+# region:shared
+echo "hello"
+# endregion:shared
+EOF
+  cat >"$TMP_DIR/b.sh" <<'EOF'
+#!/usr/bin/env bash
+# region:shared
+# endregion:shared
+EOF
+  cat >"$TMP_DIR/manifest" <<EOF
+demo|shared|$TMP_DIR/a.sh $TMP_DIR/b.sh
+EOF
+  CHECK_DRIFT_MANIFEST="$TMP_DIR/manifest" run bash "$CHECK_DRIFT"
+  assert_failure
+  assert_output --partial "region empty in"
+  assert_output --partial "b.sh"
+  # And it shouldn't be mislabelled as missing.
+  refute_output --partial "region missing in: $TMP_DIR/b.sh"
+}
+
+@test "check-drift fails when a manifest file does not exist" {
+  cat >"$TMP_DIR/manifest" <<EOF
+demo|shared|$TMP_DIR/missing.sh $TMP_DIR/also-missing.sh
+EOF
+  CHECK_DRIFT_MANIFEST="$TMP_DIR/manifest" run bash "$CHECK_DRIFT"
+  assert_failure
+  assert_output --partial "missing file"
+}
+
+@test "check-drift default manifest passes on the live repo" {
+  cd "$REPO_ROOT_REAL"
+  run bash "$CHECK_DRIFT"
+  assert_success
+  assert_output --partial "group(s) checked"
+}

--- a/tools/check-drift.sh
+++ b/tools/check-drift.sh
@@ -1,0 +1,118 @@
+#!/usr/bin/env bash
+# Check that named sentinel regions are byte-identical across grouped loadout
+# files. Catches the "fix lands in 6 of 7 loadouts" failure mode (#32, #38, #40).
+#
+# Manifest format (one entry per line in $GROUPS, fields | -separated):
+#   <group-label>|<region-name>|<file1> <file2> ...
+#
+# Override the manifest for tests by setting CHECK_DRIFT_MANIFEST to a file path.
+
+set -euo pipefail
+
+# region:default-manifest
+GROUPS_DEFAULT=(
+  "task-done-std|flag-parsing|claude-gh/bin/task-done claude-jira/bin/task-done claude-notion/bin/task-done kiro-gh/bin/task-done kiro-notion/bin/task-done"
+  "task-done-std|worktree-context|claude-gh/bin/task-done claude-jira/bin/task-done claude-notion/bin/task-done kiro-gh/bin/task-done kiro-notion/bin/task-done"
+  "task-done-std|diff-summary|claude-gh/bin/task-done claude-jira/bin/task-done claude-notion/bin/task-done kiro-gh/bin/task-done kiro-notion/bin/task-done"
+  "task-done-std|confirm-and-cleanup|claude-gh/bin/task-done claude-jira/bin/task-done claude-notion/bin/task-done kiro-gh/bin/task-done kiro-notion/bin/task-done"
+  "task-done-local|flag-parsing|claude-local/bin/task-done kiro-local/bin/task-done"
+  "task-done-local|worktree-context|claude-local/bin/task-done kiro-local/bin/task-done"
+  "task-done-local|diff-summary|claude-local/bin/task-done kiro-local/bin/task-done"
+  "task-done-local|confirm-and-cleanup|claude-local/bin/task-done kiro-local/bin/task-done"
+  "task-work|lib-source-header|claude-gh/bin/task-work claude-jira/bin/task-work claude-local/bin/task-work claude-notion/bin/task-work kiro-gh/bin/task-work kiro-local/bin/task-work kiro-notion/bin/task-work"
+  "task-work|worktree-creation-pre-info|claude-gh/bin/task-work claude-local/bin/task-work claude-notion/bin/task-work kiro-gh/bin/task-work kiro-local/bin/task-work kiro-notion/bin/task-work"
+  "task-work-claude|worktree-creation-post-info|claude-gh/bin/task-work claude-local/bin/task-work claude-notion/bin/task-work"
+  "task-work-kiro|worktree-creation-post-info|kiro-gh/bin/task-work kiro-local/bin/task-work kiro-notion/bin/task-work"
+)
+# endregion:default-manifest
+
+extract_region() {
+  local file="$1" region="$2"
+  awk -v r="$region" '
+    $0 == "# region:" r { in_region=1; next }
+    $0 == "# endregion:" r { in_region=0; next }
+    in_region { print }
+  ' "$file"
+}
+
+# Compare a single (group, region, files...) entry. Returns 0 if all files
+# share byte-identical content for the named region, 1 otherwise.
+check_group() {
+  local group="$1" region="$2"
+  shift 2
+  local files=("$@")
+  local ref_file="" ref_content="" failed=0
+
+  for file in "${files[@]}"; do
+    if [[ ! -f "$file" ]]; then
+      echo "FAIL [$group/$region]: missing file: $file" >&2
+      failed=1
+      continue
+    fi
+    # Distinguish "no opening sentinel" from "sentinel pair brackets empty body":
+    # both produce empty extract output, but the former is almost always the bug
+    # (someone renamed the region or forgot to mark a new file), while the
+    # latter is a deliberate placeholder.
+    if ! grep -qFx "# region:$region" "$file"; then
+      echo "FAIL [$group/$region]: region missing in: $file" >&2
+      failed=1
+      continue
+    fi
+    local content
+    content=$(extract_region "$file" "$region")
+    if [[ -z "$content" ]]; then
+      echo "FAIL [$group/$region]: region empty in: $file" >&2
+      failed=1
+      continue
+    fi
+    if [[ -z "$ref_file" ]]; then
+      ref_file="$file"
+      ref_content="$content"
+      continue
+    fi
+    if [[ "$content" != "$ref_content" ]]; then
+      echo "DRIFT [$group/$region]: $file diverges from $ref_file" >&2
+      diff -u --label "$ref_file" --label "$file" \
+        <(printf '%s\n' "$ref_content") \
+        <(printf '%s\n' "$content") >&2 || true
+      failed=1
+    fi
+  done
+
+  return "$failed"
+}
+
+# Read manifest entries from stdin (one per line). Lines starting with '#' or
+# blank lines are skipped.
+run_manifest() {
+  local fail=0 checked=0
+  local line group region files_str
+  while IFS= read -r line || [[ -n "$line" ]]; do
+    [[ -z "$line" || "$line" == \#* ]] && continue
+    IFS='|' read -r group region files_str <<<"$line"
+    # shellcheck disable=SC2206
+    files=($files_str)
+    checked=$((checked + 1))
+    check_group "$group" "$region" "${files[@]}" || fail=1
+  done
+  echo "check-drift: $checked group(s) checked"
+  return "$fail"
+}
+
+main() {
+  if [[ -n "${CHECK_DRIFT_MANIFEST:-}" ]]; then
+    [[ -f "$CHECK_DRIFT_MANIFEST" ]] || {
+      echo "Error: manifest file not found: $CHECK_DRIFT_MANIFEST" >&2
+      exit 2
+    }
+    run_manifest < "$CHECK_DRIFT_MANIFEST"
+  else
+    printf '%s\n' "${GROUPS_DEFAULT[@]}" | run_manifest
+  fi
+}
+
+# Only run main when executed directly (so tests can source this script and
+# call check_group / extract_region without triggering the manifest run).
+if [[ "${BASH_SOURCE[0]}" == "${0}" ]]; then
+  main "$@"
+fi


### PR DESCRIPTION
## Summary

Implements option (A) from #49 — a CI guardrail that catches the "identical patch × 7 loadout files" failure mode behind #32/#38/#40.

- Adds `tools/check-drift.sh`: a ~90-line bash checker that reads a manifest of `(group, region, files)` tuples, extracts each sentinel-marked region with `awk`, and asserts byte-equality. Distinguishes "region missing" (no opening sentinel — almost always a bug) from "region empty" (sentinels bracket nothing — deliberate placeholder) in its error output. Prints a unified diff identifying the drifted file on failure.
- Marks **7** conservative region names with `# region:<name>` / `# endregion:<name>` sentinels across all 7 `task-done` and all 7 `task-work` loadout files — 4 in task-done (`flag-parsing`, `worktree-context`, `diff-summary`, `confirm-and-cleanup`) + 3 in task-work (`lib-source-header`, `worktree-creation-pre-info`, `worktree-creation-post-info`). 12 manifest groups total (some names appear in multiple groups when cluster-A and cluster-C content differs).
- Aligns 5 stray inline comments in `claude-jira/bin/task-done` with the rest of cluster A so all 5 "standard" loadouts share a single group per `task-done` region.
- Adds `tests/drift_check.bats` with positive + 4 negative cases (drift, missing-region, empty-region, missing-manifest-file) plus a regression case against the live repo (6 tests).
- Wires `drift-check` into `.github/workflows/ci.yml` as a third job and extends the shellcheck step to cover `tools/*.sh`.

## Region map

| Region | Files in group |
|---|---|
| `task-done:flag-parsing`, `worktree-context`, `diff-summary`, `confirm-and-cleanup` | claude-gh, claude-jira, claude-notion, kiro-gh, kiro-notion (5) |
| (same 4 names) for cluster C | claude-local, kiro-local (2) |
| `task-work:lib-source-header` | all 7 |
| `task-work:worktree-creation-pre-info` | 6 non-jira |
| `task-work:worktree-creation-post-info` | 3 claude-\* + 3 kiro-\* (two groups) |

`claude-jira`'s task-work has structural differences (no `--no-launch`, different usage shape) that put its pre/post-info regions in a single-file group — drift-checking jira against itself isn't meaningful, so it's omitted from those entries. Folding it in is a follow-up.

## Test plan

- [x] `./run_tests.sh` — 452/452 tests pass on macOS (post-rebase)
- [x] `bash tools/check-drift.sh` — clean repo passes (`12 group(s) checked`, exit 0)
- [x] Deliberately drift one echo string in `claude-gh/bin/task-done` → re-run → exits 1 with a per-file diff
- [x] `shellcheck -x ... tools/*.sh ... */bin/*` — clean
- [x] Rebased onto current `main` (#57's `FROM_REF` plumbing + sentinels both survive; pre-info region stays byte-identical across the 6 non-jira files after the `aw_create_worktree` 3rd-arg rename)
- [ ] CI green (test ×2 OS, lint, drift-check)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
