### PR TITLE
installer prompts: enable readline so arrow keys work (#23)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,10 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 
 ## [Unreleased]
 
+### Fixed
+
+- Installer prompts: arrow keys (↑/↓/←/→) now provide readline navigation instead of echoing raw escape sequences (`^[[A`). Switched `read -rp` → `read -erp` in `install.sh`, `task-init`, and `*/bin/task-init`. (#23)
+
 ## [0.1.0] — 2026-05-19
 
 First feature release since `v0.0.1`. Highlights: two new local-tracking loadouts (`claude-local`, `kiro-local`), `--from` / `--plan` / `--auto` flags for `task-work`, a CI drift-check guardrail across all 7 loadouts, macOS CI coverage, and a string of safety fixes for `task-done` / submodules / stale-base worktrees.

--- a/claude-gh/bin/task-init
+++ b/claude-gh/bin/task-init
@@ -63,22 +63,22 @@ fi
 if [[ -t 0 ]]; then
   if [[ "$OWNER_VIA_FLAG" == false ]]; then
     if [[ -n "$OWNER" ]]; then
-      read -rp "GitHub owner [$OWNER]: " _input
+      read -erp "GitHub owner [$OWNER]: " _input
       [[ -n "${_input:-}" ]] && OWNER="$_input"
     else
-      read -rp "GitHub owner (user or org) [blank → leaves {OWNER}]: " OWNER
+      read -erp "GitHub owner (user or org) [blank → leaves {OWNER}]: " OWNER
     fi
   fi
   if [[ "$REPO_VIA_FLAG" == false ]]; then
     if [[ -n "$REPO" ]]; then
-      read -rp "Repository name [$REPO]: " _input
+      read -erp "Repository name [$REPO]: " _input
       [[ -n "${_input:-}" ]] && REPO="$_input"
     else
-      read -rp "Repository name [blank → leaves {REPO}]: " REPO
+      read -erp "Repository name [blank → leaves {REPO}]: " REPO
     fi
   fi
   if [[ "$PROJECT_VIA_FLAG" == false ]]; then
-    read -rp "Project number (find at: github.com/users/OWNER/projects/N or github.com/orgs/OWNER/projects/N) [blank → leaves {PROJECT}]: " PROJECT
+    read -erp "Project number (find at: github.com/users/OWNER/projects/N or github.com/orgs/OWNER/projects/N) [blank → leaves {PROJECT}]: " PROJECT
   fi
 fi
 

--- a/claude-jira/bin/task-init
+++ b/claude-jira/bin/task-init
@@ -38,13 +38,13 @@ done
 # Interactive prompts when running from a terminal and values are still missing
 if [[ -t 0 ]]; then
   if [[ -z "$SITE" ]]; then
-    read -rp "Jira site URL (e.g. https://acme.atlassian.net) [blank → leaves {SITE}]: " SITE
+    read -erp "Jira site URL (e.g. https://acme.atlassian.net) [blank → leaves {SITE}]: " SITE
   fi
   if [[ -z "$KEY" ]]; then
-    read -rp "Project key (e.g. PROJ) [blank → leaves {KEY}]: " KEY
+    read -erp "Project key (e.g. PROJ) [blank → leaves {KEY}]: " KEY
   fi
   if [[ -z "$BOARD" ]]; then
-    read -rp "Board name (e.g. My Board) [blank → leaves {BOARD}]: " BOARD
+    read -erp "Board name (e.g. My Board) [blank → leaves {BOARD}]: " BOARD
   fi
 fi
 

--- a/install.sh
+++ b/install.sh
@@ -96,7 +96,7 @@ if [[ -z "$TARGET" ]]; then
     echo "Which AI tool?"
     echo "  1) Claude Code"
     echo "  2) Kiro"
-    read -rp "Choice [1-2]: " tool_choice
+    read -erp "Choice [1-2]: " tool_choice
 
     case "$tool_choice" in
       1)
@@ -106,7 +106,7 @@ if [[ -z "$TARGET" ]]; then
         echo "  2) Notion (Notion MCP)"
         echo "  3) GitHub Projects (GitHub MCP)"
         echo "  4) Local markdown (no external tracker)"
-        read -rp "Choice [1-4]: " board_choice
+        read -erp "Choice [1-4]: " board_choice
         case "$board_choice" in
           1) TARGET="claude-jira" ;;
           2) TARGET="claude-notion" ;;
