### PR TITLE
Release v0.1.0

### DIFF
--- a/.claude/gh-workflow.md
+++ b/.claude/gh-workflow.md
@@ -51,16 +51,24 @@ Use the issue title as prefix: `<Issue title>: <short description>`
 
 `task-work <slug> [gh-url] [options]` — create worktree + zellij tab + worker session
 
-- `-b, --base BRANCH` — base branch for the PR (default: current branch)
+- `-b, --base BRANCH` — branch the PR will target (default: current branch at call time)
+- `-f, --from REF` — git ref to fork the new worktree's branch from (default: `HEAD`)
+- `-p, --plan` — launch the worker in Claude plan mode (runs `/planner`); mutually exclusive with `--auto`
+- `--auto` — launch the worker in Claude auto permission mode (runs `/worker`); mutually exclusive with `--plan`
 - `--no-launch` — open the worktree tab but do NOT start Claude
+
+If local `<base>` is strictly behind `origin/<base>`, `task-work` auto-refreshes and forks the new worktree from `origin/<base>` instead of the stale local tip. Pass `--from` to override.
 
 Examples:
 ```bash
 task-work add-auth "https://github.com/martin-conur/task-force/issues/42"
 task-work https://github.com/martin-conur/task-force/issues/42
-task-work refactor-auth
+task-work refactor-auth --plan
+task-work issue-99 --from task/issue-46 --base main --auto   # stack on an in-flight branch
 task-work spike-idea --no-launch
 ```
 
