### PR TITLE
task-work: refresh local base before forking the worktree (avoid stale-base PRs)

### DIFF
--- a/claude-gh/bin/task-work
+++ b/claude-gh/bin/task-work
@@ -172,6 +172,24 @@ build_claude_cmd() {
 
 # ---------------- worktree creation ----------------
 # region:worktree-creation-pre-info
+# Auto-refresh: if local <base> is strictly behind origin/<base>, fork from
+# origin/<base> instead of the stale local tip. Skipped when --from was given
+# (that flag is the explicit user override). Local-ahead and diverged cases
+# are left alone so unpushed work isn't silently bypassed.
+if [[ -z "$FROM_REF_OVERRIDE" ]]; then
+  git fetch origin "$BASE_BRANCH" --quiet 2>/dev/null || true
+  if git rev-parse --verify --quiet "$BASE_BRANCH" >/dev/null 2>&1 \
+     && git rev-parse --verify --quiet "origin/$BASE_BRANCH" >/dev/null 2>&1; then
+    LOCAL_SHA=$(git rev-parse "$BASE_BRANCH")
+    REMOTE_SHA=$(git rev-parse "origin/$BASE_BRANCH")
+    if [[ "$LOCAL_SHA" != "$REMOTE_SHA" ]] \
+       && git merge-base --is-ancestor "$LOCAL_SHA" "$REMOTE_SHA" 2>/dev/null; then
+      echo "⚠ Local '$BASE_BRANCH' is behind 'origin/$BASE_BRANCH'. Forking from origin/$BASE_BRANCH."
+      FROM_REF="origin/$BASE_BRANCH"
+    fi
+  fi
+fi
+
 if [[ -d "$WORKTREE_DIR" ]]; then
   HASH=$(LC_ALL=C head -c 256 /dev/urandom | LC_ALL=C tr -dc 'a-z0-9' | head -c 5)
   SLUG="${SLUG}-${HASH}"

--- a/claude-jira/bin/task-work
+++ b/claude-jira/bin/task-work
@@ -117,6 +117,24 @@ build_claude_cmd() {
   fi
 }
 
+# Auto-refresh: if local <base> is strictly behind origin/<base>, fork from
+# origin/<base> instead of the stale local tip. Skipped when --from was given
+# (that flag is the explicit user override). Local-ahead and diverged cases
+# are left alone so unpushed work isn't silently bypassed.
+if [[ -z "$FROM_REF_OVERRIDE" ]]; then
+  git fetch origin "$BASE_BRANCH" --quiet 2>/dev/null || true
+  if git rev-parse --verify --quiet "$BASE_BRANCH" >/dev/null 2>&1 \
+     && git rev-parse --verify --quiet "origin/$BASE_BRANCH" >/dev/null 2>&1; then
+    LOCAL_SHA=$(git rev-parse "$BASE_BRANCH")
+    REMOTE_SHA=$(git rev-parse "origin/$BASE_BRANCH")
+    if [[ "$LOCAL_SHA" != "$REMOTE_SHA" ]] \
+       && git merge-base --is-ancestor "$LOCAL_SHA" "$REMOTE_SHA" 2>/dev/null; then
+      echo "⚠ Local '$BASE_BRANCH' is behind 'origin/$BASE_BRANCH'. Forking from origin/$BASE_BRANCH."
+      FROM_REF="origin/$BASE_BRANCH"
+    fi
+  fi
+fi
+
 # Worktree already exists for this Jira key? Spin up a parallel session
 # with a short hash suffix so multiple agents can iterate on the same ticket.
 if [[ -d "$WORKTREE_DIR" ]]; then

--- a/claude-local/bin/task-work
+++ b/claude-local/bin/task-work
@@ -157,6 +157,24 @@ build_claude_cmd() {
 
 # ---------------- worktree creation ----------------
 # region:worktree-creation-pre-info
+# Auto-refresh: if local <base> is strictly behind origin/<base>, fork from
+# origin/<base> instead of the stale local tip. Skipped when --from was given
+# (that flag is the explicit user override). Local-ahead and diverged cases
+# are left alone so unpushed work isn't silently bypassed.
+if [[ -z "$FROM_REF_OVERRIDE" ]]; then
+  git fetch origin "$BASE_BRANCH" --quiet 2>/dev/null || true
+  if git rev-parse --verify --quiet "$BASE_BRANCH" >/dev/null 2>&1 \
+     && git rev-parse --verify --quiet "origin/$BASE_BRANCH" >/dev/null 2>&1; then
+    LOCAL_SHA=$(git rev-parse "$BASE_BRANCH")
+    REMOTE_SHA=$(git rev-parse "origin/$BASE_BRANCH")
+    if [[ "$LOCAL_SHA" != "$REMOTE_SHA" ]] \
+       && git merge-base --is-ancestor "$LOCAL_SHA" "$REMOTE_SHA" 2>/dev/null; then
+      echo "⚠ Local '$BASE_BRANCH' is behind 'origin/$BASE_BRANCH'. Forking from origin/$BASE_BRANCH."
+      FROM_REF="origin/$BASE_BRANCH"
+    fi
+  fi
+fi
+
 if [[ -d "$WORKTREE_DIR" ]]; then
   HASH=$(LC_ALL=C head -c 256 /dev/urandom | LC_ALL=C tr -dc 'a-z0-9' | head -c 5)
   SLUG="${SLUG}-${HASH}"

--- a/claude-notion/bin/task-work
+++ b/claude-notion/bin/task-work
@@ -169,6 +169,24 @@ build_claude_cmd() {
 
 # ---------------- worktree creation ----------------
 # region:worktree-creation-pre-info
+# Auto-refresh: if local <base> is strictly behind origin/<base>, fork from
+# origin/<base> instead of the stale local tip. Skipped when --from was given
+# (that flag is the explicit user override). Local-ahead and diverged cases
+# are left alone so unpushed work isn't silently bypassed.
+if [[ -z "$FROM_REF_OVERRIDE" ]]; then
+  git fetch origin "$BASE_BRANCH" --quiet 2>/dev/null || true
+  if git rev-parse --verify --quiet "$BASE_BRANCH" >/dev/null 2>&1 \
+     && git rev-parse --verify --quiet "origin/$BASE_BRANCH" >/dev/null 2>&1; then
+    LOCAL_SHA=$(git rev-parse "$BASE_BRANCH")
+    REMOTE_SHA=$(git rev-parse "origin/$BASE_BRANCH")
+    if [[ "$LOCAL_SHA" != "$REMOTE_SHA" ]] \
+       && git merge-base --is-ancestor "$LOCAL_SHA" "$REMOTE_SHA" 2>/dev/null; then
+      echo "⚠ Local '$BASE_BRANCH' is behind 'origin/$BASE_BRANCH'. Forking from origin/$BASE_BRANCH."
+      FROM_REF="origin/$BASE_BRANCH"
+    fi
+  fi
+fi
+
 if [[ -d "$WORKTREE_DIR" ]]; then
   HASH=$(LC_ALL=C head -c 256 /dev/urandom | LC_ALL=C tr -dc 'a-z0-9' | head -c 5)
   SLUG="${SLUG}-${HASH}"

--- a/kiro-gh/bin/task-work
+++ b/kiro-gh/bin/task-work
@@ -167,6 +167,24 @@ build_kiro_cmd() {
 
 # ---------------- worktree creation ----------------
 # region:worktree-creation-pre-info
+# Auto-refresh: if local <base> is strictly behind origin/<base>, fork from
+# origin/<base> instead of the stale local tip. Skipped when --from was given
+# (that flag is the explicit user override). Local-ahead and diverged cases
+# are left alone so unpushed work isn't silently bypassed.
+if [[ -z "$FROM_REF_OVERRIDE" ]]; then
+  git fetch origin "$BASE_BRANCH" --quiet 2>/dev/null || true
+  if git rev-parse --verify --quiet "$BASE_BRANCH" >/dev/null 2>&1 \
+     && git rev-parse --verify --quiet "origin/$BASE_BRANCH" >/dev/null 2>&1; then
+    LOCAL_SHA=$(git rev-parse "$BASE_BRANCH")
+    REMOTE_SHA=$(git rev-parse "origin/$BASE_BRANCH")
+    if [[ "$LOCAL_SHA" != "$REMOTE_SHA" ]] \
+       && git merge-base --is-ancestor "$LOCAL_SHA" "$REMOTE_SHA" 2>/dev/null; then
+      echo "⚠ Local '$BASE_BRANCH' is behind 'origin/$BASE_BRANCH'. Forking from origin/$BASE_BRANCH."
+      FROM_REF="origin/$BASE_BRANCH"
+    fi
+  fi
+fi
+
 if [[ -d "$WORKTREE_DIR" ]]; then
   HASH=$(LC_ALL=C head -c 256 /dev/urandom | LC_ALL=C tr -dc 'a-z0-9' | head -c 5)
   SLUG="${SLUG}-${HASH}"

--- a/kiro-local/bin/task-work
+++ b/kiro-local/bin/task-work
@@ -156,6 +156,24 @@ build_kiro_cmd() {
 
 # ---------------- worktree creation ----------------
 # region:worktree-creation-pre-info
+# Auto-refresh: if local <base> is strictly behind origin/<base>, fork from
+# origin/<base> instead of the stale local tip. Skipped when --from was given
+# (that flag is the explicit user override). Local-ahead and diverged cases
+# are left alone so unpushed work isn't silently bypassed.
+if [[ -z "$FROM_REF_OVERRIDE" ]]; then
+  git fetch origin "$BASE_BRANCH" --quiet 2>/dev/null || true
+  if git rev-parse --verify --quiet "$BASE_BRANCH" >/dev/null 2>&1 \
+     && git rev-parse --verify --quiet "origin/$BASE_BRANCH" >/dev/null 2>&1; then
+    LOCAL_SHA=$(git rev-parse "$BASE_BRANCH")
+    REMOTE_SHA=$(git rev-parse "origin/$BASE_BRANCH")
+    if [[ "$LOCAL_SHA" != "$REMOTE_SHA" ]] \
+       && git merge-base --is-ancestor "$LOCAL_SHA" "$REMOTE_SHA" 2>/dev/null; then
+      echo "⚠ Local '$BASE_BRANCH' is behind 'origin/$BASE_BRANCH'. Forking from origin/$BASE_BRANCH."
+      FROM_REF="origin/$BASE_BRANCH"
+    fi
+  fi
+fi
+
 if [[ -d "$WORKTREE_DIR" ]]; then
   HASH=$(LC_ALL=C head -c 256 /dev/urandom | LC_ALL=C tr -dc 'a-z0-9' | head -c 5)
   SLUG="${SLUG}-${HASH}"

--- a/kiro-notion/bin/task-work
+++ b/kiro-notion/bin/task-work
@@ -169,6 +169,24 @@ build_kiro_cmd() {
 # Worktree already exists? Spin up a parallel session with a hash suffix
 # so multiple agents can iterate on the same task at the same time.
 # region:worktree-creation-pre-info
+# Auto-refresh: if local <base> is strictly behind origin/<base>, fork from
+# origin/<base> instead of the stale local tip. Skipped when --from was given
+# (that flag is the explicit user override). Local-ahead and diverged cases
+# are left alone so unpushed work isn't silently bypassed.
+if [[ -z "$FROM_REF_OVERRIDE" ]]; then
+  git fetch origin "$BASE_BRANCH" --quiet 2>/dev/null || true
+  if git rev-parse --verify --quiet "$BASE_BRANCH" >/dev/null 2>&1 \
+     && git rev-parse --verify --quiet "origin/$BASE_BRANCH" >/dev/null 2>&1; then
+    LOCAL_SHA=$(git rev-parse "$BASE_BRANCH")
+    REMOTE_SHA=$(git rev-parse "origin/$BASE_BRANCH")
+    if [[ "$LOCAL_SHA" != "$REMOTE_SHA" ]] \
+       && git merge-base --is-ancestor "$LOCAL_SHA" "$REMOTE_SHA" 2>/dev/null; then
+      echo "⚠ Local '$BASE_BRANCH' is behind 'origin/$BASE_BRANCH'. Forking from origin/$BASE_BRANCH."
+      FROM_REF="origin/$BASE_BRANCH"
+    fi
+  fi
+fi
+
 if [[ -d "$WORKTREE_DIR" ]]; then
   HASH=$(LC_ALL=C head -c 256 /dev/urandom | LC_ALL=C tr -dc 'a-z0-9' | head -c 5)
   SLUG="${SLUG}-${HASH}"

--- a/tests/claude_gh_task_work.bats
+++ b/tests/claude_gh_task_work.bats
@@ -320,6 +320,41 @@ _setup_stale_local_base() {
   rm -rf "$UPSTREAM_DIR"
 }
 
+@test "diverged local + remote: behavior unchanged (no warning, forks from local HEAD)" {
+  local upstream sibling
+  upstream=$(mktemp -d)
+  git -C "$upstream" init -q --bare -b main
+  git -C "$MAIN_REPO" remote add origin "$upstream"
+  git -C "$MAIN_REPO" push -q origin main
+
+  # Local main advances with its own commit.
+  echo "local diverge" > "$MAIN_REPO/local.txt"
+  git -C "$MAIN_REPO" add local.txt
+  git -C "$MAIN_REPO" commit -q -m "local-only"
+  local local_head
+  local_head=$(git -C "$MAIN_REPO" rev-parse main)
+
+  # Remote main advances with a DIFFERENT commit via a sibling clone — true divergence.
+  sibling=$(mktemp -d)
+  git -C "$sibling" clone -q "$upstream" .
+  git -C "$sibling" config user.email "s@s.local"
+  git -C "$sibling" config user.name "S"
+  echo "remote diverge" > "$sibling/remote.txt"
+  git -C "$sibling" add remote.txt
+  git -C "$sibling" commit -q -m "remote-only"
+  git -C "$sibling" push -q origin main
+  rm -rf "$sibling"
+
+  run "$CLAUDE_GH_TASK_WORK" my-feature
+  assert_success
+  refute_output --partial "is behind"
+  local wt_head
+  wt_head=$(git -C "$WORKTREE_BASE/my-feature" rev-parse HEAD)
+  assert_equal "$wt_head" "$local_head"
+
+  rm -rf "$upstream"
+}
+
 @test "no remote configured: auto-refresh is a silent no-op" {
   # No origin set on $MAIN_REPO at all — task-work should just work as before.
   local local_head

--- a/tests/claude_gh_task_work.bats
+++ b/tests/claude_gh_task_work.bats
@@ -209,6 +209,131 @@ teardown() {
 }
 
 # ---------------------------------------------------------------------------
+# Auto-refresh: detect a stale local base and fork from origin/<base>
+# ---------------------------------------------------------------------------
+
+# Wire up $MAIN_REPO to a bare upstream and advance the upstream's main by
+# one commit, leaving local main behind. Prints the upstream's main SHA on
+# stdout so callers can assert against it.
+_setup_stale_local_base() {
+  local upstream
+  upstream=$(mktemp -d)
+  UPSTREAM_DIR="$upstream"  # export so the test can rm -rf it later
+  git -C "$upstream" init -q --bare -b main
+  git -C "$MAIN_REPO" remote add origin "$upstream"
+  git -C "$MAIN_REPO" push -q origin main
+  # Advance upstream main via a sibling clone (no `git pull` in $MAIN_REPO).
+  local sibling
+  sibling=$(mktemp -d)
+  git -C "$sibling" clone -q "$upstream" .
+  git -C "$sibling" config user.email "s@s.local"
+  git -C "$sibling" config user.name "S"
+  echo "remote advance" > "$sibling/remote.txt"
+  git -C "$sibling" add remote.txt
+  git -C "$sibling" commit -q -m "advance remote main"
+  git -C "$sibling" push -q origin main
+  local remote_head
+  remote_head=$(git -C "$sibling" rev-parse HEAD)
+  rm -rf "$sibling"
+  echo "$remote_head"
+}
+
+@test "stale local base: warns and forks from origin/<base>" {
+  local remote_head
+  remote_head=$(_setup_stale_local_base)
+  local local_head
+  local_head=$(git -C "$MAIN_REPO" rev-parse main)
+  [[ "$remote_head" != "$local_head" ]]
+
+  run "$CLAUDE_GH_TASK_WORK" my-feature
+  assert_success
+  assert_output --partial "Local 'main' is behind 'origin/main'"
+  assert_output --partial "Forking from origin/main"
+  local wt_head
+  wt_head=$(git -C "$WORKTREE_BASE/my-feature" rev-parse HEAD)
+  assert_equal "$wt_head" "$remote_head"
+
+  rm -rf "$UPSTREAM_DIR"
+}
+
+@test "local base ahead of remote: behavior unchanged (no warning, forks from HEAD)" {
+  local upstream
+  upstream=$(mktemp -d)
+  git -C "$upstream" init -q --bare -b main
+  git -C "$MAIN_REPO" remote add origin "$upstream"
+  git -C "$MAIN_REPO" push -q origin main
+  # Local main moves ahead; remote stays put.
+  echo "local ahead" > "$MAIN_REPO/local.txt"
+  git -C "$MAIN_REPO" add local.txt
+  git -C "$MAIN_REPO" commit -q -m "local-only commit"
+  local local_head
+  local_head=$(git -C "$MAIN_REPO" rev-parse main)
+
+  run "$CLAUDE_GH_TASK_WORK" my-feature
+  assert_success
+  refute_output --partial "is behind"
+  local wt_head
+  wt_head=$(git -C "$WORKTREE_BASE/my-feature" rev-parse HEAD)
+  assert_equal "$wt_head" "$local_head"
+
+  rm -rf "$upstream"
+}
+
+@test "local base matches remote: behavior unchanged (no warning)" {
+  local upstream
+  upstream=$(mktemp -d)
+  git -C "$upstream" init -q --bare -b main
+  git -C "$MAIN_REPO" remote add origin "$upstream"
+  git -C "$MAIN_REPO" push -q origin main
+  local local_head
+  local_head=$(git -C "$MAIN_REPO" rev-parse main)
+
+  run "$CLAUDE_GH_TASK_WORK" my-feature
+  assert_success
+  refute_output --partial "is behind"
+  local wt_head
+  wt_head=$(git -C "$WORKTREE_BASE/my-feature" rev-parse HEAD)
+  assert_equal "$wt_head" "$local_head"
+
+  rm -rf "$upstream"
+}
+
+@test "stale local base + --from override: --from wins, no auto-refresh" {
+  local remote_head
+  remote_head=$(_setup_stale_local_base)
+  # Create a local feature branch to fork from.
+  git -C "$MAIN_REPO" checkout -q -b feature-w
+  echo "w" > "$MAIN_REPO/w.txt"
+  git -C "$MAIN_REPO" add w.txt
+  git -C "$MAIN_REPO" commit -q -m "w"
+  local feat_head
+  feat_head=$(git -C "$MAIN_REPO" rev-parse HEAD)
+  git -C "$MAIN_REPO" checkout -q main
+
+  run "$CLAUDE_GH_TASK_WORK" --from feature-w stacked
+  assert_success
+  refute_output --partial "is behind"
+  local wt_head
+  wt_head=$(git -C "$WORKTREE_BASE/stacked" rev-parse HEAD)
+  assert_equal "$wt_head" "$feat_head"
+
+  rm -rf "$UPSTREAM_DIR"
+}
+
+@test "no remote configured: auto-refresh is a silent no-op" {
+  # No origin set on $MAIN_REPO at all — task-work should just work as before.
+  local local_head
+  local_head=$(git -C "$MAIN_REPO" rev-parse main)
+
+  run "$CLAUDE_GH_TASK_WORK" my-feature
+  assert_success
+  refute_output --partial "is behind"
+  local wt_head
+  wt_head=$(git -C "$WORKTREE_BASE/my-feature" rev-parse HEAD)
+  assert_equal "$wt_head" "$local_head"
+}
+
+# ---------------------------------------------------------------------------
 # .info file
 # ---------------------------------------------------------------------------
 


### PR DESCRIPTION
## Summary

- Adds an auto-refresh step in each `<impl>/bin/task-work` before `aw_create_worktree`. If the local base branch is strictly behind `origin/<base>` (i.e. local is an ancestor of remote), warn and fork the new worktree from `origin/<base>` instead. Local-ahead and diverged cases are unchanged so unpushed work isn't silently bypassed.
- `--from` always wins over the auto-refresh (explicit user override).
- Applied byte-identically to the 6 non-jira loadouts inside the existing `worktree-creation-pre-info` sentinel region — `tools/check-drift.sh` enforces this. The jira loadout (which lives outside the region) gets the same block.
- New bats coverage in `tests/claude_gh_task_work.bats` for: stale-behind, ahead, equal, `--from` override, and no-remote-configured.

Closes #60

## Test plan

- [x] `./run_tests.sh` — 460/460 green
- [x] `bash tools/check-drift.sh` — passes
- [x] Stale-base scenario: bats test spawns an upstream bare remote, advances it, runs `task-work`, asserts the warning and that the new worktree's HEAD equals the remote tip
- [x] `--from` override path bypasses the auto-refresh
- [x] Local-ahead path leaves behavior unchanged

🤖 Generated with [Claude Code](https://claude.com/claude-code)