@@ -120,7 +120,7 @@ if [[ -z "$TARGET" ]]; then
         echo "  1) Notion (Notion MCP)"
         echo "  2) GitHub Projects (GitHub MCP)"
         echo "  3) Local markdown (no external tracker)"
-        read -rp "Choice [1-3]: " board_choice
+        read -erp "Choice [1-3]: " board_choice
         case "$board_choice" in
           1) TARGET="kiro-notion" ;;
           2) TARGET="kiro-gh" ;;

--- a/kiro-gh/bin/task-init
+++ b/kiro-gh/bin/task-init
@@ -62,22 +62,22 @@ fi
 if [[ -t 0 ]]; then
   if [[ "$OWNER_VIA_FLAG" == false ]]; then
     if [[ -n "$OWNER" ]]; then
-      read -rp "GitHub owner [$OWNER]: " _input
+      read -erp "GitHub owner [$OWNER]: " _input
       [[ -n "${_input:-}" ]] && OWNER="$_input"
     else
-      read -rp "GitHub owner (user or org) [blank → leaves {OWNER}]: " OWNER
+      read -erp "GitHub owner (user or org) [blank → leaves {OWNER}]: " OWNER
     fi
   fi
   if [[ "$REPO_VIA_FLAG" == false ]]; then
     if [[ -n "$REPO" ]]; then
-      read -rp "Repository name [$REPO]: " _input
+      read -erp "Repository name [$REPO]: " _input
       [[ -n "${_input:-}" ]] && REPO="$_input"
     else
-      read -rp "Repository name [blank → leaves {REPO}]: " REPO
+      read -erp "Repository name [blank → leaves {REPO}]: " REPO
     fi
   fi
   if [[ "$PROJECT_VIA_FLAG" == false ]]; then
-    read -rp "Project number (find at: github.com/users/OWNER/projects/N or github.com/orgs/OWNER/projects/N) [blank → leaves {PROJECT}]: " PROJECT
+    read -erp "Project number (find at: github.com/users/OWNER/projects/N or github.com/orgs/OWNER/projects/N) [blank → leaves {PROJECT}]: " PROJECT
   fi
 fi
 

--- a/task-init
+++ b/task-init
@@ -112,7 +112,7 @@ if [[ -z "$IMPL" ]]; then
     echo "Which AI tool?"
     echo "  1) Claude Code"
     echo "  2) Kiro"
-    read -rp "Choice [1-2]: " tool_choice
+    read -erp "Choice [1-2]: " tool_choice
 
     case "$tool_choice" in
       1)
@@ -122,7 +122,7 @@ if [[ -z "$IMPL" ]]; then
         echo "  2) Notion (Notion MCP)          → .claude/notion-workflow.md + CLAUDE.md"
         echo "  3) GitHub Projects (GitHub MCP) → .claude/gh-workflow.md + CLAUDE.md"
         echo "  4) Local markdown               → .claude/local-workflow.md + CLAUDE.md + tasks/"
-        read -rp "Choice [1-4]: " board_choice
+        read -erp "Choice [1-4]: " board_choice
         case "$board_choice" in
           1) IMPL="claude-jira" ;;
           2) IMPL="claude-notion" ;;
@@ -136,7 +136,7 @@ if [[ -z "$IMPL" ]]; then
         echo "  1) Notion (Notion MCP)          → .kiro/steering/notion-workflow.md"
         echo "  2) GitHub Projects (GitHub MCP) → .kiro/steering/gh-workflow.md"
         echo "  3) Local markdown               → .kiro/steering/local-workflow.md + tasks/"
-        read -rp "Choice [1-3]: " board_choice
+        read -erp "Choice [1-3]: " board_choice
         case "$board_choice" in
           1) IMPL="kiro-notion" ;;
           2) IMPL="kiro-gh" ;;