-`task-done` — from within worktree: show diff, print/detect PR, cleanup
-`task-done --remove-worktree` — cleanup only (use after worker has already created the PR)
+`task-done [options]` — from within a worktree: show diff, print/detect PR, cleanup
+
+- `--force` — skip all confirmation prompts
+- `--remove-worktree` — cleanup only (use after worker has already created the PR)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,44 @@
+# Changelog
+
+All notable changes to this project will be documented in this file.
+
+The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/), and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
+
+## [Unreleased]
+
+## [0.1.0] — 2026-05-19
+
+First feature release since `v0.0.1`. Highlights: two new local-tracking loadouts (`claude-local`, `kiro-local`), `--from` / `--plan` / `--auto` flags for `task-work`, a CI drift-check guardrail across all 7 loadouts, macOS CI coverage, and a string of safety fixes for `task-done` / submodules / stale-base worktrees.
+
+### Added
+
+- **Loadouts:** `claude-local` and `kiro-local` — local markdown task tracking, no external tracker required (#30, #34)
+- **Loadout docs:** README coverage for the new local loadouts (#33)
+- **Claude slash commands** (`/planner`, `/pm`, `/worker`) + `gh-workflow.md` template installed by `task-init` (#25)
+- **`task-work --from <ref>`:** fork the new worktree's branch from an arbitrary git ref (stacked PRs become first-class); independent of `--base` (#57)
+- **`task-work --plan` / `--auto`:** launch the worker in Claude's plan-mode or auto-permission-mode (Claude loadouts only) (#45)
+- **`task-work` auto-refresh:** if local `<base>` is strictly behind `origin/<base>`, warn and fork from `origin/<base>` instead of stale local tip (#62)
+- **Drift-check guardrail:** `tools/check-drift.sh` + sentinel regions across all 7 loadouts' `task-work` / `task-done`; wired into CI as a third job (#58)
+- **macOS in CI:** Bats runs on both `ubuntu-latest` and `macos-latest` (#56)
+- **LICENSE:** MIT (#51)
+
+### Changed
+
+- `task-init` installs slash commands and agents at the project level instead of overwriting global Claude config (#22)
+- `task-init` **copies** slash commands and agents into the project instead of symlinking — survives re-installs and supports parallel projects (#36)
+- `task-done --remove-worktree` skips the removal confirmation when intent is already declared (#41)
+- `task-done` attempts a safe `git branch -d` after worktree removal — no orphan local branches when the branch is fully merged (#43)
+
+### Fixed
+
+- `task-work` no longer silently reuses an existing branch on name collision — warns loudly with branch-tip and divergence info before reusing (#44)
+- `task-done` no longer silently swallows the *"working trees containing submodules cannot be moved or removed"* error — deinits submodules before `git worktree remove` and surfaces real failures (#59)
+- CI shellcheck now covers all loadouts and is clean across BSD/GNU coreutils on macOS (#52, #55)
+
+### Internal
+
+- Test temp-dir cleanups moved to bats `teardown()` so they fire even on assertion failure (#64)
+- Bats suite at **460 tests** across 7 loadouts × 2 OS
+
+[Unreleased]: https://github.com/martin-conur/task-force/compare/v0.1.0...HEAD
+[0.1.0]: https://github.com/martin-conur/task-force/compare/v0.0.1...v0.1.0

--- a/claude-gh/steering/gh-workflow.example.md
+++ b/claude-gh/steering/gh-workflow.example.md
@@ -51,16 +51,24 @@ Use the issue title as prefix: `<Issue title>: <short description>`
 
 `task-work <slug> [gh-url] [options]` — create worktree + zellij tab + worker session
 
-- `-b, --base BRANCH` — base branch for the PR (default: current branch)
+- `-b, --base BRANCH` — branch the PR will target (default: current branch at call time)
+- `-f, --from REF` — git ref to fork the new worktree's branch from (default: `HEAD`)
+- `-p, --plan` — launch the worker in Claude plan mode (runs `/planner`); mutually exclusive with `--auto`
+- `--auto` — launch the worker in Claude auto permission mode (runs `/worker`); mutually exclusive with `--plan`
 - `--no-launch` — open the worktree tab but do NOT start Claude
+
+If local `<base>` is strictly behind `origin/<base>`, `task-work` auto-refreshes and forks the new worktree from `origin/<base>` instead of the stale local tip. Pass `--from` to override.
 
 Examples:
 ```bash
 task-work add-auth "https://github.com/{OWNER}/{REPO}/issues/42"
 task-work https://github.com/{OWNER}/{REPO}/issues/42
-task-work refactor-auth
+task-work refactor-auth --plan
+task-work issue-99 --from task/issue-46 --base main --auto   # stack on an in-flight branch
 task-work spike-idea --no-launch
 ```
 
-`task-done` — from within worktree: show diff, print/detect PR, cleanup
-`task-done --remove-worktree` — cleanup only (use after worker has already created the PR)
+`task-done [options]` — from within a worktree: show diff, print/detect PR, cleanup
+
+- `--force` — skip all confirmation prompts
+- `--remove-worktree` — cleanup only (use after worker has already created the PR)

--- a/claude-jira/steering/jira-workflow.example.md
+++ b/claude-jira/steering/jira-workflow.example.md
@@ -43,9 +43,27 @@ Reference the Jira key as a prefix: `{KEY}-123: <short description>`
 
 ### Shell Commands
 
-- `task-work <JIRA-KEY-or-url-or-slug>` — create worktree + zellij tab + worker session
-- `task-done` — from within a worktree: show diff, print PR command, cleanup
-- `task-done --remove-worktree` — cleanup only (use after worker has already created the PR)
+`task-work <JIRA-KEY-or-url-or-slug> [options]` — create worktree + zellij tab + worker session
+
+- `-b, --base BRANCH` — branch the PR will target (default: current branch at call time)
+- `-f, --from REF` — git ref to fork the new worktree's branch from (default: `HEAD`)
+- `-p, --plan` — launch the worker in Claude plan mode (runs `/planner`); mutually exclusive with `--auto`
+- `--auto` — launch the worker in Claude auto permission mode (runs `/worker`); mutually exclusive with `--plan`
+
+If local `<base>` is strictly behind `origin/<base>`, `task-work` auto-refreshes and forks the new worktree from `origin/<base>` instead of the stale local tip. Pass `--from` to override.
+
+Examples:
+```bash
+task-work {KEY}-42
+task-work https://{SITE}.atlassian.net/browse/{KEY}-42
+task-work refactor-auth --plan
+task-work {KEY}-99 --from task/{KEY}-46 --base main --auto   # stack on an in-flight branch
+```
+
+`task-done [options]` — from within a worktree: show diff, print/detect PR, cleanup
+
+- `--force` — skip all confirmation prompts
+- `--remove-worktree` — cleanup only (use after worker has already created the PR)
 
 ### Atlassian MCP
 

--- a/claude-local/steering/local-workflow.example.md
+++ b/claude-local/steering/local-workflow.example.md
@@ -72,18 +72,26 @@ Use the task title as prefix: `<Task title>: <short description>`
 
 `task-work tasks/NNN-slug.md [options]` — create worktree + zellij tab + worker session
 
-- `-b, --base BRANCH` — base branch for the PR (default: current branch)
+- `-b, --base BRANCH` — branch the PR will target (default: current branch at call time)
+- `-f, --from REF` — git ref to fork the new worktree's branch from (default: `HEAD`)
+- `-p, --plan` — launch the worker in Claude plan mode (runs `/planner`); mutually exclusive with `--auto`
+- `--auto` — launch the worker in Claude auto permission mode (runs `/worker`); mutually exclusive with `--plan`
 - `--no-launch` — open the worktree tab but do NOT start Claude
+
+If local `<base>` is strictly behind `origin/<base>`, `task-work` auto-refreshes and forks the new worktree from `origin/<base>` instead of the stale local tip. Pass `--from` to override.
 
 Examples:
 ```bash
 task-work tasks/001-add-login-flow.md
-task-work tasks/042-refactor-auth.md --base develop
+task-work tasks/042-refactor-auth.md --base develop --plan
+task-work tasks/050-stacked-feature.md --from task/042-refactor-auth --auto
 task-work tasks/007-spike-idea.md --no-launch
 ```
 
-`task-done` — from within worktree: show diff, print/detect PR, cleanup
-`task-done --remove-worktree` — cleanup only (use after worker has already created the PR)
+`task-done [options]` — from within a worktree: show diff, print/detect PR, cleanup
+
+- `--force` — skip all confirmation prompts
+- `--remove-worktree` — cleanup only (use after worker has already created the PR)
 
 `task-board` — regenerate `tasks/_board.md` from `tasks/*.md` frontmatter +
 `.git/task-force/state.json`. Idempotent; safe to run anytime.

--- a/claude-notion/steering/notion-workflow.example.md
+++ b/claude-notion/steering/notion-workflow.example.md
@@ -66,15 +66,23 @@ Use the task name as prefix: `<Task name>: <description>`
 
 `task-work <slug> [notion-url] [options]` — create worktree + zellij tab + worker session
 
-- `-b, --base BRANCH` — base branch for the PR (default: current branch)
+- `-b, --base BRANCH` — branch the PR will target (default: current branch at call time)
+- `-f, --from REF` — git ref to fork the new worktree's branch from (default: `HEAD`)
+- `-p, --plan` — launch the worker in Claude plan mode (runs `/planner`); mutually exclusive with `--auto`
+- `--auto` — launch the worker in Claude auto permission mode (runs `/worker`); mutually exclusive with `--plan`
 - `--no-launch` — open the worktree tab but do NOT start Claude (lets you type the command yourself)
+
+If local `<base>` is strictly behind `origin/<base>`, `task-work` auto-refreshes and forks the new worktree from `origin/<base>` instead of the stale local tip. Pass `--from` to override.
 
 Examples:
 ```bash
 task-work add-store-filtering https://www.notion.so/My-Task-abc123def456
-task-work refactor-auth
+task-work refactor-auth --plan
+task-work feature-x --from task/in-flight --base main --auto   # stack on an in-flight branch
 task-work spike-idea --no-launch
 ```
 
-`task-done` — from within worktree: show diff, print/detect PR, cleanup
-`task-done --remove-worktree` — cleanup only (use after worker has already created the PR)
+`task-done [options]` — from within a worktree: show diff, print/detect PR, cleanup
+
+- `--force` — skip all confirmation prompts
+- `--remove-worktree` — cleanup only (use after worker has already created the PR)

--- a/kiro-gh/steering/gh-workflow.example.md
+++ b/kiro-gh/steering/gh-workflow.example.md
@@ -44,16 +44,22 @@ Use the issue title as prefix: `<Issue title>: <short description>`
 
 - `-m, --model MODEL` — pick a specific kiro model
 - `-a, --trust-all` — pass `--trust-all-tools` so the worker runs without per-tool confirmation
-- `-b, --base BRANCH` — base branch for the PR (default: current branch)
+- `-b, --base BRANCH` — branch the PR will target (default: current branch at call time)
+- `-f, --from REF` — git ref to fork the new worktree's branch from (default: `HEAD`)
 - `--no-launch` — open the worktree tab but do NOT start kiro
+
+If local `<base>` is strictly behind `origin/<base>`, `task-work` auto-refreshes and forks the new worktree from `origin/<base>` instead of the stale local tip. Pass `--from` to override.
 
 Examples:
 ```bash
 task-work add-auth "https://github.com/{OWNER}/{REPO}/issues/42"
 task-work https://github.com/{OWNER}/{REPO}/issues/42
 task-work refactor-auth -m claude-opus-4.6 --trust-all
+task-work issue-99 --from task/issue-46 --base main         # stack on an in-flight branch
 task-work spike-idea --no-launch
 ```
 
-`task-done` — from within worktree: show diff, print/detect PR, cleanup
-`task-done --remove-worktree` — cleanup only (use after worker has already created the PR)
+`task-done [options]` — from within a worktree: show diff, print/detect PR, cleanup
+
+- `--force` — skip all confirmation prompts
+- `--remove-worktree` — cleanup only (use after worker has already created the PR)

--- a/kiro-local/steering/local-workflow.example.md
+++ b/kiro-local/steering/local-workflow.example.md
@@ -70,18 +70,24 @@ Use the task title as prefix: `<Task title>: <short description>`
 
 - `-m, --model MODEL` — model to pass to `kiro-cli`
 - `-a, --trust-all` — pass `--trust-all-tools` to `kiro-cli`
-- `-b, --base BRANCH` — base branch for the PR (default: current branch)
+- `-b, --base BRANCH` — branch the PR will target (default: current branch at call time)
+- `-f, --from REF` — git ref to fork the new worktree's branch from (default: `HEAD`)
 - `--no-launch` — open the worktree tab but do NOT start `kiro-cli`
+
+If local `<base>` is strictly behind `origin/<base>`, `task-work` auto-refreshes and forks the new worktree from `origin/<base>` instead of the stale local tip. Pass `--from` to override.
 
 Examples:
 ```bash
 task-work tasks/001-add-login-flow.md
 task-work tasks/042-refactor-auth.md --base develop
+task-work tasks/050-stacked-feature.md --from task/042-refactor-auth
 task-work tasks/007-spike-idea.md --no-launch
 ```
 
-`task-done` — from within worktree: show diff, print/detect PR, cleanup
-`task-done --remove-worktree` — cleanup only (use after worker has already created the PR)
+`task-done [options]` — from within a worktree: show diff, print/detect PR, cleanup
+
+- `--force` — skip all confirmation prompts
+- `--remove-worktree` — cleanup only (use after worker has already created the PR)
 
 `task-board` — regenerate `tasks/_board.md` from `tasks/*.md` frontmatter +
 `.git/task-force/state.json`. Idempotent; safe to run anytime.

--- a/kiro-notion/steering/notion-workflow.example.md
+++ b/kiro-notion/steering/notion-workflow.example.md
@@ -41,16 +41,24 @@ Use the task name as prefix: `<Task name>: <description>`
 ### Shell Commands
 
 `task-work <slug> [notion-url] [options]` — create worktree + zellij tab + worker agent
+
 - `-m, --model MODEL` — pick a specific kiro model (e.g. `claude-opus-4.6`, `claude-sonnet-4.6`). Falls back to `$TASK_WORK_MODEL`, else kiro's default (`auto`).
 - `-a, --trust-all` — pass `--trust-all-tools` so the worker runs commands without per-tool confirmation. Defaults to `$TASK_WORK_TRUST_ALL=1` if set.
+- `-b, --base BRANCH` — branch the PR will target (default: current branch at call time)
+- `-f, --from REF` — git ref to fork the new worktree's branch from (default: `HEAD`)
 - `--no-launch` — open the worktree's tab but do NOT start kiro (lets you type the command yourself).
+
+If local `<base>` is strictly behind `origin/<base>`, `task-work` auto-refreshes and forks the new worktree from `origin/<base>` instead of the stale local tip. Pass `--from` to override.
 
 Examples:
 ```bash
 task-work add-store-filtering https://www.notion.so/My-Task-abc123def456
 task-work refactor-auth -m claude-opus-4.6 --trust-all
+task-work feature-x --from task/in-flight --base main       # stack on an in-flight branch
 task-work spike-idea --no-launch
 ```
 
-`task-done` — from within worktree: show diff, print/detect PR, cleanup
-`task-done --remove-worktree` — cleanup only (use after worker has already created the PR)
+`task-done [options]` — from within a worktree: show diff, print/detect PR, cleanup
+
+- `--force` — skip all confirmation prompts
+- `--remove-worktree` — cleanup only (use after worker has already created the PR)


### PR DESCRIPTION
## Summary

First feature release since `v0.0.1`. Bundles:

1. **`CHANGELOG.md`** — new file, Keep-a-Changelog format, covering 19 merged PRs since v0.0.1
2. **Workflow doc refresh** across all 8 workflow markdowns (1 active `.claude/gh-workflow.md` + 7 `*.example.md` templates). They were stuck on the pre-v0.0.1 CLI surface — `--base` and `--no-launch` only — and missed `--from` (#57), `--plan` / `--auto` (#45, Claude loadouts), `--force` for `task-done`, and the auto-refresh behavior from #62.

No code changes; doc-only PR. Drift-check stays clean (12 groups checked).

Closes #50.

## Test plan

- [x] `bash tools/check-drift.sh` — clean
- [x] Spot-check: every Claude workflow file lists `--from`, `--plan`, `--auto`, `--force`; every Kiro workflow file lists `--from`, `--force` (no `--plan` / `--auto` since those are Claude-only)
- [ ] CI green on the doc-only PR

## After merge

- Tag `v0.1.0` on the squash-merge commit
- `gh release create v0.1.0 --notes-file CHANGELOG.md --title "v0.1.0"`

🤖 Generated with [Claude Code](https://claude.com/claude-code)