### PR TITLE
task-done: handle submodules in worktrees instead of silently swallowing the error

### DIFF
--- a/claude-gh/bin/task-done
+++ b/claude-gh/bin/task-done
@@ -95,8 +95,12 @@ cd "$MAIN_WORKTREE"
 
 # Remove worktree
 echo "Removing worktree..."
-git worktree remove "$WORKTREE_DIR" --force 2>/dev/null || {
-  echo "Warning: could not remove worktree cleanly. Trying prune..."
+# Deinit any submodules first — git refuses to remove a worktree containing them.
+if [[ -f "$WORKTREE_DIR/.gitmodules" ]]; then
+  git -C "$WORKTREE_DIR" submodule deinit --all --force >/dev/null 2>&1 || true
+fi
+git worktree remove "$WORKTREE_DIR" --force || {
+  echo "Warning: removal failed, falling back to rm + prune"
   rm -rf "$WORKTREE_DIR"
   git worktree prune
 }

--- a/claude-jira/bin/task-done
+++ b/claude-jira/bin/task-done
@@ -97,8 +97,12 @@ fi
 cd "$MAIN_WORKTREE"
 
 echo "Removing worktree..."
-git worktree remove "$WORKTREE_DIR" --force 2>/dev/null || {
-  echo "Warning: could not remove worktree cleanly. Trying prune..."
+# Deinit any submodules first — git refuses to remove a worktree containing them.
+if [[ -f "$WORKTREE_DIR/.gitmodules" ]]; then
+  git -C "$WORKTREE_DIR" submodule deinit --all --force >/dev/null 2>&1 || true
+fi
+git worktree remove "$WORKTREE_DIR" --force || {
+  echo "Warning: removal failed, falling back to rm + prune"
   rm -rf "$WORKTREE_DIR"
   git worktree prune
 }

--- a/claude-local/bin/task-done
+++ b/claude-local/bin/task-done
@@ -97,8 +97,12 @@ cd "$MAIN_WORKTREE"
 
 # Remove worktree
 echo "Removing worktree..."
-git worktree remove "$WORKTREE_DIR" --force 2>/dev/null || {
-  echo "Warning: could not remove worktree cleanly. Trying prune..."
+# Deinit any submodules first — git refuses to remove a worktree containing them.
+if [[ -f "$WORKTREE_DIR/.gitmodules" ]]; then
+  git -C "$WORKTREE_DIR" submodule deinit --all --force >/dev/null 2>&1 || true
+fi
+git worktree remove "$WORKTREE_DIR" --force || {
+  echo "Warning: removal failed, falling back to rm + prune"
   rm -rf "$WORKTREE_DIR"
   git worktree prune
 }

--- a/claude-notion/bin/task-done
+++ b/claude-notion/bin/task-done
@@ -95,8 +95,12 @@ cd "$MAIN_WORKTREE"
 
 # Remove worktree
 echo "Removing worktree..."
-git worktree remove "$WORKTREE_DIR" --force 2>/dev/null || {
-  echo "Warning: could not remove worktree cleanly. Trying prune..."
+# Deinit any submodules first — git refuses to remove a worktree containing them.
+if [[ -f "$WORKTREE_DIR/.gitmodules" ]]; then
+  git -C "$WORKTREE_DIR" submodule deinit --all --force >/dev/null 2>&1 || true
+fi
+git worktree remove "$WORKTREE_DIR" --force || {
+  echo "Warning: removal failed, falling back to rm + prune"
   rm -rf "$WORKTREE_DIR"
   git worktree prune
 }

--- a/kiro-gh/bin/task-done
+++ b/kiro-gh/bin/task-done
@@ -95,8 +95,12 @@ cd "$MAIN_WORKTREE"
 
 # Remove worktree
 echo "Removing worktree..."
-git worktree remove "$WORKTREE_DIR" --force 2>/dev/null || {
-  echo "Warning: could not remove worktree cleanly. Trying prune..."
+# Deinit any submodules first — git refuses to remove a worktree containing them.
+if [[ -f "$WORKTREE_DIR/.gitmodules" ]]; then
+  git -C "$WORKTREE_DIR" submodule deinit --all --force >/dev/null 2>&1 || true
+fi
+git worktree remove "$WORKTREE_DIR" --force || {
+  echo "Warning: removal failed, falling back to rm + prune"
   rm -rf "$WORKTREE_DIR"
   git worktree prune
 }

--- a/kiro-local/bin/task-done
+++ b/kiro-local/bin/task-done
@@ -97,8 +97,12 @@ cd "$MAIN_WORKTREE"
 
 # Remove worktree
 echo "Removing worktree..."
-git worktree remove "$WORKTREE_DIR" --force 2>/dev/null || {
-  echo "Warning: could not remove worktree cleanly. Trying prune..."
+# Deinit any submodules first — git refuses to remove a worktree containing them.
+if [[ -f "$WORKTREE_DIR/.gitmodules" ]]; then
+  git -C "$WORKTREE_DIR" submodule deinit --all --force >/dev/null 2>&1 || true
+fi
+git worktree remove "$WORKTREE_DIR" --force || {
+  echo "Warning: removal failed, falling back to rm + prune"
   rm -rf "$WORKTREE_DIR"
   git worktree prune
 }

--- a/kiro-notion/bin/task-done
+++ b/kiro-notion/bin/task-done
@@ -95,8 +95,12 @@ cd "$MAIN_WORKTREE"
 
 # Remove worktree
 echo "Removing worktree..."
-git worktree remove "$WORKTREE_DIR" --force 2>/dev/null || {
-  echo "Warning: could not remove worktree cleanly. Trying prune..."
+# Deinit any submodules first — git refuses to remove a worktree containing them.
+if [[ -f "$WORKTREE_DIR/.gitmodules" ]]; then
+  git -C "$WORKTREE_DIR" submodule deinit --all --force >/dev/null 2>&1 || true
+fi
+git worktree remove "$WORKTREE_DIR" --force || {
+  echo "Warning: removal failed, falling back to rm + prune"
   rm -rf "$WORKTREE_DIR"
   git worktree prune
 }

--- a/tests/task_done.bats
+++ b/tests/task_done.bats
@@ -350,3 +350,73 @@ teardown() {
   run git -C "$MAIN_REPO" branch --list "task/$SLUG"
   assert_output --partial "task/$SLUG"
 }
+
+# ---------------------------------------------------------------------------
+# Submodule cleanup (issue #35)
+# Without the deinit step, `git worktree remove` refuses with
+# "fatal: working trees containing submodules cannot be moved or removed".
+# ---------------------------------------------------------------------------
+
+# Initialize a real submodule inside the current worktree.
+# Creates a separate source repo and adds it as a submodule named "lib".
+add_submodule_to_worktree() {
+  local worktree="$1"
+  local submodule_src
+  submodule_src=$(mktemp -d)
+  git -C "$submodule_src" init -q -b main
+  git -C "$submodule_src" config user.email "test@test.local"
+  git -C "$submodule_src" config user.name "Test"
+  touch "$submodule_src/sub.txt"
+  git -C "$submodule_src" add sub.txt
+  git -C "$submodule_src" commit -q -m "init submodule"
+
+  # protocol.file.allow=always is required by modern git for local-path submodules.
+  git -C "$worktree" -c protocol.file.allow=always submodule add -q "$submodule_src" lib
+  git -C "$worktree" commit -q -m "add submodule"
+  # Stash for cleanup
+  echo "$submodule_src" > "$BATS_TEST_TMPDIR/.submodule_src"
+}
+
+teardown_submodule_src() {
+  local src
+  if [[ -f "$BATS_TEST_TMPDIR/.submodule_src" ]]; then
+    src=$(cat "$BATS_TEST_TMPDIR/.submodule_src")
+    [[ -d "$src" ]] && rm -rf "$src"
+  fi
+}
+
+@test "kiro: removes worktree containing initialized submodules without warning" {
+  add_submodule_to_worktree "$WORKTREE_BASE/$SLUG"
+
+  run_task_done "$KIRO_TASK_DONE" --force
+  assert_success
+  refute_output --partial "could not remove worktree cleanly"
+  refute_output --partial "removal failed"
+  assert [ ! -d "$WORKTREE_BASE/$SLUG" ]
+
+  teardown_submodule_src
+}
+
+@test "jira: removes worktree containing initialized submodules without warning" {
+  add_submodule_to_worktree "$WORKTREE_BASE/$SLUG"
+
+  run_task_done "$JIRA_TASK_DONE" --force
+  assert_success
+  refute_output --partial "could not remove worktree cleanly"
+  refute_output --partial "removal failed"
+  assert [ ! -d "$WORKTREE_BASE/$SLUG" ]
+
+  teardown_submodule_src
+}
+
+@test "claude-notion: removes worktree containing initialized submodules without warning" {
+  add_submodule_to_worktree "$WORKTREE_BASE/$SLUG"
+
+  run_task_done "$CLAUDE_NOTION_TASK_DONE" --force
+  assert_success
+  refute_output --partial "could not remove worktree cleanly"
+  refute_output --partial "removal failed"
+  assert [ ! -d "$WORKTREE_BASE/$SLUG" ]
+
+  teardown_submodule_src
+}


### PR DESCRIPTION
## Summary

Closes #35.

- Deinit submodules before `git worktree remove` so removal succeeds git-natively when a worktree contains initialized submodules (e.g. `tests/libs/bats-*`), instead of silently falling through to `rm -rf` + `git worktree prune`.
- Drop `2>/dev/null` on the remove call and tighten the warning, so a *genuine* removal failure surfaces the real git error to the user.
- Applied byte-identically across all seven loadouts' `task-done` scripts (`claude-gh`, `claude-jira`, `claude-local`, `claude-notion`, `kiro-gh`, `kiro-local`, `kiro-notion`).
- Added 3 new bats cases covering the submodule path for `kiro-notion`, `claude-jira`, and `claude-notion` task-done scripts.

## Test plan

- [x] `./run_tests.sh task_done` — 44/44 pass (incl. 3 new submodule cases)
- [x] `./run_tests.sh` (full suite) — 442/442 pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)