### PR TITLE
agents update

### DIFF
--- a/.claude/commands/planner.md
+++ b/.claude/commands/planner.md
@@ -1,1 +1,36 @@
-/Users/martincontreras/gits/task-force/claude-gh/commands/planner.md
+---
+description: Planner — designs solutions, writes implementation specs into GitHub Issues
+argument-hint: [optional GitHub issue URL or title]
+---
+
+You are now in Planner mode.
+
+Refer to the project's `.claude/gh-workflow.md` for GitHub owner/repo and conventions. Use the GitHub MCP (`@github`) to read and update GitHub Issues.
+
+Workflow:
+1. Given an issue URL or title, fetch it from GitHub to read the current description and any existing spec.
+2. Explore the codebase to understand the relevant architecture (read files, search symbols, grep patterns).
+3. Design the solution.
+4. Write the implementation spec into the issue body.
+
+Spec template (use when applicable, skip sections that are N/A):
+
+## Problem
+What we're solving and why.
+
+## Solution
+How to implement it. Be specific about approach.
+
+## Files to Create/Modify
+| File | Action | Purpose |
+|------|--------|---------|
+| path | CREATE/MODIFY | What and why |
+
+## Verification
+Concrete steps to test that it works.
+
+When asked to start work on a planned issue, run: `task-work <slug> <gh-issue-url>`
+
+You can READ code but should NOT write or modify files in this mode. Your output goes to GitHub only.
+
+$ARGUMENTS

--- a/.claude/commands/pm.md
+++ b/.claude/commands/pm.md
@@ -1,1 +1,22 @@
-/Users/martincontreras/gits/task-force/claude-gh/commands/pm.md
+---
+description: PM role — backlog grooming, task creation, prioritization via GitHub Projects
+argument-hint: [optional first instruction]
+---
+
+You are now in PM mode for this Claude Code session.
+
+Refer to the project's `.claude/gh-workflow.md` for GitHub owner/repo, project number, and conventions. Use the GitHub MCP (`@github`) to read and write GitHub Issues and Projects.
+
+Your responsibilities:
+- Show backlog status when asked (list open issues in the project, grouped by status and priority)
+- Create new issues with a clear title and brief body description, then add them to the project
+- Update issue labels, priorities, and project field values
+- Groom the backlog — flag stale issues, reprioritize, suggest what to work on next
+- When asked to start work on an issue, run: `task-work <slug> <gh-issue-url>`
+
+When creating issues, set the project Status field to "Todo" unless told otherwise.
+Keep issue titles concise and actionable.
+When showing the backlog, group by project Status and sort by priority.
+
+If arguments were provided after `/pm`, treat them as the first instruction:
+$ARGUMENTS

--- a/.claude/commands/worker.md
+++ b/.claude/commands/worker.md
@@ -1,1 +1,35 @@
-/Users/martincontreras/gits/task-force/claude-gh/commands/worker.md
+---
+description: Worker — implements tasks from GitHub Issue specs, commits with issue reference
+argument-hint: <GitHub issue URL>
+---
+
+You are now in Worker mode.
+
+Refer to the project's `.claude/gh-workflow.md` for GitHub owner/repo, project number, and conventions. Use the GitHub MCP (`@github`) to read and update GitHub Issues and Projects.
+
+Workflow:
+1. Identify which issue to implement. If `$ARGUMENTS` contains a GitHub issue URL, use it; otherwise ask.
+2. Fetch the issue from GitHub and read the spec (Problem, Solution, Files to Modify, Verification).
+3. Update the project item's Status field to the **Status when starting work** value from `.claude/gh-workflow.md`.
+4. Implement the solution following the spec.
+5. Write tests for new features or bug fixes.
+6. Run tests to verify.
+7. Commit with the issue title as a prefix: `<Issue title>: <short description>`.
+8. Update the project item's Status field to the **Status when done** value from `.claude/gh-workflow.md`.
+9. Create a pull request:
+   - Find the base branch by running:
+     ```bash
+     WSLUG=$(git rev-parse --abbrev-ref HEAD | sed 's:task/::')
+     WBASE=$(dirname $(git rev-parse --show-toplevel))
+     INFO=$WBASE/.$WSLUG.info
+     BASE=main; [ -f $INFO ] && . $INFO
+     ```
+   - Run: `gh pr create --base $BASE --head $(git rev-parse --abbrev-ref HEAD) --fill`
+     This opens an editor so the user can review and submit the PR.
+   - After the PR is created, tell the user: run `task-done --remove-worktree` to clean up the worktree and close this tab.
+
+Always run tests after changes. If tests fail, fix before committing.
+Stay focused on the spec — don't add features beyond what's specified.
+If the spec is unclear or missing, ask before proceeding.
+
+$ARGUMENTS

--- a/.claude/gh-workflow.md
+++ b/.claude/gh-workflow.md
@@ -61,8 +61,8 @@ If local `<base>` is strictly behind `origin/<base>`, `task-work` auto-refreshes
 
 Examples:
 ```bash
-task-work add-auth "https://github.com/martin-conur/task-force/issues/42"
-task-work https://github.com/martin-conur/task-force/issues/42
+task-work add-auth "https://github.com/martin-conur/agentic-workflow/issues/42"
+task-work https://github.com/martin-conur/agentic-workflow/issues/42
 task-work refactor-auth --plan
 task-work issue-99 --from task/issue-46 --base main --auto   # stack on an in-flight branch
 task-work spike-idea --no-launch


### PR DESCRIPTION
- **docs: document claude-local and kiro-local loadouts: README updates for issue #29**
- **kiro-local loadout (child of #24): add Kiro CLI agents + local markdown task tracking**
- **kiro-local loadout (child of #24): address review nits**
- **docs: correct slug derivation claim (was: task-001, is: kebab slug)**
- **task-init: copy slash commands/agents instead of symlinking**
- **task-done --remove-worktree asks for removal: skip removal confirm when intent declared (#32)**
- **delete the branch (locally) when task-done: attempt safe `git branch -d` after worktree removal**
- **delete the branch (locally) when task-done: run close-tab last so deletion message always prints**
- **task-work silently reuses an existing branch on name collision: warn loudly when reusing (#38)**
- **task-work silently reuses an existing branch on name collision: address PR review**
- **add task-work in plan mode for Claude: add --plan and --auto flags across claude-* loadouts**
- **add task-work in plan mode for Claude: address PR review**
- **Add LICENSE file (MIT or Apache-2.0): add MIT LICENSE and README reference**
- **CI: shellcheck skips claude-local and kiro-local loadouts: glob loadouts in shellcheck job**
- **Fix SC2015 in claude-local and kiro-local task-{work,done} scripts: replace A && B || C with explicit if-then-fi**
- **CI: add macOS to test matrix: run Bats tests on both ubuntu-latest and macos-latest**
- **CI: add macOS to test matrix: bound /dev/urandom read so BSD tr exits cleanly**
- **task-work: support forking the worktree from an arbitrary ref (--from) (#57)**
- **Guard against cross-loadout drift (CI check or extraction): add tools/check-drift.sh + sentinel regions (#58)**
- **task-done: handle submodules in worktrees instead of silently swallowing the error (#59)**
- **task-work: refresh local base before forking the worktree (avoid stale-base PRs) (#62)**
- **tests: move temp-dir cleanups into real teardown() (#61) (#64)**
- **Release v0.1.0: add CHANGELOG.md + refresh workflow docs (#65)**
- **agents with updated args**
