### PR TITLE
tests: move temp-dir cleanups into real teardown() (#61)

### DIFF
--- a/tests/claude_gh_task_work.bats
+++ b/tests/claude_gh_task_work.bats
@@ -14,6 +14,11 @@ setup() {
 
 teardown() {
   teardown_all
+  if [[ -f "$BATS_TEST_TMPDIR/.upstream" ]]; then
+    local up
+    up=$(cat "$BATS_TEST_TMPDIR/.upstream")
+    [[ -d "$up" ]] && rm -rf "$up"
+  fi
 }
 
 # ---------------------------------------------------------------------------
@@ -218,7 +223,8 @@ teardown() {
 _setup_stale_local_base() {
   local upstream
   upstream=$(mktemp -d)
-  UPSTREAM_DIR="$upstream"  # export so the test can rm -rf it later
+  UPSTREAM_DIR="$upstream"
+  echo "$upstream" > "$BATS_TEST_TMPDIR/.upstream"
   git -C "$upstream" init -q --bare -b main
   git -C "$MAIN_REPO" remote add origin "$upstream"
   git -C "$MAIN_REPO" push -q origin main
@@ -252,13 +258,12 @@ _setup_stale_local_base() {
   local wt_head
   wt_head=$(git -C "$WORKTREE_BASE/my-feature" rev-parse HEAD)
   assert_equal "$wt_head" "$remote_head"
-
-  rm -rf "$UPSTREAM_DIR"
 }
 
 @test "local base ahead of remote: behavior unchanged (no warning, forks from HEAD)" {
   local upstream
   upstream=$(mktemp -d)
+  echo "$upstream" > "$BATS_TEST_TMPDIR/.upstream"
   git -C "$upstream" init -q --bare -b main
   git -C "$MAIN_REPO" remote add origin "$upstream"
   git -C "$MAIN_REPO" push -q origin main
@@ -275,13 +280,12 @@ _setup_stale_local_base() {
   local wt_head
   wt_head=$(git -C "$WORKTREE_BASE/my-feature" rev-parse HEAD)
   assert_equal "$wt_head" "$local_head"
-
-  rm -rf "$upstream"
 }
 
 @test "local base matches remote: behavior unchanged (no warning)" {
   local upstream
   upstream=$(mktemp -d)
+  echo "$upstream" > "$BATS_TEST_TMPDIR/.upstream"
   git -C "$upstream" init -q --bare -b main
   git -C "$MAIN_REPO" remote add origin "$upstream"
   git -C "$MAIN_REPO" push -q origin main
@@ -294,8 +298,6 @@ _setup_stale_local_base() {
   local wt_head
   wt_head=$(git -C "$WORKTREE_BASE/my-feature" rev-parse HEAD)
   assert_equal "$wt_head" "$local_head"
-
-  rm -rf "$upstream"
 }
 
 @test "stale local base + --from override: --from wins, no auto-refresh" {
@@ -316,13 +318,12 @@ _setup_stale_local_base() {
   local wt_head
   wt_head=$(git -C "$WORKTREE_BASE/stacked" rev-parse HEAD)
   assert_equal "$wt_head" "$feat_head"
-
-  rm -rf "$UPSTREAM_DIR"
 }
 
 @test "diverged local + remote: behavior unchanged (no warning, forks from local HEAD)" {
   local upstream sibling
   upstream=$(mktemp -d)
+  echo "$upstream" > "$BATS_TEST_TMPDIR/.upstream"
   git -C "$upstream" init -q --bare -b main
   git -C "$MAIN_REPO" remote add origin "$upstream"
   git -C "$MAIN_REPO" push -q origin main
@@ -351,8 +352,6 @@ _setup_stale_local_base() {
   local wt_head
   wt_head=$(git -C "$WORKTREE_BASE/my-feature" rev-parse HEAD)
   assert_equal "$wt_head" "$local_head"
-
-  rm -rf "$upstream"
 }
 
 @test "no remote configured: auto-refresh is a silent no-op" {

--- a/tests/task_done.bats
+++ b/tests/task_done.bats
@@ -27,6 +27,11 @@ setup() {
 
 teardown() {
   teardown_all
+  if [[ -f "$BATS_TEST_TMPDIR/.submodule_src" ]]; then
+    local src
+    src=$(cat "$BATS_TEST_TMPDIR/.submodule_src")
+    [[ -d "$src" ]] && rm -rf "$src"
+  fi
 }
 
 # ---------------------------------------------------------------------------
@@ -373,16 +378,8 @@ add_submodule_to_worktree() {
   # protocol.file.allow=always is required by modern git for local-path submodules.
   git -C "$worktree" -c protocol.file.allow=always submodule add -q "$submodule_src" lib
   git -C "$worktree" commit -q -m "add submodule"
-  # Stash for cleanup
+  # Stash for cleanup; teardown() reads this marker.
   echo "$submodule_src" > "$BATS_TEST_TMPDIR/.submodule_src"
-}
-
-teardown_submodule_src() {
-  local src
-  if [[ -f "$BATS_TEST_TMPDIR/.submodule_src" ]]; then
-    src=$(cat "$BATS_TEST_TMPDIR/.submodule_src")
-    [[ -d "$src" ]] && rm -rf "$src"
-  fi
 }
 
 @test "kiro: removes worktree containing initialized submodules without warning" {
@@ -393,8 +390,6 @@ teardown_submodule_src() {
   refute_output --partial "could not remove worktree cleanly"
   refute_output --partial "removal failed"
   assert [ ! -d "$WORKTREE_BASE/$SLUG" ]
-
-  teardown_submodule_src
 }
 
 @test "jira: removes worktree containing initialized submodules without warning" {
@@ -405,8 +400,6 @@ teardown_submodule_src() {
   refute_output --partial "could not remove worktree cleanly"
   refute_output --partial "removal failed"
   assert [ ! -d "$WORKTREE_BASE/$SLUG" ]
-
-  teardown_submodule_src
 }
 
 @test "claude-notion: removes worktree containing initialized submodules without warning" {
@@ -417,6 +410,4 @@ teardown_submodule_src() {
   refute_output --partial "could not remove worktree cleanly"
   refute_output --partial "removal failed"
   assert [ ! -d "$WORKTREE_BASE/$SLUG" ]
-
-  teardown_submodule_src
 }


### PR DESCRIPTION
## Summary
- Move submodule + upstream temp-dir cleanups from inline `rm -rf` at end-of-body into bats' `teardown()` so they fire unconditionally (even on assertion failure).
- Use a `$BATS_TEST_TMPDIR/.<marker>` handshake: helpers stash the temp dir path; teardown reads it and cleans up.
- Drop 3 inline `teardown_submodule_src` calls + the now-dead helper in `tests/task_done.bats`.
- Drop 5 inline `rm -rf "$UPSTREAM_DIR"` / `rm -rf "$upstream"` calls in the auto-refresh tests in `tests/claude_gh_task_work.bats`.

Closes #61.

## Test plan
- [x] `./run_tests.sh task_done` — all 44 pass (including 3 submodule cases).
- [x] `./run_tests.sh claude_gh_task_work` — all 39 pass (including 5 auto-refresh cases).
- [x] Manually broke an assert in `tests/task_done.bats` (kiro submodule case) and ran the suite — failure reported, `/tmp` clean afterwards.
- [x] Manually broke an assert in `tests/claude_gh_task_work.bats` (stale-local-base case) and ran the suite — failure reported, `/tmp` clean afterwards.

🤖 Generated with [Claude Code](https://claude.com/claude-code)