--- a/tests/readline_flag.bats
+++ b/tests/readline_flag.bats
@@ -2,6 +2,10 @@
 # Regression guard for issue #23: installer prompts must use `read -erp`
 # (readline enabled) so arrow keys provide editing/history instead of
 # echoing raw escape bytes (`^[[A`, `^[[B`, ...).
+#
+# Recursive on purpose — any future loadout that adds a `bin/task-init`
+# or an installer `*.sh` is auto-covered. Vendored bats submodules under
+# tests/libs/ are excluded to avoid upstream false-positives.
 
 bats_load_library bats-support
 bats_load_library bats-assert
@@ -9,14 +13,9 @@ bats_load_library bats-assert
 load helpers/common
 
 @test "installer prompts use 'read -erp' (readline enabled)" {
-  local files=(
-    "$REPO_ROOT_REAL/install.sh"
-    "$REPO_ROOT_REAL/task-init"
-    "$REPO_ROOT_REAL/claude-jira/bin/task-init"
-    "$REPO_ROOT_REAL/claude-gh/bin/task-init"
-    "$REPO_ROOT_REAL/kiro-gh/bin/task-init"
-  )
-  # Match `read -rp` NOT preceded by `-e` (i.e. not `read -erp`). Skip comments.
-  run grep -nE '^[[:space:]]*[^#[:space:]].*\bread -rp\b' "${files[@]}"
+  # Match `read -rp` NOT preceded by `-e` (i.e. not `read -erp`). Skip comment lines.
+  run grep -rnE '^[[:space:]]*[^#[:space:]].*\bread -rp\b' "$REPO_ROOT_REAL" \
+    --include='task-init' --include='*.sh' \
+    --exclude-dir='libs'
   assert_failure
 }

--- a/tests/readline_flag.bats
+++ b/tests/readline_flag.bats
@@ -1,0 +1,22 @@
+#!/usr/bin/env bats
+# Regression guard for issue #23: installer prompts must use `read -erp`
+# (readline enabled) so arrow keys provide editing/history instead of
+# echoing raw escape bytes (`^[[A`, `^[[B`, ...).
+
+bats_load_library bats-support
+bats_load_library bats-assert
+
+load helpers/common
+
+@test "installer prompts use 'read -erp' (readline enabled)" {
+  local files=(
+    "$REPO_ROOT_REAL/install.sh"
+    "$REPO_ROOT_REAL/task-init"
+    "$REPO_ROOT_REAL/claude-jira/bin/task-init"
+    "$REPO_ROOT_REAL/claude-gh/bin/task-init"
+    "$REPO_ROOT_REAL/kiro-gh/bin/task-init"
+  )
+  # Match `read -rp` NOT preceded by `-e` (i.e. not `read -erp`). Skip comments.
+  run grep -nE '^[[:space:]]*[^#[:space:]].*\bread -rp\b' "${files[@]}"
+  assert_failure
+}


### PR DESCRIPTION
## Summary

- Switch every interactive `read -rp` in installer scripts to `read -erp` so arrow keys (↑/↓/←/→) provide readline navigation instead of echoing raw escape bytes (`^[[A`).
- 19 prompts touched across `install.sh`, `task-init`, and `{claude-jira,claude-gh,kiro-gh}/bin/task-init`. Notion / local implementations have no interactive prompts; `task-done` y/N confirms are out of scope (no free-form text input).
- New `tests/readline_flag.bats` — static-grep regression guard asserting no bare `read -rp` survives in installer scripts.
- CHANGELOG: one-line `[Unreleased] / ### Fixed` entry.

Fixes #23.

## Test plan

- [x] `./run_tests.sh` — all 462 tests pass (was 461; +1 from the new regression test)
- [x] `grep -nE '\bread -rp\b' install.sh task-init */bin/task-init` returns nothing
- [ ] Manual smoke in a real terminal: run `claude-jira/bin/task-init`, press ← / ↑ at the "Jira site URL" prompt and confirm the cursor moves / history recalls without `^[[A` echo

🤖 Generated with [Claude Code](https://claude.com/claude-code)