### PR TITLE
task-init: preserve user edits in workflow file when re-initing (#37)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,18 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 
 ## [Unreleased]
 
+### Added
+
+- **`task-init --restore`:** fill in only the files that are missing; never touch anything that already exists. Lets you restore a deleted slash command / agent without re-typing your board IDs. (#37)
+- **`task-init --workflow` / `--commands`:** scope the run to just the workflow doc, or just the slash commands / agents. Compose with `--force` / `--restore` for surgical refreshes. (#37)
+- **Per-file `[k]eep / [o]verwrite / [d]iff` prompt:** in a TTY, when a target already exists `task-init` prompts per file (default = keep). Old behavior was hard-fail with "Use --force." (#37)
+- **Placeholder preservation:** when re-rendering the workflow doc, previously-filled `{OWNER}` / `{REPO}` / `{PROJECT}` / `{SITE}` / `{KEY}` / `{BOARD}` values are carried forward automatically. Precedence: this-run flag → existing-file value → leave the `{PLACEHOLDER}` token. (#37)
+- **Shared helpers:** `lib/install-file.sh` (exists / prompt / diff / overwrite / keep decision) and `lib/preserve-placeholders.sh` (generic placeholder extractor), with unit tests in `tests/install_file.bats` and `tests/preserve_placeholders.bats`. (#37)
+
+### Changed
+
+- **`task-init` no longer hard-fails when target files exist.** In a TTY it now prompts per file (`[k]eep / [o]verwrite / [d]iff`, default = keep). In a non-TTY context it silently skips existing files and exits 0. `--force` (unchanged behavior) remains for unconditional overwrite. (#37)
+
 ### Fixed
 
 - Installer prompts: arrow keys (↑/↓/←/→) now provide readline navigation instead of echoing raw escape sequences (`^[[A`). Switched `read -rp` → `read -erp` in `install.sh`, `task-init`, and `*/bin/task-init`. (#23)

--- a/README.md
+++ b/README.md
@@ -88,6 +88,39 @@ task-init claude-gh
 
 This writes a workflow config (e.g. `.claude/gh-workflow.md` or `.kiro/steering/notion-workflow.md`) so your agents know which board to read from. After that, `task-work` and `task-done` **auto-detect** the right combo from that file — see [How the dispatchers work](#how-the-dispatchers-work).
 
+#### Re-running `task-init`
+
+`task-init` is safe to re-run any time you want to pull in new template scaffolding or restore deleted files. Two orthogonal axes of control:
+
+**Scope** — which categories of files to touch:
+
+| Flag         | Files touched                                           |
+|--------------|---------------------------------------------------------|
+| _(none)_     | workflow doc + slash commands / agents + tasks/ for local |
+| `--workflow` | workflow doc only (+ CLAUDE.md import for Claude loadouts) |
+| `--commands` | slash commands / agents only                            |
+
+**Overwrite policy** — what to do when a target file already exists:
+
+| Flag        | Existing file behavior                                                                  |
+|-------------|-----------------------------------------------------------------------------------------|
+| _(TTY)_     | per-file prompt: `[k]eep / [o]verwrite / [d]iff` (default = keep)                       |
+| _(non-TTY)_ | silently keep (exit 0) — script-safe                                                    |
+| `--force`   | overwrite everything in scope, no prompt                                                |
+| `--restore` | fill missing files only; never touch anything that exists                               |
+
+`--force` and `--restore` are mutually exclusive.
+
+When the workflow doc is re-rendered, previously-filled `{OWNER}` / `{REPO}` / `{PROJECT}` / `{SITE}` / `{KEY}` / `{BOARD}` values are **carried forward automatically**. Precedence: this-run flag → existing-file value → `{PLACEHOLDER}`. So `task-init claude-gh --force` after you've already filled in your IDs does the right thing (refreshes the template, keeps your values).
+
+Common use cases:
+
+```bash
+task-init claude-gh --restore                # restore a deleted slash command, leave everything else alone
+task-init claude-gh --commands --force       # refresh slash commands to current templates
+task-init claude-gh --workflow               # pull in template updates, keep current scope's other files
+```
+
 ### 4. Fly
 
 Open Zellij, start your AI tool, and brief the PM:
@@ -170,7 +203,7 @@ cd ~/my-project
 task-init claude-jira --site https://acme.atlassian.net --key PROJ --board "My Board"
 ```
 
-This writes `.claude/jira-workflow.md` and references it from `CLAUDE.md` so every session loads it. Pass `--force` to overwrite an existing config.
+This writes `.claude/jira-workflow.md` and references it from `CLAUDE.md` so every session loads it. See [Re-running `task-init`](#re-running-task-init) for the `--force` / `--restore` / `--workflow` / `--commands` flags.
 
 | Role | How to invoke |
 |------|---------------|

--- a/claude-gh/bin/task-init
+++ b/claude-gh/bin/task-init
@@ -2,20 +2,34 @@
 set -euo pipefail
 
 usage() {
-  echo "Usage: task-init [--owner OWNER] [--repo REPO] [--project N] [--force]"
-  echo ""
-  echo "Set up the current repo for the claude-gh workflow:"
-  echo "  - Create .claude/gh-workflow.md from the bundled template"
-  echo "  - Substitute owner / repo / project number if provided"
-  echo "    (auto-detected from git remote when possible; missing values prompted interactively)"
-  echo "  - Add @.claude/gh-workflow.md to CLAUDE.md so it auto-loads in every session"
-  echo "  - Install /pm, /planner, /worker slash commands into .claude/commands/"
-  echo ""
-  echo "Options:"
-  echo "  --owner OWNER    GitHub user or org name"
-  echo "  --repo  REPO     Repository name"
-  echo "  --project N      GitHub Projects board number"
-  echo "  --force          Overwrite .claude/gh-workflow.md and project-level slash commands if present"
+  cat <<'EOF'
+Usage: task-init [--owner OWNER] [--repo REPO] [--project N]
+                 [--workflow | --commands]
+                 [--force | --restore]
+
+Set up the current repo for the claude-gh workflow:
+  - Create .claude/gh-workflow.md from the bundled template
+  - Substitute owner / repo / project number if provided
+    (auto-detected from git remote when possible; missing values prompted interactively)
+  - Add @.claude/gh-workflow.md to CLAUDE.md so it auto-loads in every session
+  - Install /pm, /planner, /worker slash commands into .claude/commands/
+
+Scope (which categories of files to touch):
+  --workflow       Workflow doc only (and CLAUDE.md import)
+  --commands       Slash commands only
+  (none)           All of the above (default)
+
+Overwrite policy when a target file already exists:
+  --force          Overwrite all targets (no prompt)
+  --restore        Only fill missing targets; never touch existing files
+  (TTY default)    Per-file prompt: [k]eep / [o]verwrite / [d]iff
+  (non-TTY)        Silently keep existing files (script-safe)
+
+When refreshing an existing workflow doc, previously-filled {OWNER} / {REPO} /
+{PROJECT} values are automatically preserved (this-run flags take precedence).
+
+--force and --restore are mutually exclusive.
+EOF
   exit 1
 }
 
@@ -23,20 +37,41 @@ OWNER=""
 REPO=""
 PROJECT=""
 FORCE=false
+RESTORE=false
+SCOPE="all"
 OWNER_VIA_FLAG=false
 REPO_VIA_FLAG=false
 PROJECT_VIA_FLAG=false
 
 while [[ $# -gt 0 ]]; do
   case "$1" in
-    --owner)   OWNER="$2";   OWNER_VIA_FLAG=true;   shift 2;;
-    --repo)    REPO="$2";    REPO_VIA_FLAG=true;    shift 2;;
-    --project) PROJECT="$2"; PROJECT_VIA_FLAG=true; shift 2;;
-    --force)   FORCE=true; shift;;
-    -h|--help) usage;;
+    --owner)    OWNER="$2";   OWNER_VIA_FLAG=true;   shift 2;;
+    --repo)     REPO="$2";    REPO_VIA_FLAG=true;    shift 2;;
+    --project)  PROJECT="$2"; PROJECT_VIA_FLAG=true; shift 2;;
+    --force)    FORCE=true; shift;;
+    --restore)  RESTORE=true; shift;;
+    --workflow) SCOPE="workflow"; shift;;
+    --commands) SCOPE="commands"; shift;;
+    -h|--help)  usage;;
     *) echo "Unknown option: $1"; usage;;
   esac
 done
+
+if [[ "$FORCE" == true && "$RESTORE" == true ]]; then
+  echo "Error: --force and --restore are mutually exclusive" >&2
+  exit 2
+fi
+
+# Pick the install policy that install_file will consult.
+if [[ "$FORCE" == true ]]; then
+  POLICY="force"
+elif [[ "$RESTORE" == true ]]; then
+  POLICY="restore"
+elif [[ -t 0 ]]; then
+  POLICY="prompt"
+else
+  POLICY="keep"
+fi
 
 # Escape special sed replacement characters (|, &, \) to prevent injection
 _sed_escape() { printf '%s' "$1" | sed 's/[|&\]/\\&/g'; }
@@ -51,37 +86,6 @@ _detect_gh_remote() {
   fi
 }
 
-if [[ "$OWNER_VIA_FLAG" == false ]] || [[ "$REPO_VIA_FLAG" == false ]]; then
-  _detected=$(_detect_gh_remote 2>/dev/null) || true
-  if [[ -n "${_detected:-}" ]]; then
-    [[ "$OWNER_VIA_FLAG" == false ]] && OWNER="${_detected%% *}"
-    [[ "$REPO_VIA_FLAG"  == false ]] && REPO="${_detected##* }"
-  fi
-fi
-
-# Interactive prompts when running from a terminal (skipped for values set via flag)
-if [[ -t 0 ]]; then
-  if [[ "$OWNER_VIA_FLAG" == false ]]; then
-    if [[ -n "$OWNER" ]]; then
-      read -erp "GitHub owner [$OWNER]: " _input
-      [[ -n "${_input:-}" ]] && OWNER="$_input"
-    else
-      read -erp "GitHub owner (user or org) [blank → leaves {OWNER}]: " OWNER
-    fi
-  fi
-  if [[ "$REPO_VIA_FLAG" == false ]]; then
-    if [[ -n "$REPO" ]]; then
-      read -erp "Repository name [$REPO]: " _input
-      [[ -n "${_input:-}" ]] && REPO="$_input"
-    else
-      read -erp "Repository name [blank → leaves {REPO}]: " REPO
-    fi
-  fi
-  if [[ "$PROJECT_VIA_FLAG" == false ]]; then
-    read -erp "Project number (find at: github.com/users/OWNER/projects/N or github.com/orgs/OWNER/projects/N) [blank → leaves {PROJECT}]: " PROJECT
-  fi
-fi
-
 # Resolve script path through symlinks (install.sh symlinks into ~/.local/bin)
 src="${BASH_SOURCE[0]}"
 while [ -L "$src" ]; do
@@ -91,6 +95,11 @@ while [ -L "$src" ]; do
 done
 SCRIPT_DIR=$(cd -P "$(dirname "$src")" && pwd)
 TEMPLATE="$SCRIPT_DIR/../steering/gh-workflow.example.md"
+LIB_DIR="$SCRIPT_DIR/../../lib"
+# shellcheck source=lib/install-file.sh
+. "$LIB_DIR/install-file.sh"
+# shellcheck source=lib/preserve-placeholders.sh
+. "$LIB_DIR/preserve-placeholders.sh"
 
 if [[ ! -f "$TEMPLATE" ]]; then
   echo "Error: template not found at $TEMPLATE"
@@ -104,51 +113,113 @@ CLAUDE_MD="$REPO_ROOT/CLAUDE.md"
 
 mkdir -p "$REPO_ROOT/.claude"
 
-if [[ -f "$TARGET" && "$FORCE" != true ]]; then
-  echo "$TARGET already exists. Use --force to overwrite."
-  exit 1
-fi
-
-sed_args=()
-[[ -n "$OWNER"   ]] && sed_args+=(-e "s|{OWNER}|$(_sed_escape "$OWNER")|g")
-[[ -n "$REPO"    ]] && sed_args+=(-e "s|{REPO}|$(_sed_escape "$REPO")|g")
-[[ -n "$PROJECT" ]] && sed_args+=(-e "s|{PROJECT}|$(_sed_escape "$PROJECT")|g")
-
-if [[ ${#sed_args[@]} -gt 0 ]]; then
-  sed "${sed_args[@]}" "$TEMPLATE" > "$TARGET"
-else
-  cp "$TEMPLATE" "$TARGET"
-fi
-echo "✓ Wrote $TARGET"
-
-IMPORT_LINE="@.claude/gh-workflow.md"
-if [[ -f "$CLAUDE_MD" ]]; then
-  if grep -qF "$IMPORT_LINE" "$CLAUDE_MD"; then
-    echo "✓ CLAUDE.md already references gh-workflow.md"
-  else
-    printf '\n%s\n' "$IMPORT_LINE" >> "$CLAUDE_MD"
-    echo "✓ Appended $IMPORT_LINE to CLAUDE.md"
+# Loadout-specific placeholder extractor. Fills in OWNER / REPO / PROJECT from
+# an existing workflow file when the user did not pass a flag and the variable
+# is still empty (interactive prompts run after this so the user can still
+# override).
+_preserve_placeholders() {
+  local existing="$1"
+  [[ -f "$existing" ]] || return 0
+  local v
+  if [[ "$OWNER_VIA_FLAG" == false && -z "$OWNER" ]]; then
+    v=$(extract_existing_value "$existing" '^- \*\*Owner\*\*: `([^`]+)`.*' '{OWNER}')
+    if [[ -n "$v" ]]; then OWNER="$v"; fi
   fi
-else
-  printf '%s\n' "$IMPORT_LINE" > "$CLAUDE_MD"
-  echo "✓ Created CLAUDE.md with $IMPORT_LINE"
+  if [[ "$REPO_VIA_FLAG" == false && -z "$REPO" ]]; then
+    v=$(extract_existing_value "$existing" '^- \*\*Repo\*\*: `([^`]+)`.*' '{REPO}')
+    if [[ -n "$v" ]]; then REPO="$v"; fi
+  fi
+  if [[ "$PROJECT_VIA_FLAG" == false && -z "$PROJECT" ]]; then
+    v=$(extract_existing_value "$existing" '^- \*\*Project number\*\*: `([^`]+)`.*' '{PROJECT}')
+    if [[ -n "$v" ]]; then PROJECT="$v"; fi
+  fi
+  return 0
+}
+
+# Only do prompts / detect / placeholder preservation when we're actually going
+# to render the workflow.
+if [[ "$SCOPE" != "commands" ]]; then
+  _preserve_placeholders "$TARGET"
+
+  if [[ "$OWNER_VIA_FLAG" == false ]] || [[ "$REPO_VIA_FLAG" == false ]]; then
+    _detected=$(_detect_gh_remote 2>/dev/null) || true
+    if [[ -n "${_detected:-}" ]]; then
+      [[ "$OWNER_VIA_FLAG" == false && -z "$OWNER" ]] && OWNER="${_detected%% *}"
+      [[ "$REPO_VIA_FLAG"  == false && -z "$REPO"  ]] && REPO="${_detected##* }"
+    fi
+  fi
+
+  # Interactive prompts when running from a terminal (skipped for values set via flag).
+  if [[ -t 0 ]]; then
+    if [[ "$OWNER_VIA_FLAG" == false ]]; then
+      if [[ -n "$OWNER" ]]; then
+        read -erp "GitHub owner [$OWNER]: " _input
+        [[ -n "${_input:-}" ]] && OWNER="$_input"
+      else
+        read -erp "GitHub owner (user or org) [blank → leaves {OWNER}]: " OWNER
+      fi
+    fi
+    if [[ "$REPO_VIA_FLAG" == false ]]; then
+      if [[ -n "$REPO" ]]; then
+        read -erp "Repository name [$REPO]: " _input
+        [[ -n "${_input:-}" ]] && REPO="$_input"
+      else
+        read -erp "Repository name [blank → leaves {REPO}]: " REPO
+      fi
+    fi
+    if [[ "$PROJECT_VIA_FLAG" == false ]]; then
+      if [[ -n "$PROJECT" ]]; then
+        read -erp "Project number [$PROJECT]: " _input
+        [[ -n "${_input:-}" ]] && PROJECT="$_input"
+      else
+        read -erp "Project number (find at: github.com/users/OWNER/projects/N or github.com/orgs/OWNER/projects/N) [blank → leaves {PROJECT}]: " PROJECT
+      fi
+    fi
+  fi
+
+  # Render the template into a temp file, then hand to install_file so the
+  # overwrite policy (force / restore / prompt / keep) is honored uniformly.
+  TMP_RENDERED=$(mktemp)
+  trap 'rm -f "$TMP_RENDERED"' EXIT
+
+  sed_args=()
+  [[ -n "$OWNER"   ]] && sed_args+=(-e "s|{OWNER}|$(_sed_escape "$OWNER")|g")
+  [[ -n "$REPO"    ]] && sed_args+=(-e "s|{REPO}|$(_sed_escape "$REPO")|g")
+  [[ -n "$PROJECT" ]] && sed_args+=(-e "s|{PROJECT}|$(_sed_escape "$PROJECT")|g")
+
+  if [[ ${#sed_args[@]} -gt 0 ]]; then
+    sed "${sed_args[@]}" "$TEMPLATE" > "$TMP_RENDERED"
+  else
+    cp "$TEMPLATE" "$TMP_RENDERED"
+  fi
+
+  INSTALL_POLICY="$POLICY" install_file "$TMP_RENDERED" "$TARGET" "gh-workflow.md"
+
+  IMPORT_LINE="@.claude/gh-workflow.md"
+  if [[ -f "$CLAUDE_MD" ]]; then
+    if grep -qF "$IMPORT_LINE" "$CLAUDE_MD"; then
+      echo "✓ CLAUDE.md already references gh-workflow.md"
+    else
+      printf '\n%s\n' "$IMPORT_LINE" >> "$CLAUDE_MD"
+      echo "✓ Appended $IMPORT_LINE to CLAUDE.md"
+    fi
+  else
+    printf '%s\n' "$IMPORT_LINE" > "$CLAUDE_MD"
+    echo "✓ Created CLAUDE.md with $IMPORT_LINE"
+  fi
 fi
 
 # Project-level slash commands → <project>/.claude/commands/
-COMMANDS_DIR="$REPO_ROOT/.claude/commands"
-COMMANDS_SRC=$(cd "$SCRIPT_DIR/.." && pwd)/commands
-mkdir -p "$COMMANDS_DIR"
-for cmd in "$COMMANDS_SRC"/*.md; do
-  cmd_name=$(basename "$cmd")
-  cmd_target="$COMMANDS_DIR/$cmd_name"
-  if [[ ( -e "$cmd_target" || -L "$cmd_target" ) && "$FORCE" != true ]]; then
-    echo "⚠ $cmd_target already exists — skipping (use --force to overwrite)"
-  else
-    rm -f "$cmd_target"
-    cp "$cmd" "$cmd_target"
-    echo "✓ Slash command: /$(basename "$cmd_name" .md)"
-  fi
-done
+if [[ "$SCOPE" != "workflow" ]]; then
+  COMMANDS_DIR="$REPO_ROOT/.claude/commands"
+  COMMANDS_SRC=$(cd "$SCRIPT_DIR/.." && pwd)/commands
+  mkdir -p "$COMMANDS_DIR"
+  for cmd in "$COMMANDS_SRC"/*.md; do
+    cmd_name=$(basename "$cmd")
+    cmd_target="$COMMANDS_DIR/$cmd_name"
+    INSTALL_POLICY="$POLICY" install_file "$cmd" "$cmd_target" "/$(basename "$cmd_name" .md)"
+  done
+fi
 
 echo ""
 echo "Done. Open .claude/gh-workflow.md to fill in any remaining {placeholders}."

--- a/claude-jira/bin/task-init
+++ b/claude-jira/bin/task-init
@@ -2,20 +2,34 @@
 set -euo pipefail
 
 usage() {
-  echo "Usage: task-init [--site URL] [--key PROJ] [--board NAME] [--force]"
-  echo ""
-  echo "Set up the current repo for the claude-jira workflow:"
-  echo "  - Create .claude/jira-workflow.md from the bundled template"
-  echo "  - Substitute site / project key / board name if provided"
-  echo "    (missing values are prompted interactively; blank input leaves {placeholders})"
-  echo "  - Add @.claude/jira-workflow.md to CLAUDE.md so it auto-loads in every session"
-  echo "  - Install /pm, /planner, /worker slash commands into .claude/commands/"
-  echo ""
-  echo "Options:"
-  echo "  --site URL       e.g. https://acme.atlassian.net"
-  echo "  --key  PROJ      Jira project key (e.g. ML)"
-  echo "  --board NAME     Board name (quote if it has spaces)"
-  echo "  --force          Overwrite .claude/jira-workflow.md and project-level slash commands if present"
+  cat <<'EOF'
+Usage: task-init [--site URL] [--key PROJ] [--board NAME]
+                 [--workflow | --commands]
+                 [--force | --restore]
+
+Set up the current repo for the claude-jira workflow:
+  - Create .claude/jira-workflow.md from the bundled template
+  - Substitute site / project key / board name if provided
+    (missing values are prompted interactively; blank input leaves {placeholders})
+  - Add @.claude/jira-workflow.md to CLAUDE.md so it auto-loads in every session
+  - Install /pm, /planner, /worker slash commands into .claude/commands/
+
+Scope (which categories of files to touch):
+  --workflow       Workflow doc only (and CLAUDE.md import)
+  --commands       Slash commands only
+  (none)           All of the above (default)
+
+Overwrite policy when a target file already exists:
+  --force          Overwrite all targets (no prompt)
+  --restore        Only fill missing targets; never touch existing files
+  (TTY default)    Per-file prompt: [k]eep / [o]verwrite / [d]iff
+  (non-TTY)        Silently keep existing files (script-safe)
+
+When refreshing an existing workflow doc, previously-filled {SITE} / {KEY} /
+{BOARD} values are automatically preserved (this-run flags take precedence).
+
+--force and --restore are mutually exclusive.
+EOF
   exit 1
 }
 
@@ -23,29 +37,39 @@ SITE=""
 KEY=""
 BOARD=""
 FORCE=false
+RESTORE=false
+SCOPE="all"
+SITE_VIA_FLAG=false
+KEY_VIA_FLAG=false
+BOARD_VIA_FLAG=false
 
 while [[ $# -gt 0 ]]; do
   case "$1" in
-    --site)    SITE="$2"; shift 2;;
-    --key)     KEY="$2"; shift 2;;
-    --board)   BOARD="$2"; shift 2;;
-    --force)   FORCE=true; shift;;
-    -h|--help) usage;;
+    --site)     SITE="$2";  SITE_VIA_FLAG=true;  shift 2;;
+    --key)      KEY="$2";   KEY_VIA_FLAG=true;   shift 2;;
+    --board)    BOARD="$2"; BOARD_VIA_FLAG=true; shift 2;;
+    --force)    FORCE=true; shift;;
+    --restore)  RESTORE=true; shift;;
+    --workflow) SCOPE="workflow"; shift;;
+    --commands) SCOPE="commands"; shift;;
+    -h|--help)  usage;;
     *) echo "Unknown option: $1"; usage;;
   esac
 done
 
-# Interactive prompts when running from a terminal and values are still missing
-if [[ -t 0 ]]; then
-  if [[ -z "$SITE" ]]; then
-    read -erp "Jira site URL (e.g. https://acme.atlassian.net) [blank → leaves {SITE}]: " SITE
-  fi
-  if [[ -z "$KEY" ]]; then
-    read -erp "Project key (e.g. PROJ) [blank → leaves {KEY}]: " KEY
-  fi
-  if [[ -z "$BOARD" ]]; then
-    read -erp "Board name (e.g. My Board) [blank → leaves {BOARD}]: " BOARD
-  fi
+if [[ "$FORCE" == true && "$RESTORE" == true ]]; then
+  echo "Error: --force and --restore are mutually exclusive" >&2
+  exit 2
+fi
+
+if [[ "$FORCE" == true ]]; then
+  POLICY="force"
+elif [[ "$RESTORE" == true ]]; then
+  POLICY="restore"
+elif [[ -t 0 ]]; then
+  POLICY="prompt"
+else
+  POLICY="keep"
 fi
 
 # Resolve script path through symlinks (install.sh symlinks into ~/.local/bin)
@@ -57,6 +81,11 @@ while [ -L "$src" ]; do
 done
 SCRIPT_DIR=$(cd -P "$(dirname "$src")" && pwd)
 TEMPLATE="$SCRIPT_DIR/../steering/jira-workflow.example.md"
+LIB_DIR="$SCRIPT_DIR/../../lib"
+# shellcheck source=lib/install-file.sh
+. "$LIB_DIR/install-file.sh"
+# shellcheck source=lib/preserve-placeholders.sh
+. "$LIB_DIR/preserve-placeholders.sh"
 
 if [[ ! -f "$TEMPLATE" ]]; then
   echo "Error: template not found at $TEMPLATE"
@@ -70,51 +99,96 @@ CLAUDE_MD="$REPO_ROOT/CLAUDE.md"
 
 mkdir -p "$REPO_ROOT/.claude"
 
-if [[ -f "$TARGET" && "$FORCE" != true ]]; then
-  echo "$TARGET already exists. Use --force to overwrite."
-  exit 1
-fi
-
-sed_args=()
-[[ -n "$SITE"  ]] && sed_args+=(-e "s|{SITE}|$SITE|g")
-[[ -n "$KEY"   ]] && sed_args+=(-e "s/{KEY}/$KEY/g")
-[[ -n "$BOARD" ]] && sed_args+=(-e "s|{BOARD}|$BOARD|g")
-
-if [[ ${#sed_args[@]} -gt 0 ]]; then
-  sed "${sed_args[@]}" "$TEMPLATE" > "$TARGET"
-else
-  cp "$TEMPLATE" "$TARGET"
-fi
-echo "✓ Wrote $TARGET"
-
-IMPORT_LINE="@.claude/jira-workflow.md"
-if [[ -f "$CLAUDE_MD" ]]; then
-  if grep -qF "$IMPORT_LINE" "$CLAUDE_MD"; then
-    echo "✓ CLAUDE.md already references jira-workflow.md"
-  else
-    printf '\n%s\n' "$IMPORT_LINE" >> "$CLAUDE_MD"
-    echo "✓ Appended $IMPORT_LINE to CLAUDE.md"
+_preserve_placeholders() {
+  local existing="$1"
+  [[ -f "$existing" ]] || return 0
+  local v
+  if [[ "$SITE_VIA_FLAG" == false && -z "$SITE" ]]; then
+    v=$(extract_existing_value "$existing" '^- \*\*Site\*\*: `([^`]+)`.*' '{SITE}')
+    if [[ -n "$v" ]]; then SITE="$v"; fi
   fi
-else
-  printf '%s\n' "$IMPORT_LINE" > "$CLAUDE_MD"
-  echo "✓ Created CLAUDE.md with $IMPORT_LINE"
+  if [[ "$KEY_VIA_FLAG" == false && -z "$KEY" ]]; then
+    v=$(extract_existing_value "$existing" '^- \*\*Project key\(s\)\*\*: `([^`]+)`.*' '{KEY}')
+    if [[ -n "$v" ]]; then KEY="$v"; fi
+  fi
+  if [[ "$BOARD_VIA_FLAG" == false && -z "$BOARD" ]]; then
+    v=$(extract_existing_value "$existing" '^- \*\*Board name\*\*: `([^`]+)`.*' '{BOARD}')
+    if [[ -n "$v" ]]; then BOARD="$v"; fi
+  fi
+  return 0
+}
+
+if [[ "$SCOPE" != "commands" ]]; then
+  _preserve_placeholders "$TARGET"
+
+  # Interactive prompts when running from a terminal and values are still missing
+  if [[ -t 0 ]]; then
+    if [[ "$SITE_VIA_FLAG" == false ]]; then
+      if [[ -n "$SITE" ]]; then
+        read -erp "Jira site URL [$SITE]: " _input
+        [[ -n "${_input:-}" ]] && SITE="$_input"
+      else
+        read -erp "Jira site URL (e.g. https://acme.atlassian.net) [blank → leaves {SITE}]: " SITE
+      fi
+    fi
+    if [[ "$KEY_VIA_FLAG" == false ]]; then
+      if [[ -n "$KEY" ]]; then
+        read -erp "Project key [$KEY]: " _input
+        [[ -n "${_input:-}" ]] && KEY="$_input"
+      else
+        read -erp "Project key (e.g. PROJ) [blank → leaves {KEY}]: " KEY
+      fi
+    fi
+    if [[ "$BOARD_VIA_FLAG" == false ]]; then
+      if [[ -n "$BOARD" ]]; then
+        read -erp "Board name [$BOARD]: " _input
+        [[ -n "${_input:-}" ]] && BOARD="$_input"
+      else
+        read -erp "Board name (e.g. My Board) [blank → leaves {BOARD}]: " BOARD
+      fi
+    fi
+  fi
+
+  TMP_RENDERED=$(mktemp)
+  trap 'rm -f "$TMP_RENDERED"' EXIT
+
+  sed_args=()
+  [[ -n "$SITE"  ]] && sed_args+=(-e "s|{SITE}|$SITE|g")
+  [[ -n "$KEY"   ]] && sed_args+=(-e "s/{KEY}/$KEY/g")
+  [[ -n "$BOARD" ]] && sed_args+=(-e "s|{BOARD}|$BOARD|g")
+
+  if [[ ${#sed_args[@]} -gt 0 ]]; then
+    sed "${sed_args[@]}" "$TEMPLATE" > "$TMP_RENDERED"
+  else
+    cp "$TEMPLATE" "$TMP_RENDERED"
+  fi
+
+  INSTALL_POLICY="$POLICY" install_file "$TMP_RENDERED" "$TARGET" "jira-workflow.md"
+
+  IMPORT_LINE="@.claude/jira-workflow.md"
+  if [[ -f "$CLAUDE_MD" ]]; then
+    if grep -qF "$IMPORT_LINE" "$CLAUDE_MD"; then
+      echo "✓ CLAUDE.md already references jira-workflow.md"
+    else
+      printf '\n%s\n' "$IMPORT_LINE" >> "$CLAUDE_MD"
+      echo "✓ Appended $IMPORT_LINE to CLAUDE.md"
+    fi
+  else
+    printf '%s\n' "$IMPORT_LINE" > "$CLAUDE_MD"
+    echo "✓ Created CLAUDE.md with $IMPORT_LINE"
+  fi
 fi
 
-# Project-level slash commands → <project>/.claude/commands/
-COMMANDS_DIR="$REPO_ROOT/.claude/commands"
-COMMANDS_SRC=$(cd "$SCRIPT_DIR/.." && pwd)/commands
-mkdir -p "$COMMANDS_DIR"
-for cmd in "$COMMANDS_SRC"/*.md; do
-  cmd_name=$(basename "$cmd")
-  cmd_target="$COMMANDS_DIR/$cmd_name"
-  if [[ ( -e "$cmd_target" || -L "$cmd_target" ) && "$FORCE" != true ]]; then
-    echo "⚠ $cmd_target already exists — skipping (use --force to overwrite)"
-  else
-    rm -f "$cmd_target"
-    cp "$cmd" "$cmd_target"
-    echo "✓ Slash command: /$(basename "$cmd_name" .md)"
-  fi
-done
+if [[ "$SCOPE" != "workflow" ]]; then
+  COMMANDS_DIR="$REPO_ROOT/.claude/commands"
+  COMMANDS_SRC=$(cd "$SCRIPT_DIR/.." && pwd)/commands
+  mkdir -p "$COMMANDS_DIR"
+  for cmd in "$COMMANDS_SRC"/*.md; do
+    cmd_name=$(basename "$cmd")
+    cmd_target="$COMMANDS_DIR/$cmd_name"
+    INSTALL_POLICY="$POLICY" install_file "$cmd" "$cmd_target" "/$(basename "$cmd_name" .md)"
+  done
+fi
 
 echo ""
 echo "Done. Open .claude/jira-workflow.md to fill in any remaining {placeholders}."

--- a/claude-local/bin/task-init
+++ b/claude-local/bin/task-init
@@ -2,29 +2,61 @@
 set -euo pipefail
 
 usage() {
-  echo "Usage: task-init [--force]"
-  echo ""
-  echo "Set up the current repo for the claude-local workflow:"
-  echo "  - Create .claude/local-workflow.md from the bundled template"
-  echo "  - Add @.claude/local-workflow.md to CLAUDE.md so it auto-loads in every session"
-  echo "  - Install /pm, /planner, /worker slash commands into .claude/commands/"
-  echo "  - Create tasks/{README.md, _board.md} with starter content"
-  echo "  - Append .git/task-force/ to .gitignore (create if missing)"
-  echo ""
-  echo "Options:"
-  echo "  --force   Overwrite .claude/local-workflow.md and project-level slash commands if present"
+  cat <<'EOF'
+Usage: task-init [--workflow | --commands] [--force | --restore]
+
+Set up the current repo for the claude-local workflow:
+  - Create .claude/local-workflow.md from the bundled template
+  - Add @.claude/local-workflow.md to CLAUDE.md so it auto-loads in every session
+  - Install /pm, /planner, /worker slash commands into .claude/commands/
+  - Create tasks/{README.md, _board.md} with starter content
+  - Append .git/task-force/ to .gitignore (create if missing)
+
+Scope (which categories of files to touch):
+  --workflow       Workflow doc only (and CLAUDE.md import / tasks scaffolding)
+  --commands       Slash commands only
+  (none)           All of the above (default)
+
+Overwrite policy when a target file already exists:
+  --force          Overwrite all targets (no prompt)
+  --restore        Only fill missing targets; never touch existing files
+  (TTY default)    Per-file prompt: [k]eep / [o]verwrite / [d]iff
+  (non-TTY)        Silently keep existing files (script-safe)
+
+--force and --restore are mutually exclusive.
+EOF
   exit 1
 }
 
 FORCE=false
+RESTORE=false
+SCOPE="all"
 
 while [[ $# -gt 0 ]]; do
   case "$1" in
-    --force)   FORCE=true; shift;;
-    -h|--help) usage;;
+    --force)    FORCE=true; shift;;
+    --restore)  RESTORE=true; shift;;
+    --workflow) SCOPE="workflow"; shift;;
+    --commands) SCOPE="commands"; shift;;
+    -h|--help)  usage;;
     *) echo "Unknown option: $1"; usage;;
   esac
 done
+
+if [[ "$FORCE" == true && "$RESTORE" == true ]]; then
+  echo "Error: --force and --restore are mutually exclusive" >&2
+  exit 2
+fi
+
+if [[ "$FORCE" == true ]]; then
+  POLICY="force"
+elif [[ "$RESTORE" == true ]]; then
+  POLICY="restore"
+elif [[ -t 0 ]]; then
+  POLICY="prompt"
+else
+  POLICY="keep"
+fi
 
 # Resolve script path through symlinks (install.sh symlinks into ~/.local/bin)
 src="${BASH_SOURCE[0]}"
@@ -35,6 +67,9 @@ while [ -L "$src" ]; do
 done
 SCRIPT_DIR=$(cd -P "$(dirname "$src")" && pwd)
 TEMPLATE="$SCRIPT_DIR/../steering/local-workflow.example.md"
+LIB_DIR="$SCRIPT_DIR/../../lib"
+# shellcheck source=lib/install-file.sh
+. "$LIB_DIR/install-file.sh"
 
 if [[ ! -f "$TEMPLATE" ]]; then
   echo "Error: template not found at $TEMPLATE"
@@ -50,48 +85,41 @@ TASKS_DIR="$REPO_ROOT/tasks"
 
 mkdir -p "$REPO_ROOT/.claude"
 
-if [[ -f "$TARGET" && "$FORCE" != true ]]; then
-  echo "$TARGET already exists. Use --force to overwrite."
-  exit 1
+# The local template has no placeholders — just install the raw template.
+if [[ "$SCOPE" != "commands" ]]; then
+  INSTALL_POLICY="$POLICY" install_file "$TEMPLATE" "$TARGET" "local-workflow.md"
+
+  IMPORT_LINE="@.claude/local-workflow.md"
+  if [[ -f "$CLAUDE_MD" ]]; then
+    if grep -qF "$IMPORT_LINE" "$CLAUDE_MD"; then
+      echo "✓ CLAUDE.md already references local-workflow.md"
+    else
+      printf '\n%s\n' "$IMPORT_LINE" >> "$CLAUDE_MD"
+      echo "✓ Appended $IMPORT_LINE to CLAUDE.md"
+    fi
+  else
+    printf '%s\n' "$IMPORT_LINE" > "$CLAUDE_MD"
+    echo "✓ Created CLAUDE.md with $IMPORT_LINE"
+  fi
 fi
 
-cp "$TEMPLATE" "$TARGET"
-echo "✓ Wrote $TARGET"
-
-IMPORT_LINE="@.claude/local-workflow.md"
-if [[ -f "$CLAUDE_MD" ]]; then
-  if grep -qF "$IMPORT_LINE" "$CLAUDE_MD"; then
-    echo "✓ CLAUDE.md already references local-workflow.md"
-  else
-    printf '\n%s\n' "$IMPORT_LINE" >> "$CLAUDE_MD"
-    echo "✓ Appended $IMPORT_LINE to CLAUDE.md"
-  fi
-else
-  printf '%s\n' "$IMPORT_LINE" > "$CLAUDE_MD"
-  echo "✓ Created CLAUDE.md with $IMPORT_LINE"
+if [[ "$SCOPE" != "workflow" ]]; then
+  COMMANDS_DIR="$REPO_ROOT/.claude/commands"
+  COMMANDS_SRC=$(cd "$SCRIPT_DIR/.." && pwd)/commands
+  mkdir -p "$COMMANDS_DIR"
+  for cmd in "$COMMANDS_SRC"/*.md; do
+    cmd_name=$(basename "$cmd")
+    cmd_target="$COMMANDS_DIR/$cmd_name"
+    INSTALL_POLICY="$POLICY" install_file "$cmd" "$cmd_target" "/$(basename "$cmd_name" .md)"
+  done
 fi
 
-# Project-level slash commands → <project>/.claude/commands/
-COMMANDS_DIR="$REPO_ROOT/.claude/commands"
-COMMANDS_SRC=$(cd "$SCRIPT_DIR/.." && pwd)/commands
-mkdir -p "$COMMANDS_DIR"
-for cmd in "$COMMANDS_SRC"/*.md; do
-  cmd_name=$(basename "$cmd")
-  cmd_target="$COMMANDS_DIR/$cmd_name"
-  if [[ ( -e "$cmd_target" || -L "$cmd_target" ) && "$FORCE" != true ]]; then
-    echo "⚠ $cmd_target already exists — skipping (use --force to overwrite)"
-  else
-    rm -f "$cmd_target"
-    cp "$cmd" "$cmd_target"
-    echo "✓ Slash command: /$(basename "$cmd_name" .md)"
-  fi
-done
-
-# tasks/ skeleton
-mkdir -p "$TASKS_DIR"
-TASKS_README="$TASKS_DIR/README.md"
-if [[ ! -f "$TASKS_README" ]]; then
-  cat > "$TASKS_README" <<'EOF'
+# tasks/ skeleton — already idempotent; only touch when scope includes workflow.
+if [[ "$SCOPE" != "commands" ]]; then
+  mkdir -p "$TASKS_DIR"
+  TASKS_README="$TASKS_DIR/README.md"
+  if [[ ! -f "$TASKS_README" ]]; then
+    cat > "$TASKS_README" <<'EOF'
 # Tasks
 
 This directory holds the project's task backlog as individual markdown files.
@@ -138,14 +166,14 @@ pr: ""
 - `task-work tasks/NNN-slug.md` — open a worktree + worker session
 - `task-done --remove-worktree` — clean up after the PR is open
 EOF
-  echo "✓ Wrote $TASKS_README"
-else
-  echo "✓ $TASKS_README already exists — left alone"
-fi
+    echo "✓ Wrote $TASKS_README"
+  else
+    echo "✓ $TASKS_README already exists — left alone"
+  fi
 
-BOARD="$TASKS_DIR/_board.md"
-if [[ ! -f "$BOARD" ]]; then
-  cat > "$BOARD" <<'EOF'
+  BOARD="$TASKS_DIR/_board.md"
+  if [[ ! -f "$BOARD" ]]; then
+    cat > "$BOARD" <<'EOF'
 <!-- AUTOGENERATED by task-board — do not edit by hand -->
 
 # Board
@@ -162,23 +190,24 @@ _(none)_
 
 _(none yet)_
 EOF
-  echo "✓ Wrote $BOARD"
-else
-  echo "✓ $BOARD already exists — left alone"
-fi
-
-# Ensure .git/task-force/ is gitignored
-IGNORE_LINE=".git/task-force/"
-if [[ -f "$GITIGNORE" ]]; then
-  if grep -qxF "$IGNORE_LINE" "$GITIGNORE"; then
-    echo "✓ .gitignore already excludes $IGNORE_LINE"
+    echo "✓ Wrote $BOARD"
   else
-    printf '\n%s\n' "$IGNORE_LINE" >> "$GITIGNORE"
-    echo "✓ Appended $IGNORE_LINE to .gitignore"
+    echo "✓ $BOARD already exists — left alone"
   fi
-else
-  printf '%s\n' "$IGNORE_LINE" > "$GITIGNORE"
-  echo "✓ Created .gitignore with $IGNORE_LINE"
+
+  # Ensure .git/task-force/ is gitignored
+  IGNORE_LINE=".git/task-force/"
+  if [[ -f "$GITIGNORE" ]]; then
+    if grep -qxF "$IGNORE_LINE" "$GITIGNORE"; then
+      echo "✓ .gitignore already excludes $IGNORE_LINE"
+    else
+      printf '\n%s\n' "$IGNORE_LINE" >> "$GITIGNORE"
+      echo "✓ Appended $IGNORE_LINE to .gitignore"
+    fi
+  else
+    printf '%s\n' "$IGNORE_LINE" > "$GITIGNORE"
+    echo "✓ Created .gitignore with $IGNORE_LINE"
+  fi
 fi
 
 echo ""

--- a/claude-notion/bin/task-init
+++ b/claude-notion/bin/task-init
@@ -2,16 +2,30 @@
 set -euo pipefail
 
 usage() {
-  echo "Usage: task-init [--force] [--help-ids]"
-  echo ""
-  echo "Set up the current repo for the claude-notion workflow:"
-  echo "  - Create .claude/notion-workflow.md from the bundled template"
-  echo "  - Add @.claude/notion-workflow.md to CLAUDE.md so it auto-loads in every session"
-  echo "  - Install /pm, /planner, /worker slash commands into .claude/commands/"
-  echo ""
-  echo "Options:"
-  echo "  --force      Overwrite .claude/notion-workflow.md and project-level slash commands if present"
-  echo "  --help-ids   Print guide for finding Notion database IDs (no setup)"
+  cat <<'EOF'
+Usage: task-init [--workflow | --commands] [--force | --restore] [--help-ids]
+
+Set up the current repo for the claude-notion workflow:
+  - Create .claude/notion-workflow.md from the bundled template
+  - Add @.claude/notion-workflow.md to CLAUDE.md so it auto-loads in every session
+  - Install /pm, /planner, /worker slash commands into .claude/commands/
+
+Scope (which categories of files to touch):
+  --workflow       Workflow doc only (and CLAUDE.md import)
+  --commands       Slash commands only
+  (none)           All of the above (default)
+
+Overwrite policy when a target file already exists:
+  --force          Overwrite all targets (no prompt)
+  --restore        Only fill missing targets; never touch existing files
+  (TTY default)    Per-file prompt: [k]eep / [o]verwrite / [d]iff
+  (non-TTY)        Silently keep existing files (script-safe)
+
+--force and --restore are mutually exclusive.
+
+Other:
+  --help-ids       Print guide for finding Notion database IDs (no setup)
+EOF
   exit 1
 }
 
@@ -43,11 +57,16 @@ GUIDE
 }
 
 FORCE=false
+RESTORE=false
+SCOPE="all"
 HELP_IDS=false
 
 while [[ $# -gt 0 ]]; do
   case "$1" in
-    --force) FORCE=true; shift ;;
+    --force)    FORCE=true; shift ;;
+    --restore)  RESTORE=true; shift ;;
+    --workflow) SCOPE="workflow"; shift ;;
+    --commands) SCOPE="commands"; shift ;;
     --help-ids) HELP_IDS=true; shift ;;
     -h|--help) usage ;;
     *) echo "Unknown option: $1"; usage ;;
@@ -59,6 +78,21 @@ if [[ "$HELP_IDS" == true ]]; then
   exit 0
 fi
 
+if [[ "$FORCE" == true && "$RESTORE" == true ]]; then
+  echo "Error: --force and --restore are mutually exclusive" >&2
+  exit 2
+fi
+
+if [[ "$FORCE" == true ]]; then
+  POLICY="force"
+elif [[ "$RESTORE" == true ]]; then
+  POLICY="restore"
+elif [[ -t 0 ]]; then
+  POLICY="prompt"
+else
+  POLICY="keep"
+fi
+
 # Resolve script path through symlinks (install.sh symlinks into ~/.local/bin)
 src="${BASH_SOURCE[0]}"
 while [ -L "$src" ]; do
@@ -68,6 +102,9 @@ while [ -L "$src" ]; do
 done
 SCRIPT_DIR=$(cd -P "$(dirname "$src")" && pwd)
 TEMPLATE="$SCRIPT_DIR/../steering/notion-workflow.example.md"
+LIB_DIR="$SCRIPT_DIR/../../lib"
+# shellcheck source=lib/install-file.sh
+. "$LIB_DIR/install-file.sh"
 
 if [[ ! -f "$TEMPLATE" ]]; then
   echo "Error: template not found at $TEMPLATE"
@@ -81,41 +118,34 @@ CLAUDE_MD="$REPO_ROOT/CLAUDE.md"
 
 mkdir -p "$REPO_ROOT/.claude"
 
-if [[ -f "$TARGET" && "$FORCE" != true ]]; then
-  echo "$TARGET already exists. Use --force to overwrite."
-  exit 1
+# The notion template has no flag-driven placeholders — its IDs are filled in
+# manually after init via the MCP. So we just install the raw template.
+if [[ "$SCOPE" != "commands" ]]; then
+  INSTALL_POLICY="$POLICY" install_file "$TEMPLATE" "$TARGET" "notion-workflow.md"
+
+  IMPORT_LINE="@.claude/notion-workflow.md"
+  if [[ -f "$CLAUDE_MD" ]]; then
+    if grep -qF "$IMPORT_LINE" "$CLAUDE_MD"; then
+      echo "✓ CLAUDE.md already references notion-workflow.md"
+    else
+      printf '\n%s\n' "$IMPORT_LINE" >> "$CLAUDE_MD"
+      echo "✓ Appended $IMPORT_LINE to CLAUDE.md"
+    fi
+  else
+    printf '%s\n' "$IMPORT_LINE" > "$CLAUDE_MD"
+    echo "✓ Created CLAUDE.md with $IMPORT_LINE"
+  fi
 fi
 
-cp "$TEMPLATE" "$TARGET"
-echo "✓ Wrote $TARGET"
-
-IMPORT_LINE="@.claude/notion-workflow.md"
-if [[ -f "$CLAUDE_MD" ]]; then
-  if grep -qF "$IMPORT_LINE" "$CLAUDE_MD"; then
-    echo "✓ CLAUDE.md already references notion-workflow.md"
-  else
-    printf '\n%s\n' "$IMPORT_LINE" >> "$CLAUDE_MD"
-    echo "✓ Appended $IMPORT_LINE to CLAUDE.md"
-  fi
-else
-  printf '%s\n' "$IMPORT_LINE" > "$CLAUDE_MD"
-  echo "✓ Created CLAUDE.md with $IMPORT_LINE"
+if [[ "$SCOPE" != "workflow" ]]; then
+  COMMANDS_DIR="$REPO_ROOT/.claude/commands"
+  COMMANDS_SRC=$(cd "$SCRIPT_DIR/.." && pwd)/commands
+  mkdir -p "$COMMANDS_DIR"
+  for cmd in "$COMMANDS_SRC"/*.md; do
+    cmd_name=$(basename "$cmd")
+    cmd_target="$COMMANDS_DIR/$cmd_name"
+    INSTALL_POLICY="$POLICY" install_file "$cmd" "$cmd_target" "/$(basename "$cmd_name" .md)"
+  done
 fi
-
-# Project-level slash commands → <project>/.claude/commands/
-COMMANDS_DIR="$REPO_ROOT/.claude/commands"
-COMMANDS_SRC=$(cd "$SCRIPT_DIR/.." && pwd)/commands
-mkdir -p "$COMMANDS_DIR"
-for cmd in "$COMMANDS_SRC"/*.md; do
-  cmd_name=$(basename "$cmd")
-  cmd_target="$COMMANDS_DIR/$cmd_name"
-  if [[ ( -e "$cmd_target" || -L "$cmd_target" ) && "$FORCE" != true ]]; then
-    echo "⚠ $cmd_target already exists — skipping (use --force to overwrite)"
-  else
-    rm -f "$cmd_target"
-    cp "$cmd" "$cmd_target"
-    echo "✓ Slash command: /$(basename "$cmd_name" .md)"
-  fi
-done
 
 print_ids_guide

--- a/kiro-gh/bin/task-init
+++ b/kiro-gh/bin/task-init
@@ -2,19 +2,33 @@
 set -euo pipefail
 
 usage() {
-  echo "Usage: task-init [--owner OWNER] [--repo REPO] [--project N] [--force]"
-  echo ""
-  echo "Set up the current repo for the kiro-gh workflow:"
-  echo "  - Create .kiro/steering/gh-workflow.md from the bundled template"
-  echo "  - Substitute owner / repo / project number if provided"
-  echo "    (auto-detected from git remote when possible; missing values prompted interactively)"
-  echo "  - Install pm, planner, worker agents into .kiro/agents/"
-  echo ""
-  echo "Options:"
-  echo "  --owner OWNER    GitHub user or org name"
-  echo "  --repo  REPO     Repository name"
-  echo "  --project N      GitHub Projects board number"
-  echo "  --force          Overwrite .kiro/steering/gh-workflow.md and project-level agents if present"
+  cat <<'EOF'
+Usage: task-init [--owner OWNER] [--repo REPO] [--project N]
+                 [--workflow | --commands]
+                 [--force | --restore]
+
+Set up the current repo for the kiro-gh workflow:
+  - Create .kiro/steering/gh-workflow.md from the bundled template
+  - Substitute owner / repo / project number if provided
+    (auto-detected from git remote when possible; missing values prompted interactively)
+  - Install pm, planner, worker agents into .kiro/agents/
+
+Scope (which categories of files to touch):
+  --workflow       Workflow doc only
+  --commands       Agents only
+  (none)           All of the above (default)
+
+Overwrite policy when a target file already exists:
+  --force          Overwrite all targets (no prompt)
+  --restore        Only fill missing targets; never touch existing files
+  (TTY default)    Per-file prompt: [k]eep / [o]verwrite / [d]iff
+  (non-TTY)        Silently keep existing files (script-safe)
+
+When refreshing an existing workflow doc, previously-filled {OWNER} / {REPO} /
+{PROJECT} values are automatically preserved (this-run flags take precedence).
+
+--force and --restore are mutually exclusive.
+EOF
   exit 1
 }
 
@@ -22,64 +36,51 @@ OWNER=""
 REPO=""
 PROJECT=""
 FORCE=false
+RESTORE=false
+SCOPE="all"
 OWNER_VIA_FLAG=false
 REPO_VIA_FLAG=false
 PROJECT_VIA_FLAG=false
 
 while [[ $# -gt 0 ]]; do
   case "$1" in
-    --owner)   OWNER="$2";   OWNER_VIA_FLAG=true;   shift 2;;
-    --repo)    REPO="$2";    REPO_VIA_FLAG=true;    shift 2;;
-    --project) PROJECT="$2"; PROJECT_VIA_FLAG=true; shift 2;;
-    --force)   FORCE=true; shift;;
-    -h|--help) usage;;
+    --owner)    OWNER="$2";   OWNER_VIA_FLAG=true;   shift 2;;
+    --repo)     REPO="$2";    REPO_VIA_FLAG=true;    shift 2;;
+    --project)  PROJECT="$2"; PROJECT_VIA_FLAG=true; shift 2;;
+    --force)    FORCE=true; shift;;
+    --restore)  RESTORE=true; shift;;
+    --workflow) SCOPE="workflow"; shift;;
+    --commands) SCOPE="commands"; shift;;
+    -h|--help)  usage;;
     *) echo "Unknown option: $1"; usage;;
   esac
 done
 
-# Escape special sed replacement characters (|, &, \) to prevent injection
+if [[ "$FORCE" == true && "$RESTORE" == true ]]; then
+  echo "Error: --force and --restore are mutually exclusive" >&2
+  exit 2
+fi
+
+if [[ "$FORCE" == true ]]; then
+  POLICY="force"
+elif [[ "$RESTORE" == true ]]; then
+  POLICY="restore"
+elif [[ -t 0 ]]; then
+  POLICY="prompt"
+else
+  POLICY="keep"
+fi
+
 _sed_escape() { printf '%s' "$1" | sed 's/[|&\]/\\&/g'; }
 
-# Auto-detect owner/repo from git remote (only for values not set via flag)
 _detect_gh_remote() {
   local url
   url=$(git remote get-url origin 2>/dev/null) || return 1
-  url="${url%.git}"  # strip trailing .git before matching
+  url="${url%.git}"
   if [[ "$url" =~ github\.com[:/]([^/]+)/([^/]+)$ ]]; then
     echo "${BASH_REMATCH[1]} ${BASH_REMATCH[2]}"
   fi
 }
-
-if [[ "$OWNER_VIA_FLAG" == false ]] || [[ "$REPO_VIA_FLAG" == false ]]; then
-  _detected=$(_detect_gh_remote 2>/dev/null) || true
-  if [[ -n "${_detected:-}" ]]; then
-    [[ "$OWNER_VIA_FLAG" == false ]] && OWNER="${_detected%% *}"
-    [[ "$REPO_VIA_FLAG"  == false ]] && REPO="${_detected##* }"
-  fi
-fi
-
-# Interactive prompts when running from a terminal (skipped for values set via flag)
-if [[ -t 0 ]]; then
-  if [[ "$OWNER_VIA_FLAG" == false ]]; then
-    if [[ -n "$OWNER" ]]; then
-      read -erp "GitHub owner [$OWNER]: " _input
-      [[ -n "${_input:-}" ]] && OWNER="$_input"
-    else
-      read -erp "GitHub owner (user or org) [blank → leaves {OWNER}]: " OWNER
-    fi
-  fi
-  if [[ "$REPO_VIA_FLAG" == false ]]; then
-    if [[ -n "$REPO" ]]; then
-      read -erp "Repository name [$REPO]: " _input
-      [[ -n "${_input:-}" ]] && REPO="$_input"
-    else
-      read -erp "Repository name [blank → leaves {REPO}]: " REPO
-    fi
-  fi
-  if [[ "$PROJECT_VIA_FLAG" == false ]]; then
-    read -erp "Project number (find at: github.com/users/OWNER/projects/N or github.com/orgs/OWNER/projects/N) [blank → leaves {PROJECT}]: " PROJECT
-  fi
-fi
 
 # Resolve script path through symlinks
 src="${BASH_SOURCE[0]}"
@@ -90,6 +91,11 @@ while [ -L "$src" ]; do
 done
 SCRIPT_DIR=$(cd -P "$(dirname "$src")" && pwd)
 TEMPLATE="$SCRIPT_DIR/../steering/gh-workflow.example.md"
+LIB_DIR="$SCRIPT_DIR/../../lib"
+# shellcheck source=lib/install-file.sh
+. "$LIB_DIR/install-file.sh"
+# shellcheck source=lib/preserve-placeholders.sh
+. "$LIB_DIR/preserve-placeholders.sh"
 
 if [[ ! -f "$TEMPLATE" ]]; then
   echo "Error: template not found at $TEMPLATE"
@@ -102,38 +108,91 @@ TARGET="$REPO_ROOT/.kiro/steering/gh-workflow.md"
 
 mkdir -p "$REPO_ROOT/.kiro/steering"
 
-if [[ -f "$TARGET" && "$FORCE" != true ]]; then
-  echo "$TARGET already exists. Use --force to overwrite."
-  exit 1
-fi
+_preserve_placeholders() {
+  local existing="$1"
+  [[ -f "$existing" ]] || return 0
+  local v
+  if [[ "$OWNER_VIA_FLAG" == false && -z "$OWNER" ]]; then
+    v=$(extract_existing_value "$existing" '^- \*\*Owner\*\*: `([^`]+)`.*' '{OWNER}')
+    if [[ -n "$v" ]]; then OWNER="$v"; fi
+  fi
+  if [[ "$REPO_VIA_FLAG" == false && -z "$REPO" ]]; then
+    v=$(extract_existing_value "$existing" '^- \*\*Repo\*\*: `([^`]+)`.*' '{REPO}')
+    if [[ -n "$v" ]]; then REPO="$v"; fi
+  fi
+  if [[ "$PROJECT_VIA_FLAG" == false && -z "$PROJECT" ]]; then
+    v=$(extract_existing_value "$existing" '^- \*\*Project number\*\*: `([^`]+)`.*' '{PROJECT}')
+    if [[ -n "$v" ]]; then PROJECT="$v"; fi
+  fi
+  return 0
+}
 
-sed_args=()
-[[ -n "$OWNER"   ]] && sed_args+=(-e "s|{OWNER}|$(_sed_escape "$OWNER")|g")
-[[ -n "$REPO"    ]] && sed_args+=(-e "s|{REPO}|$(_sed_escape "$REPO")|g")
-[[ -n "$PROJECT" ]] && sed_args+=(-e "s|{PROJECT}|$(_sed_escape "$PROJECT")|g")
+if [[ "$SCOPE" != "commands" ]]; then
+  _preserve_placeholders "$TARGET"
 
-if [[ ${#sed_args[@]} -gt 0 ]]; then
-  sed "${sed_args[@]}" "$TEMPLATE" > "$TARGET"
-else
-  cp "$TEMPLATE" "$TARGET"
+  if [[ "$OWNER_VIA_FLAG" == false ]] || [[ "$REPO_VIA_FLAG" == false ]]; then
+    _detected=$(_detect_gh_remote 2>/dev/null) || true
+    if [[ -n "${_detected:-}" ]]; then
+      [[ "$OWNER_VIA_FLAG" == false && -z "$OWNER" ]] && OWNER="${_detected%% *}"
+      [[ "$REPO_VIA_FLAG"  == false && -z "$REPO"  ]] && REPO="${_detected##* }"
+    fi
+  fi
+
+  if [[ -t 0 ]]; then
+    if [[ "$OWNER_VIA_FLAG" == false ]]; then
+      if [[ -n "$OWNER" ]]; then
+        read -erp "GitHub owner [$OWNER]: " _input
+        [[ -n "${_input:-}" ]] && OWNER="$_input"
+      else
+        read -erp "GitHub owner (user or org) [blank → leaves {OWNER}]: " OWNER
+      fi
+    fi
+    if [[ "$REPO_VIA_FLAG" == false ]]; then
+      if [[ -n "$REPO" ]]; then
+        read -erp "Repository name [$REPO]: " _input
+        [[ -n "${_input:-}" ]] && REPO="$_input"
+      else
+        read -erp "Repository name [blank → leaves {REPO}]: " REPO
+      fi
+    fi
+    if [[ "$PROJECT_VIA_FLAG" == false ]]; then
+      if [[ -n "$PROJECT" ]]; then
+        read -erp "Project number [$PROJECT]: " _input
+        [[ -n "${_input:-}" ]] && PROJECT="$_input"
+      else
+        read -erp "Project number (find at: github.com/users/OWNER/projects/N or github.com/orgs/OWNER/projects/N) [blank → leaves {PROJECT}]: " PROJECT
+      fi
+    fi
+  fi
+
+  TMP_RENDERED=$(mktemp)
+  trap 'rm -f "$TMP_RENDERED"' EXIT
+
+  sed_args=()
+  [[ -n "$OWNER"   ]] && sed_args+=(-e "s|{OWNER}|$(_sed_escape "$OWNER")|g")
+  [[ -n "$REPO"    ]] && sed_args+=(-e "s|{REPO}|$(_sed_escape "$REPO")|g")
+  [[ -n "$PROJECT" ]] && sed_args+=(-e "s|{PROJECT}|$(_sed_escape "$PROJECT")|g")
+
+  if [[ ${#sed_args[@]} -gt 0 ]]; then
+    sed "${sed_args[@]}" "$TEMPLATE" > "$TMP_RENDERED"
+  else
+    cp "$TEMPLATE" "$TMP_RENDERED"
+  fi
+
+  INSTALL_POLICY="$POLICY" install_file "$TMP_RENDERED" "$TARGET" "gh-workflow.md"
 fi
-echo "✓ Wrote $TARGET"
 
 # Project-level agents → <project>/.kiro/agents/
-AGENTS_DIR="$REPO_ROOT/.kiro/agents"
-AGENTS_SRC=$(cd "$SCRIPT_DIR/.." && pwd)/agents
-mkdir -p "$AGENTS_DIR"
-for agent in "$AGENTS_SRC"/*.json; do
-  agent_name=$(basename "$agent")
-  agent_target="$AGENTS_DIR/$agent_name"
-  if [[ ( -e "$agent_target" || -L "$agent_target" ) && "$FORCE" != true ]]; then
-    echo "⚠ $agent_target already exists — skipping (use --force to overwrite)"
-  else
-    rm -f "$agent_target"
-    cp "$agent" "$agent_target"
-    echo "✓ Agent: $agent_name"
-  fi
-done
+if [[ "$SCOPE" != "workflow" ]]; then
+  AGENTS_DIR="$REPO_ROOT/.kiro/agents"
+  AGENTS_SRC=$(cd "$SCRIPT_DIR/.." && pwd)/agents
+  mkdir -p "$AGENTS_DIR"
+  for agent in "$AGENTS_SRC"/*.json; do
+    agent_name=$(basename "$agent")
+    agent_target="$AGENTS_DIR/$agent_name"
+    INSTALL_POLICY="$POLICY" install_file "$agent" "$agent_target" "agent: $agent_name"
+  done
+fi
 
 echo ""
 echo "Done. Open .kiro/steering/gh-workflow.md to fill in any remaining {placeholders}."

--- a/kiro-local/bin/task-init
+++ b/kiro-local/bin/task-init
@@ -2,28 +2,60 @@
 set -euo pipefail
 
 usage() {
-  echo "Usage: task-init [--force]"
-  echo ""
-  echo "Set up the current repo for the kiro-local workflow:"
-  echo "  - Create .kiro/steering/local-workflow.md from the bundled template"
-  echo "  - Install pm, planner, worker agents into .kiro/agents/"
-  echo "  - Create tasks/{README.md, _board.md} with starter content"
-  echo "  - Append .git/task-force/ to .gitignore (create if missing)"
-  echo ""
-  echo "Options:"
-  echo "  --force   Overwrite .kiro/steering/local-workflow.md and project-level agents if present"
+  cat <<'EOF'
+Usage: task-init [--workflow | --commands] [--force | --restore]
+
+Set up the current repo for the kiro-local workflow:
+  - Create .kiro/steering/local-workflow.md from the bundled template
+  - Install pm, planner, worker agents into .kiro/agents/
+  - Create tasks/{README.md, _board.md} with starter content
+  - Append .git/task-force/ to .gitignore (create if missing)
+
+Scope (which categories of files to touch):
+  --workflow       Workflow doc only (and tasks scaffolding / .gitignore)
+  --commands       Agents only
+  (none)           All of the above (default)
+
+Overwrite policy when a target file already exists:
+  --force          Overwrite all targets (no prompt)
+  --restore        Only fill missing targets; never touch existing files
+  (TTY default)    Per-file prompt: [k]eep / [o]verwrite / [d]iff
+  (non-TTY)        Silently keep existing files (script-safe)
+
+--force and --restore are mutually exclusive.
+EOF
   exit 1
 }
 
 FORCE=false
+RESTORE=false
+SCOPE="all"
 
 while [[ $# -gt 0 ]]; do
   case "$1" in
-    --force)   FORCE=true; shift;;
-    -h|--help) usage;;
+    --force)    FORCE=true; shift;;
+    --restore)  RESTORE=true; shift;;
+    --workflow) SCOPE="workflow"; shift;;
+    --commands) SCOPE="commands"; shift;;
+    -h|--help)  usage;;
     *) echo "Unknown option: $1"; usage;;
   esac
 done
+
+if [[ "$FORCE" == true && "$RESTORE" == true ]]; then
+  echo "Error: --force and --restore are mutually exclusive" >&2
+  exit 2
+fi
+
+if [[ "$FORCE" == true ]]; then
+  POLICY="force"
+elif [[ "$RESTORE" == true ]]; then
+  POLICY="restore"
+elif [[ -t 0 ]]; then
+  POLICY="prompt"
+else
+  POLICY="keep"
+fi
 
 # Resolve script path through symlinks (install.sh symlinks into ~/.local/bin)
 src="${BASH_SOURCE[0]}"
@@ -34,6 +66,9 @@ while [ -L "$src" ]; do
 done
 SCRIPT_DIR=$(cd -P "$(dirname "$src")" && pwd)
 TEMPLATE="$SCRIPT_DIR/../steering/local-workflow.example.md"
+LIB_DIR="$SCRIPT_DIR/../../lib"
+# shellcheck source=lib/install-file.sh
+. "$LIB_DIR/install-file.sh"
 
 if [[ ! -f "$TEMPLATE" ]]; then
   echo "Error: template not found at $TEMPLATE"
@@ -48,35 +83,27 @@ TASKS_DIR="$REPO_ROOT/tasks"
 
 mkdir -p "$REPO_ROOT/.kiro/steering"
 
-if [[ -f "$TARGET" && "$FORCE" != true ]]; then
-  echo "$TARGET already exists. Use --force to overwrite."
-  exit 1
+if [[ "$SCOPE" != "commands" ]]; then
+  INSTALL_POLICY="$POLICY" install_file "$TEMPLATE" "$TARGET" "local-workflow.md"
 fi
 
-cp "$TEMPLATE" "$TARGET"
-echo "✓ Wrote $TARGET"
+if [[ "$SCOPE" != "workflow" ]]; then
+  AGENTS_DIR="$REPO_ROOT/.kiro/agents"
+  AGENTS_SRC=$(cd "$SCRIPT_DIR/.." && pwd)/agents
+  mkdir -p "$AGENTS_DIR"
+  for agent in "$AGENTS_SRC"/*.json; do
+    agent_name=$(basename "$agent")
+    agent_target="$AGENTS_DIR/$agent_name"
+    INSTALL_POLICY="$POLICY" install_file "$agent" "$agent_target" "agent: $agent_name"
+  done
+fi
 
-# Project-level agents → <project>/.kiro/agents/
-AGENTS_DIR="$REPO_ROOT/.kiro/agents"
-AGENTS_SRC=$(cd "$SCRIPT_DIR/.." && pwd)/agents
-mkdir -p "$AGENTS_DIR"
-for agent in "$AGENTS_SRC"/*.json; do
-  agent_name=$(basename "$agent")
-  agent_target="$AGENTS_DIR/$agent_name"
-  if [[ ( -e "$agent_target" || -L "$agent_target" ) && "$FORCE" != true ]]; then
-    echo "⚠ $agent_target already exists — skipping (use --force to overwrite)"
-  else
-    rm -f "$agent_target"
-    cp "$agent" "$agent_target"
-    echo "✓ Agent: $agent_name"
-  fi
-done
-
-# tasks/ skeleton
-mkdir -p "$TASKS_DIR"
-TASKS_README="$TASKS_DIR/README.md"
-if [[ ! -f "$TASKS_README" ]]; then
-  cat > "$TASKS_README" <<'EOF'
+# tasks/ skeleton — already idempotent; only touch when scope includes workflow.
+if [[ "$SCOPE" != "commands" ]]; then
+  mkdir -p "$TASKS_DIR"
+  TASKS_README="$TASKS_DIR/README.md"
+  if [[ ! -f "$TASKS_README" ]]; then
+    cat > "$TASKS_README" <<'EOF'
 # Tasks
 
 This directory holds the project's task backlog as individual markdown files.
@@ -127,14 +154,14 @@ pr: ""
 - `task-work tasks/NNN-slug.md` — open a worktree + worker session
 - `task-done --remove-worktree` — clean up after the PR is open
 EOF
-  echo "✓ Wrote $TASKS_README"
-else
-  echo "✓ $TASKS_README already exists — left alone"
-fi
+    echo "✓ Wrote $TASKS_README"
+  else
+    echo "✓ $TASKS_README already exists — left alone"
+  fi
 
-BOARD="$TASKS_DIR/_board.md"
-if [[ ! -f "$BOARD" ]]; then
-  cat > "$BOARD" <<'EOF'
+  BOARD="$TASKS_DIR/_board.md"
+  if [[ ! -f "$BOARD" ]]; then
+    cat > "$BOARD" <<'EOF'
 <!-- AUTOGENERATED by task-board — do not edit by hand -->
 
 # Board
@@ -151,23 +178,24 @@ _(none)_
 
 _(none yet)_
 EOF
-  echo "✓ Wrote $BOARD"
-else
-  echo "✓ $BOARD already exists — left alone"
-fi
-
-# Ensure .git/task-force/ is gitignored
-IGNORE_LINE=".git/task-force/"
-if [[ -f "$GITIGNORE" ]]; then
-  if grep -qxF "$IGNORE_LINE" "$GITIGNORE"; then
-    echo "✓ .gitignore already excludes $IGNORE_LINE"
+    echo "✓ Wrote $BOARD"
   else
-    printf '\n%s\n' "$IGNORE_LINE" >> "$GITIGNORE"
-    echo "✓ Appended $IGNORE_LINE to .gitignore"
+    echo "✓ $BOARD already exists — left alone"
   fi
-else
-  printf '%s\n' "$IGNORE_LINE" > "$GITIGNORE"
-  echo "✓ Created .gitignore with $IGNORE_LINE"
+
+  # Ensure .git/task-force/ is gitignored
+  IGNORE_LINE=".git/task-force/"
+  if [[ -f "$GITIGNORE" ]]; then
+    if grep -qxF "$IGNORE_LINE" "$GITIGNORE"; then
+      echo "✓ .gitignore already excludes $IGNORE_LINE"
+    else
+      printf '\n%s\n' "$IGNORE_LINE" >> "$GITIGNORE"
+      echo "✓ Appended $IGNORE_LINE to .gitignore"
+    fi
+  else
+    printf '%s\n' "$IGNORE_LINE" > "$GITIGNORE"
+    echo "✓ Created .gitignore with $IGNORE_LINE"
+  fi
 fi
 
 echo ""

--- a/kiro-notion/bin/task-init
+++ b/kiro-notion/bin/task-init
@@ -2,15 +2,29 @@
 set -euo pipefail
 
 usage() {
-  echo "Usage: task-init [--force] [--help-ids]"
-  echo ""
-  echo "Set up the current repo for the kiro-notion workflow:"
-  echo "  - Create .kiro/steering/notion-workflow.md from the bundled template"
-  echo "  - Install pm, planner, worker agents into .kiro/agents/"
-  echo ""
-  echo "Options:"
-  echo "  --force      Overwrite .kiro/steering/notion-workflow.md and project-level agents if present"
-  echo "  --help-ids   Print guide for finding Notion database IDs (no setup)"
+  cat <<'EOF'
+Usage: task-init [--workflow | --commands] [--force | --restore] [--help-ids]
+
+Set up the current repo for the kiro-notion workflow:
+  - Create .kiro/steering/notion-workflow.md from the bundled template
+  - Install pm, planner, worker agents into .kiro/agents/
+
+Scope (which categories of files to touch):
+  --workflow       Workflow doc only
+  --commands       Agents only
+  (none)           All of the above (default)
+
+Overwrite policy when a target file already exists:
+  --force          Overwrite all targets (no prompt)
+  --restore        Only fill missing targets; never touch existing files
+  (TTY default)    Per-file prompt: [k]eep / [o]verwrite / [d]iff
+  (non-TTY)        Silently keep existing files (script-safe)
+
+--force and --restore are mutually exclusive.
+
+Other:
+  --help-ids       Print guide for finding Notion database IDs (no setup)
+EOF
   exit 1
 }
 
@@ -42,11 +56,16 @@ GUIDE
 }
 
 FORCE=false
+RESTORE=false
+SCOPE="all"
 HELP_IDS=false
 
 while [[ $# -gt 0 ]]; do
   case "$1" in
-    --force) FORCE=true; shift ;;
+    --force)    FORCE=true; shift ;;
+    --restore)  RESTORE=true; shift ;;
+    --workflow) SCOPE="workflow"; shift ;;
+    --commands) SCOPE="commands"; shift ;;
     --help-ids) HELP_IDS=true; shift ;;
     -h|--help) usage ;;
     *) echo "Unknown option: $1"; usage ;;
@@ -58,6 +77,21 @@ if [[ "$HELP_IDS" == true ]]; then
   exit 0
 fi
 
+if [[ "$FORCE" == true && "$RESTORE" == true ]]; then
+  echo "Error: --force and --restore are mutually exclusive" >&2
+  exit 2
+fi
+
+if [[ "$FORCE" == true ]]; then
+  POLICY="force"
+elif [[ "$RESTORE" == true ]]; then
+  POLICY="restore"
+elif [[ -t 0 ]]; then
+  POLICY="prompt"
+else
+  POLICY="keep"
+fi
+
 # Resolve script path through symlinks
 src="${BASH_SOURCE[0]}"
 while [ -L "$src" ]; do
@@ -67,6 +101,9 @@ while [ -L "$src" ]; do
 done
 SCRIPT_DIR=$(cd -P "$(dirname "$src")" && pwd)
 TEMPLATE="$SCRIPT_DIR/../steering/notion-workflow.example.md"
+LIB_DIR="$SCRIPT_DIR/../../lib"
+# shellcheck source=lib/install-file.sh
+. "$LIB_DIR/install-file.sh"
 
 if [[ ! -f "$TEMPLATE" ]]; then
   echo "Error: template not found at $TEMPLATE"
@@ -79,28 +116,19 @@ TARGET="$REPO_ROOT/.kiro/steering/notion-workflow.md"
 
 mkdir -p "$REPO_ROOT/.kiro/steering"
 
-if [[ -f "$TARGET" && "$FORCE" != true ]]; then
-  echo "$TARGET already exists. Use --force to overwrite."
-  exit 1
+if [[ "$SCOPE" != "commands" ]]; then
+  INSTALL_POLICY="$POLICY" install_file "$TEMPLATE" "$TARGET" "notion-workflow.md"
 fi
 
-cp "$TEMPLATE" "$TARGET"
-echo "✓ Wrote $TARGET"
-
-# Project-level agents → <project>/.kiro/agents/
-AGENTS_DIR="$REPO_ROOT/.kiro/agents"
-AGENTS_SRC=$(cd "$SCRIPT_DIR/.." && pwd)/agents
-mkdir -p "$AGENTS_DIR"
-for agent in "$AGENTS_SRC"/*.json; do
-  agent_name=$(basename "$agent")
-  agent_target="$AGENTS_DIR/$agent_name"
-  if [[ ( -e "$agent_target" || -L "$agent_target" ) && "$FORCE" != true ]]; then
-    echo "⚠ $agent_target already exists — skipping (use --force to overwrite)"
-  else
-    rm -f "$agent_target"
-    cp "$agent" "$agent_target"
-    echo "✓ Agent: $agent_name"
-  fi
-done
+if [[ "$SCOPE" != "workflow" ]]; then
+  AGENTS_DIR="$REPO_ROOT/.kiro/agents"
+  AGENTS_SRC=$(cd "$SCRIPT_DIR/.." && pwd)/agents
+  mkdir -p "$AGENTS_DIR"
+  for agent in "$AGENTS_SRC"/*.json; do
+    agent_name=$(basename "$agent")
+    agent_target="$AGENTS_DIR/$agent_name"
+    INSTALL_POLICY="$POLICY" install_file "$agent" "$agent_target" "agent: $agent_name"
+  done
+fi
 
 print_ids_guide

--- a/lib/install-file.sh
+++ b/lib/install-file.sh
@@ -1,0 +1,94 @@
+#!/usr/bin/env bash
+# Shared helper for task-init scripts: deciding whether to write a file based
+# on an overwrite policy.
+#
+# Usage:
+#   INSTALL_POLICY=<policy> install_file <src> <dest> <label>
+#
+# Policies:
+#   force    - always overwrite (--force flag)
+#   restore  - only write when dest is missing; never touch existing (--restore flag)
+#   prompt   - interactively ask [k]eep / [o]verwrite / [d]iff (TTY default)
+#   keep     - silently skip when dest exists (non-TTY default)
+#
+# Caller is responsible for choosing the policy based on flags and -t 0.
+# The helper trusts the policy as given.
+#
+# Output goes to stdout (status messages) / stderr (prompts, diffs).
+
+# install_file <src> <dest> <label>
+install_file() {
+  local src="$1" dest="$2" label="$3"
+  local policy="${INSTALL_POLICY:-keep}"
+
+  if [[ ! -f "$src" ]]; then
+    echo "Error: source not found: $src" >&2
+    return 1
+  fi
+
+  # Missing target → always write, regardless of policy.
+  if [[ ! -e "$dest" && ! -L "$dest" ]]; then
+    _install_file_write "$src" "$dest" "$label"
+    return 0
+  fi
+
+  case "$policy" in
+    force)
+      _install_file_write "$src" "$dest" "$label"
+      ;;
+    restore)
+      echo "✓ $label already exists — kept (--restore)"
+      ;;
+    keep)
+      echo "✓ $label already exists — kept (use --force to overwrite)"
+      ;;
+    prompt)
+      _install_file_prompt "$src" "$dest" "$label"
+      ;;
+    *)
+      echo "Error: unknown INSTALL_POLICY: $policy" >&2
+      return 1
+      ;;
+  esac
+}
+
+_install_file_write() {
+  local src="$1" dest="$2" label="$3"
+  mkdir -p "$(dirname "$dest")"
+  rm -f "$dest"
+  cp "$src" "$dest"
+  echo "✓ Wrote $label ($dest)"
+}
+
+_install_file_prompt() {
+  local src="$1" dest="$2" label="$3"
+  local answer
+  while true; do
+    printf '%s exists at %s. [k]eep / [o]verwrite / [d]iff (default: keep): ' "$label" "$dest" >&2
+    if ! IFS= read -r answer; then
+      # EOF on stdin — fall back to keep.
+      echo "" >&2
+      answer="k"
+    fi
+    answer="${answer:-k}"
+    case "$answer" in
+      k|K|keep)
+        echo "✓ $label kept"
+        return 0
+        ;;
+      o|O|overwrite)
+        _install_file_write "$src" "$dest" "$label"
+        return 0
+        ;;
+      d|D|diff)
+        echo "--- diff: current → new template ---" >&2
+        diff -u "$dest" "$src" >&2 || true
+        echo "------------------------------------" >&2
+        # loop and re-prompt
+        ;;
+      *)
+        echo "Invalid choice '$answer'. Pick k, o, or d." >&2
+        ;;
+    esac
+  done
+}

--- a/lib/install-file.sh
+++ b/lib/install-file.sh
@@ -55,8 +55,16 @@ install_file() {
 _install_file_write() {
   local src="$1" dest="$2" label="$3"
   mkdir -p "$(dirname "$dest")"
-  rm -f "$dest"
-  cp "$src" "$dest"
+  # Atomic write via mktemp + mv: mv on the same filesystem is a POSIX rename,
+  # so the target either still points at the old file or at the new one — never
+  # missing if we get Ctrl+C'd between cp and rename.
+  local tmp
+  tmp=$(mktemp "$dest.XXXXXX")
+  if ! cp "$src" "$tmp"; then
+    rm -f "$tmp"
+    return 1
+  fi
+  mv -f "$tmp" "$dest"
   echo "✓ Wrote $label ($dest)"
 }
 

--- a/lib/preserve-placeholders.sh
+++ b/lib/preserve-placeholders.sh
@@ -1,0 +1,32 @@
+#!/usr/bin/env bash
+# Shared helper for the workflow-doc placeholder-preservation step.
+#
+# When a task-init script re-renders the workflow template into an existing
+# target, we want to carry forward whatever values the user previously filled
+# in. This file exposes a generic extractor; per-loadout task-init scripts
+# define their own placeholder→pattern map and call extract_existing_value()
+# for each placeholder.
+#
+# Precedence (per placeholder):
+#   1. value from this-run's flag         (set before calling preserve)
+#   2. value from existing rendered file  (extract_existing_value)
+#   3. leave the {PLACEHOLDER} token
+
+# extract_existing_value <file> <sed_ERE_pattern_with_one_capture> <placeholder>
+#
+# Runs the pattern as a sed -E substitution with a single capture group
+# (matched value → \1). Prints the first match if it is non-empty and not
+# equal to the literal placeholder. Otherwise prints nothing.
+extract_existing_value() {
+  local file="$1" pattern="$2" placeholder="$3"
+  [[ -f "$file" ]] || return 0
+  local matches value
+  matches=$(sed -nE "s|$pattern|\1|p" "$file")
+  # Take the first matched line without piping into head (avoids SIGPIPE
+  # interactions when callers run with set -o pipefail).
+  value="${matches%%$'\n'*}"
+  if [[ -z "$value" || "$value" == "$placeholder" ]]; then
+    return 0
+  fi
+  printf '%s' "$value"
+}

--- a/tests/claude_gh_task_init.bats
+++ b/tests/claude_gh_task_init.bats
@@ -163,15 +163,18 @@ teardown() {
 }
 
 # ---------------------------------------------------------------------------
-# --force and overwrite guard
+# Overwrite policy: --force / --restore / default (TTY prompt / non-TTY keep)
 # ---------------------------------------------------------------------------
 
-@test "fails if .claude/gh-workflow.md already exists (no --force)" {
-  run "$CLAUDE_GH_TASK_INIT"
+@test "non-TTY default: existing workflow doc is kept silently (exit 0)" {
+  run "$CLAUDE_GH_TASK_INIT" --owner old
   assert_success
-  run "$CLAUDE_GH_TASK_INIT"
-  assert_failure
-  assert_output --partial "already exists"
+  run "$CLAUDE_GH_TASK_INIT" --owner ignored
+  assert_success
+  assert_output --partial "kept"
+  run cat "$TARGET_DIR/.claude/gh-workflow.md"
+  assert_output --partial "old"
+  refute_output --partial "ignored"
 }
 
 @test "--force overwrites existing gh-workflow.md" {
@@ -182,6 +185,106 @@ teardown() {
   run cat "$TARGET_DIR/.claude/gh-workflow.md"
   assert_output --partial "new"
   refute_output --partial "**Owner**: \`old\`"
+}
+
+@test "--force + --restore is rejected" {
+  run "$CLAUDE_GH_TASK_INIT" --force --restore
+  assert_failure
+  assert_output --partial "mutually exclusive"
+}
+
+# ---------------------------------------------------------------------------
+# --restore: fill missing only
+# ---------------------------------------------------------------------------
+
+@test "--restore restores a deleted slash command without touching workflow" {
+  run "$CLAUDE_GH_TASK_INIT" --owner acme --repo widget --project 7
+  assert_success
+  # Snapshot workflow doc, delete one command.
+  cp "$TARGET_DIR/.claude/gh-workflow.md" "$BATS_TEST_TMPDIR/workflow.before"
+  rm "$TARGET_DIR/.claude/commands/pm.md"
+  run "$CLAUDE_GH_TASK_INIT" --restore
+  assert_success
+  assert [ -f "$TARGET_DIR/.claude/commands/pm.md" ]
+  run cmp -s "$BATS_TEST_TMPDIR/workflow.before" "$TARGET_DIR/.claude/gh-workflow.md"
+  assert_success
+}
+
+@test "--restore leaves existing slash commands alone" {
+  mkdir -p "$TARGET_DIR/.claude/commands"
+  echo "custom content" > "$TARGET_DIR/.claude/commands/pm.md"
+  run "$CLAUDE_GH_TASK_INIT" --restore
+  assert_success
+  run cat "$TARGET_DIR/.claude/commands/pm.md"
+  assert_output "custom content"
+  # And fills in the missing ones
+  assert [ -f "$TARGET_DIR/.claude/commands/planner.md" ]
+  assert [ -f "$TARGET_DIR/.claude/commands/worker.md" ]
+}
+
+# ---------------------------------------------------------------------------
+# --workflow / --commands scope flags
+# ---------------------------------------------------------------------------
+
+@test "--commands installs slash commands without writing workflow doc" {
+  run "$CLAUDE_GH_TASK_INIT" --commands
+  assert_success
+  assert [ ! -f "$TARGET_DIR/.claude/gh-workflow.md" ]
+  for cmd in pm planner worker; do
+    assert [ -f "$TARGET_DIR/.claude/commands/$cmd.md" ]
+  done
+}
+
+@test "--workflow installs workflow doc without writing slash commands" {
+  run "$CLAUDE_GH_TASK_INIT" --workflow
+  assert_success
+  assert [ -f "$TARGET_DIR/.claude/gh-workflow.md" ]
+  assert [ ! -d "$TARGET_DIR/.claude/commands" ]
+}
+
+@test "--commands --force overwrites pre-existing slash commands, leaves workflow alone" {
+  run "$CLAUDE_GH_TASK_INIT" --owner acme --repo widget --project 7
+  assert_success
+  cp "$TARGET_DIR/.claude/gh-workflow.md" "$BATS_TEST_TMPDIR/workflow.before"
+  echo "stale pm" > "$TARGET_DIR/.claude/commands/pm.md"
+  run "$CLAUDE_GH_TASK_INIT" --commands --force
+  assert_success
+  run cmp -s "$BATS_TEST_TMPDIR/workflow.before" "$TARGET_DIR/.claude/gh-workflow.md"
+  assert_success
+  run cmp -s "$REPO_ROOT_REAL/claude-gh/commands/pm.md" "$TARGET_DIR/.claude/commands/pm.md"
+  assert_success
+}
+
+# ---------------------------------------------------------------------------
+# Placeholder preservation
+# ---------------------------------------------------------------------------
+
+@test "--force preserves filled-in {OWNER}/{REPO}/{PROJECT} when no flags passed" {
+  run "$CLAUDE_GH_TASK_INIT" --owner acme --repo widget --project 7
+  assert_success
+  # Re-run with --force and no flag values — placeholders should be carried forward.
+  run "$CLAUDE_GH_TASK_INIT" --force
+  assert_success
+  run cat "$TARGET_DIR/.claude/gh-workflow.md"
+  assert_output --partial "acme"
+  assert_output --partial "widget"
+  assert_output --partial "**Project number**: \`7\`"
+  refute_output --partial "{OWNER}"
+  refute_output --partial "{REPO}"
+  refute_output --partial "{PROJECT}"
+}
+
+@test "this-run flag value beats preserved value" {
+  run "$CLAUDE_GH_TASK_INIT" --owner acme --repo widget --project 7
+  assert_success
+  run "$CLAUDE_GH_TASK_INIT" --owner other --force
+  assert_success
+  run cat "$TARGET_DIR/.claude/gh-workflow.md"
+  assert_output --partial "other"
+  refute_output --partial "**Owner**: \`acme\`"
+  # REPO and PROJECT still preserved
+  assert_output --partial "widget"
+  assert_output --partial "**Project number**: \`7\`"
 }
 
 # ---------------------------------------------------------------------------

--- a/tests/claude_local_task_init.bats
+++ b/tests/claude_local_task_init.bats
@@ -107,23 +107,70 @@ teardown() {
 }
 
 # ---------------------------------------------------------------------------
-# --force and overwrite guard
+# Overwrite policy: --force / --restore / default (TTY prompt / non-TTY keep)
 # ---------------------------------------------------------------------------
 
-@test "fails if .claude/local-workflow.md already exists (no --force)" {
+@test "non-TTY default: existing workflow doc is kept silently (exit 0)" {
   run "$CLAUDE_LOCAL_TASK_INIT"
   assert_success
+  echo "USER EDIT" >> "$TARGET_DIR/.claude/local-workflow.md"
   run "$CLAUDE_LOCAL_TASK_INIT"
-  assert_failure
-  assert_output --partial "already exists"
+  assert_success
+  assert_output --partial "kept"
+  run cat "$TARGET_DIR/.claude/local-workflow.md"
+  assert_output --partial "USER EDIT"
 }
 
 @test "--force overwrites existing local-workflow.md" {
   run "$CLAUDE_LOCAL_TASK_INIT"
   assert_success
+  echo "USER EDIT" >> "$TARGET_DIR/.claude/local-workflow.md"
   run "$CLAUDE_LOCAL_TASK_INIT" --force
   assert_success
+  run cat "$TARGET_DIR/.claude/local-workflow.md"
+  refute_output --partial "USER EDIT"
+}
+
+@test "--force + --restore is rejected" {
+  run "$CLAUDE_LOCAL_TASK_INIT" --force --restore
+  assert_failure
+  assert_output --partial "mutually exclusive"
+}
+
+# ---------------------------------------------------------------------------
+# --restore: fill missing only
+# ---------------------------------------------------------------------------
+
+@test "--restore restores a deleted slash command without touching workflow" {
+  run "$CLAUDE_LOCAL_TASK_INIT"
+  assert_success
+  cp "$TARGET_DIR/.claude/local-workflow.md" "$BATS_TEST_TMPDIR/workflow.before"
+  rm "$TARGET_DIR/.claude/commands/pm.md"
+  run "$CLAUDE_LOCAL_TASK_INIT" --restore
+  assert_success
+  assert [ -f "$TARGET_DIR/.claude/commands/pm.md" ]
+  run cmp -s "$BATS_TEST_TMPDIR/workflow.before" "$TARGET_DIR/.claude/local-workflow.md"
+  assert_success
+}
+
+# ---------------------------------------------------------------------------
+# --workflow / --commands scope flags
+# ---------------------------------------------------------------------------
+
+@test "--commands installs slash commands without writing workflow doc" {
+  run "$CLAUDE_LOCAL_TASK_INIT" --commands
+  assert_success
+  assert [ ! -f "$TARGET_DIR/.claude/local-workflow.md" ]
+  for cmd in pm planner worker; do
+    assert [ -f "$TARGET_DIR/.claude/commands/$cmd.md" ]
+  done
+}
+
+@test "--workflow installs workflow doc without writing slash commands" {
+  run "$CLAUDE_LOCAL_TASK_INIT" --workflow
+  assert_success
   assert [ -f "$TARGET_DIR/.claude/local-workflow.md" ]
+  assert [ ! -d "$TARGET_DIR/.claude/commands" ]
 }
 
 @test "second run preserves existing tasks/README.md" {

--- a/tests/claude_notion_task_init.bats
+++ b/tests/claude_notion_task_init.bats
@@ -67,23 +67,70 @@ teardown() {
 }
 
 # ---------------------------------------------------------------------------
-# --force and overwrite guard
+# Overwrite policy: --force / --restore / default (TTY prompt / non-TTY keep)
 # ---------------------------------------------------------------------------
 
-@test "fails if .claude/notion-workflow.md already exists (no --force)" {
+@test "non-TTY default: existing workflow doc is kept silently (exit 0)" {
   run "$CLAUDE_NOTION_TASK_INIT"
   assert_success
+  echo "USER EDIT" >> "$TARGET_DIR/.claude/notion-workflow.md"
   run "$CLAUDE_NOTION_TASK_INIT"
-  assert_failure
-  assert_output --partial "already exists"
+  assert_success
+  assert_output --partial "kept"
+  run cat "$TARGET_DIR/.claude/notion-workflow.md"
+  assert_output --partial "USER EDIT"
 }
 
 @test "--force overwrites existing notion-workflow.md" {
   run "$CLAUDE_NOTION_TASK_INIT"
   assert_success
+  echo "USER EDIT" >> "$TARGET_DIR/.claude/notion-workflow.md"
   run "$CLAUDE_NOTION_TASK_INIT" --force
   assert_success
+  run cat "$TARGET_DIR/.claude/notion-workflow.md"
+  refute_output --partial "USER EDIT"
+}
+
+@test "--force + --restore is rejected" {
+  run "$CLAUDE_NOTION_TASK_INIT" --force --restore
+  assert_failure
+  assert_output --partial "mutually exclusive"
+}
+
+# ---------------------------------------------------------------------------
+# --restore: fill missing only
+# ---------------------------------------------------------------------------
+
+@test "--restore restores a deleted slash command without touching workflow" {
+  run "$CLAUDE_NOTION_TASK_INIT"
+  assert_success
+  cp "$TARGET_DIR/.claude/notion-workflow.md" "$BATS_TEST_TMPDIR/workflow.before"
+  rm "$TARGET_DIR/.claude/commands/pm.md"
+  run "$CLAUDE_NOTION_TASK_INIT" --restore
+  assert_success
+  assert [ -f "$TARGET_DIR/.claude/commands/pm.md" ]
+  run cmp -s "$BATS_TEST_TMPDIR/workflow.before" "$TARGET_DIR/.claude/notion-workflow.md"
+  assert_success
+}
+
+# ---------------------------------------------------------------------------
+# --workflow / --commands scope flags
+# ---------------------------------------------------------------------------
+
+@test "--commands installs slash commands without writing workflow doc" {
+  run "$CLAUDE_NOTION_TASK_INIT" --commands
+  assert_success
+  assert [ ! -f "$TARGET_DIR/.claude/notion-workflow.md" ]
+  for cmd in pm planner worker; do
+    assert [ -f "$TARGET_DIR/.claude/commands/$cmd.md" ]
+  done
+}
+
+@test "--workflow installs workflow doc without writing slash commands" {
+  run "$CLAUDE_NOTION_TASK_INIT" --workflow
+  assert_success
   assert [ -f "$TARGET_DIR/.claude/notion-workflow.md" ]
+  assert [ ! -d "$TARGET_DIR/.claude/commands" ]
 }
 
 # ---------------------------------------------------------------------------

--- a/tests/install_file.bats
+++ b/tests/install_file.bats
@@ -184,6 +184,27 @@ k"
 # Default policy when INSTALL_POLICY is unset
 # ---------------------------------------------------------------------------
 
+# ---------------------------------------------------------------------------
+# Atomic write (mktemp + mv): no temp-file leftovers
+# ---------------------------------------------------------------------------
+
+@test "force overwrite leaves no .XXXXXX temp files alongside dest" {
+  mkdir -p "$(dirname "$DEST")"
+  printf 'OLD\n' > "$DEST"
+  _run_install force "$SRC" "$DEST" "my-label"
+  assert_success
+  # Glob for any stray temp files in the dest directory.
+  run bash -c "shopt -s nullglob; printf '%s\n' '$(dirname "$DEST")'/dest.md.*"
+  assert_output ""
+}
+
+@test "missing dest write leaves no .XXXXXX temp files alongside dest" {
+  _run_install keep "$SRC" "$DEST" "my-label"
+  assert_success
+  run bash -c "shopt -s nullglob; printf '%s\n' '$(dirname "$DEST")'/dest.md.*"
+  assert_output ""
+}
+
 @test "unset policy defaults to 'keep'" {
   mkdir -p "$(dirname "$DEST")"
   printf 'OLD CONTENT\n' > "$DEST"

--- a/tests/install_file.bats
+++ b/tests/install_file.bats
@@ -1,0 +1,194 @@
+#!/usr/bin/env bats
+# Unit tests for lib/install-file.sh
+
+bats_load_library bats-support
+bats_load_library bats-assert
+
+load helpers/common
+
+INSTALL_FILE_LIB="$REPO_ROOT_REAL/lib/install-file.sh"
+
+setup() {
+  TMP_DIR=$(mktemp -d)
+  SRC="$TMP_DIR/src.md"
+  DEST="$TMP_DIR/sub/dest.md"
+  printf 'NEW CONTENT\n' > "$SRC"
+}
+
+teardown() {
+  [[ -n "${TMP_DIR:-}" && -d "$TMP_DIR" ]] && rm -rf "$TMP_DIR"
+}
+
+# Run install_file in a subshell so each invocation gets a fresh INSTALL_POLICY.
+_run_install() {
+  local policy="$1"; shift
+  run env INSTALL_POLICY="$policy" bash -c "source '$INSTALL_FILE_LIB'; install_file \"\$@\"" _ "$@"
+}
+
+# ---------------------------------------------------------------------------
+# Missing target → always write
+# ---------------------------------------------------------------------------
+
+@test "missing dest: keep policy writes file" {
+  _run_install keep "$SRC" "$DEST" "my-label"
+  assert_success
+  assert [ -f "$DEST" ]
+  run cat "$DEST"
+  assert_output "NEW CONTENT"
+}
+
+@test "missing dest: force policy writes file" {
+  _run_install force "$SRC" "$DEST" "my-label"
+  assert_success
+  assert [ -f "$DEST" ]
+}
+
+@test "missing dest: restore policy writes file" {
+  _run_install restore "$SRC" "$DEST" "my-label"
+  assert_success
+  assert [ -f "$DEST" ]
+}
+
+@test "missing dest: prompt policy writes file without prompting" {
+  _run_install prompt "$SRC" "$DEST" "my-label"
+  assert_success
+  assert [ -f "$DEST" ]
+  refute_output --partial "keep"
+}
+
+@test "missing dest: creates parent directory" {
+  _run_install keep "$SRC" "$TMP_DIR/a/b/c/d.md" "deep-label"
+  assert_success
+  assert [ -f "$TMP_DIR/a/b/c/d.md" ]
+}
+
+# ---------------------------------------------------------------------------
+# Existing target — each policy
+# ---------------------------------------------------------------------------
+
+@test "existing dest + keep: silently skips" {
+  mkdir -p "$(dirname "$DEST")"
+  printf 'OLD CONTENT\n' > "$DEST"
+  _run_install keep "$SRC" "$DEST" "my-label"
+  assert_success
+  assert_output --partial "kept"
+  run cat "$DEST"
+  assert_output "OLD CONTENT"
+}
+
+@test "existing dest + force: overwrites" {
+  mkdir -p "$(dirname "$DEST")"
+  printf 'OLD CONTENT\n' > "$DEST"
+  _run_install force "$SRC" "$DEST" "my-label"
+  assert_success
+  run cat "$DEST"
+  assert_output "NEW CONTENT"
+}
+
+@test "existing dest + restore: skips with restore marker in output" {
+  mkdir -p "$(dirname "$DEST")"
+  printf 'OLD CONTENT\n' > "$DEST"
+  _run_install restore "$SRC" "$DEST" "my-label"
+  assert_success
+  assert_output --partial "--restore"
+  run cat "$DEST"
+  assert_output "OLD CONTENT"
+}
+
+# ---------------------------------------------------------------------------
+# Prompt policy (stdin fed answers)
+# ---------------------------------------------------------------------------
+
+@test "prompt: 'k' keeps existing file" {
+  mkdir -p "$(dirname "$DEST")"
+  printf 'OLD CONTENT\n' > "$DEST"
+  run env INSTALL_POLICY=prompt bash -c "
+    source '$INSTALL_FILE_LIB'
+    install_file '$SRC' '$DEST' 'my-label'
+  " <<<"k"
+  assert_success
+  run cat "$DEST"
+  assert_output "OLD CONTENT"
+}
+
+@test "prompt: empty answer (default) keeps existing file" {
+  mkdir -p "$(dirname "$DEST")"
+  printf 'OLD CONTENT\n' > "$DEST"
+  run env INSTALL_POLICY=prompt bash -c "
+    source '$INSTALL_FILE_LIB'
+    install_file '$SRC' '$DEST' 'my-label'
+  " <<<""
+  assert_success
+  run cat "$DEST"
+  assert_output "OLD CONTENT"
+}
+
+@test "prompt: 'o' overwrites with new content" {
+  mkdir -p "$(dirname "$DEST")"
+  printf 'OLD CONTENT\n' > "$DEST"
+  run env INSTALL_POLICY=prompt bash -c "
+    source '$INSTALL_FILE_LIB'
+    install_file '$SRC' '$DEST' 'my-label'
+  " <<<"o"
+  assert_success
+  run cat "$DEST"
+  assert_output "NEW CONTENT"
+}
+
+@test "prompt: 'd' shows diff then re-prompts; final 'k' keeps file" {
+  mkdir -p "$(dirname "$DEST")"
+  printf 'OLD CONTENT\n' > "$DEST"
+  run env INSTALL_POLICY=prompt bash -c "
+    source '$INSTALL_FILE_LIB'
+    install_file '$SRC' '$DEST' 'my-label'
+  " <<<"d
+k"
+  assert_success
+  # Diff output should have appeared
+  assert_output --partial "diff:"
+  run cat "$DEST"
+  assert_output "OLD CONTENT"
+}
+
+@test "prompt: invalid answer re-prompts" {
+  mkdir -p "$(dirname "$DEST")"
+  printf 'OLD CONTENT\n' > "$DEST"
+  run env INSTALL_POLICY=prompt bash -c "
+    source '$INSTALL_FILE_LIB'
+    install_file '$SRC' '$DEST' 'my-label'
+  " <<<"x
+k"
+  assert_success
+  assert_output --partial "Invalid choice"
+}
+
+# ---------------------------------------------------------------------------
+# Error cases
+# ---------------------------------------------------------------------------
+
+@test "missing source file is a hard error" {
+  _run_install keep "$TMP_DIR/nope.md" "$DEST" "my-label"
+  assert_failure
+  assert_output --partial "source not found"
+}
+
+@test "unknown policy is a hard error (when dest exists)" {
+  mkdir -p "$(dirname "$DEST")"
+  printf 'OLD CONTENT\n' > "$DEST"
+  _run_install bogus "$SRC" "$DEST" "my-label"
+  assert_failure
+  assert_output --partial "unknown INSTALL_POLICY"
+}
+
+# ---------------------------------------------------------------------------
+# Default policy when INSTALL_POLICY is unset
+# ---------------------------------------------------------------------------
+
+@test "unset policy defaults to 'keep'" {
+  mkdir -p "$(dirname "$DEST")"
+  printf 'OLD CONTENT\n' > "$DEST"
+  run bash -c "source '$INSTALL_FILE_LIB'; install_file '$SRC' '$DEST' 'my-label'"
+  assert_success
+  run cat "$DEST"
+  assert_output "OLD CONTENT"
+}

--- a/tests/jira_task_init.bats
+++ b/tests/jira_task_init.bats
@@ -94,15 +94,18 @@ teardown() {
 }
 
 # ---------------------------------------------------------------------------
-# --force and overwrite guard
+# Overwrite policy: --force / --restore / default (TTY prompt / non-TTY keep)
 # ---------------------------------------------------------------------------
 
-@test "fails if .claude/jira-workflow.md already exists (no --force)" {
-  run "$JIRA_TASK_INIT"
+@test "non-TTY default: existing workflow doc is kept silently (exit 0)" {
+  run "$JIRA_TASK_INIT" --key OLD
   assert_success
-  run "$JIRA_TASK_INIT"
-  assert_failure
-  assert_output --partial "already exists"
+  run "$JIRA_TASK_INIT" --key IGNORED
+  assert_success
+  assert_output --partial "kept"
+  run cat "$TARGET_DIR/.claude/jira-workflow.md"
+  assert_output --partial "OLD-123"
+  refute_output --partial "IGNORED-123"
 }
 
 @test "--force overwrites existing jira-workflow.md" {
@@ -113,6 +116,66 @@ teardown() {
   run cat "$TARGET_DIR/.claude/jira-workflow.md"
   assert_output --partial "NEW-123"
   refute_output --partial "OLD-123"
+}
+
+@test "--force + --restore is rejected" {
+  run "$JIRA_TASK_INIT" --force --restore
+  assert_failure
+  assert_output --partial "mutually exclusive"
+}
+
+# ---------------------------------------------------------------------------
+# --restore: fill missing only
+# ---------------------------------------------------------------------------
+
+@test "--restore restores a deleted slash command without touching workflow" {
+  run "$JIRA_TASK_INIT" --site "https://acme.atlassian.net" --key ML --board "My Board"
+  assert_success
+  cp "$TARGET_DIR/.claude/jira-workflow.md" "$BATS_TEST_TMPDIR/workflow.before"
+  rm "$TARGET_DIR/.claude/commands/pm.md"
+  run "$JIRA_TASK_INIT" --restore
+  assert_success
+  assert [ -f "$TARGET_DIR/.claude/commands/pm.md" ]
+  run cmp -s "$BATS_TEST_TMPDIR/workflow.before" "$TARGET_DIR/.claude/jira-workflow.md"
+  assert_success
+}
+
+# ---------------------------------------------------------------------------
+# --workflow / --commands scope flags
+# ---------------------------------------------------------------------------
+
+@test "--commands installs slash commands without writing workflow doc" {
+  run "$JIRA_TASK_INIT" --commands
+  assert_success
+  assert [ ! -f "$TARGET_DIR/.claude/jira-workflow.md" ]
+  for cmd in pm planner worker; do
+    assert [ -f "$TARGET_DIR/.claude/commands/$cmd.md" ]
+  done
+}
+
+@test "--workflow installs workflow doc without writing slash commands" {
+  run "$JIRA_TASK_INIT" --workflow
+  assert_success
+  assert [ -f "$TARGET_DIR/.claude/jira-workflow.md" ]
+  assert [ ! -d "$TARGET_DIR/.claude/commands" ]
+}
+
+# ---------------------------------------------------------------------------
+# Placeholder preservation
+# ---------------------------------------------------------------------------
+
+@test "--force preserves filled-in {SITE}/{KEY}/{BOARD} when no flags passed" {
+  run "$JIRA_TASK_INIT" --site "https://acme.atlassian.net" --key ML --board "My Board"
+  assert_success
+  run "$JIRA_TASK_INIT" --force
+  assert_success
+  run cat "$TARGET_DIR/.claude/jira-workflow.md"
+  assert_output --partial "https://acme.atlassian.net"
+  assert_output --partial "ML-123"
+  assert_output --partial "My Board"
+  refute_output --partial "{SITE}"
+  refute_output --partial "{KEY}"
+  refute_output --partial "{BOARD}"
 }
 
 # ---------------------------------------------------------------------------

--- a/tests/kiro_gh_task_init.bats
+++ b/tests/kiro_gh_task_init.bats
@@ -114,15 +114,18 @@ teardown() {
 }
 
 # ---------------------------------------------------------------------------
-# --force and overwrite guard
+# Overwrite policy: --force / --restore / default (TTY prompt / non-TTY keep)
 # ---------------------------------------------------------------------------
 
-@test "fails if .kiro/steering/gh-workflow.md already exists (no --force)" {
-  run "$KIRO_GH_TASK_INIT"
+@test "non-TTY default: existing workflow doc is kept silently (exit 0)" {
+  run "$KIRO_GH_TASK_INIT" --owner old
   assert_success
-  run "$KIRO_GH_TASK_INIT"
-  assert_failure
-  assert_output --partial "already exists"
+  run "$KIRO_GH_TASK_INIT" --owner ignored
+  assert_success
+  assert_output --partial "kept"
+  run cat "$TARGET_DIR/.kiro/steering/gh-workflow.md"
+  assert_output --partial "old"
+  refute_output --partial "ignored"
 }
 
 @test "--force overwrites existing gh-workflow.md" {
@@ -133,6 +136,66 @@ teardown() {
   run cat "$TARGET_DIR/.kiro/steering/gh-workflow.md"
   assert_output --partial "new"
   refute_output --partial "**Owner**: \`old\`"
+}
+
+@test "--force + --restore is rejected" {
+  run "$KIRO_GH_TASK_INIT" --force --restore
+  assert_failure
+  assert_output --partial "mutually exclusive"
+}
+
+# ---------------------------------------------------------------------------
+# --restore: fill missing only
+# ---------------------------------------------------------------------------
+
+@test "--restore restores a deleted agent without touching workflow" {
+  run "$KIRO_GH_TASK_INIT" --owner acme --repo widget --project 7
+  assert_success
+  cp "$TARGET_DIR/.kiro/steering/gh-workflow.md" "$BATS_TEST_TMPDIR/workflow.before"
+  rm "$TARGET_DIR/.kiro/agents/pm.json"
+  run "$KIRO_GH_TASK_INIT" --restore
+  assert_success
+  assert [ -f "$TARGET_DIR/.kiro/agents/pm.json" ]
+  run cmp -s "$BATS_TEST_TMPDIR/workflow.before" "$TARGET_DIR/.kiro/steering/gh-workflow.md"
+  assert_success
+}
+
+# ---------------------------------------------------------------------------
+# --workflow / --commands scope flags
+# ---------------------------------------------------------------------------
+
+@test "--commands installs agents without writing workflow doc" {
+  run "$KIRO_GH_TASK_INIT" --commands
+  assert_success
+  assert [ ! -f "$TARGET_DIR/.kiro/steering/gh-workflow.md" ]
+  for agent in pm planner worker; do
+    assert [ -f "$TARGET_DIR/.kiro/agents/$agent.json" ]
+  done
+}
+
+@test "--workflow installs workflow doc without writing agents" {
+  run "$KIRO_GH_TASK_INIT" --workflow
+  assert_success
+  assert [ -f "$TARGET_DIR/.kiro/steering/gh-workflow.md" ]
+  assert [ ! -d "$TARGET_DIR/.kiro/agents" ]
+}
+
+# ---------------------------------------------------------------------------
+# Placeholder preservation
+# ---------------------------------------------------------------------------
+
+@test "--force preserves filled-in {OWNER}/{REPO}/{PROJECT} when no flags passed" {
+  run "$KIRO_GH_TASK_INIT" --owner acme --repo widget --project 7
+  assert_success
+  run "$KIRO_GH_TASK_INIT" --force
+  assert_success
+  run cat "$TARGET_DIR/.kiro/steering/gh-workflow.md"
+  assert_output --partial "acme"
+  assert_output --partial "widget"
+  assert_output --partial "**Project number**: \`7\`"
+  refute_output --partial "{OWNER}"
+  refute_output --partial "{REPO}"
+  refute_output --partial "{PROJECT}"
 }
 
 # ---------------------------------------------------------------------------

--- a/tests/kiro_local_task_init.bats
+++ b/tests/kiro_local_task_init.bats
@@ -76,23 +76,70 @@ teardown() {
 }
 
 # ---------------------------------------------------------------------------
-# --force and overwrite guard
+# Overwrite policy: --force / --restore / default (TTY prompt / non-TTY keep)
 # ---------------------------------------------------------------------------
 
-@test "fails if .kiro/steering/local-workflow.md already exists (no --force)" {
+@test "non-TTY default: existing workflow doc is kept silently (exit 0)" {
   run "$KIRO_LOCAL_TASK_INIT"
   assert_success
+  echo "USER EDIT" >> "$TARGET_DIR/.kiro/steering/local-workflow.md"
   run "$KIRO_LOCAL_TASK_INIT"
-  assert_failure
-  assert_output --partial "already exists"
+  assert_success
+  assert_output --partial "kept"
+  run cat "$TARGET_DIR/.kiro/steering/local-workflow.md"
+  assert_output --partial "USER EDIT"
 }
 
 @test "--force overwrites existing local-workflow.md" {
   run "$KIRO_LOCAL_TASK_INIT"
   assert_success
+  echo "USER EDIT" >> "$TARGET_DIR/.kiro/steering/local-workflow.md"
   run "$KIRO_LOCAL_TASK_INIT" --force
   assert_success
+  run cat "$TARGET_DIR/.kiro/steering/local-workflow.md"
+  refute_output --partial "USER EDIT"
+}
+
+@test "--force + --restore is rejected" {
+  run "$KIRO_LOCAL_TASK_INIT" --force --restore
+  assert_failure
+  assert_output --partial "mutually exclusive"
+}
+
+# ---------------------------------------------------------------------------
+# --restore: fill missing only
+# ---------------------------------------------------------------------------
+
+@test "--restore restores a deleted agent without touching workflow" {
+  run "$KIRO_LOCAL_TASK_INIT"
+  assert_success
+  cp "$TARGET_DIR/.kiro/steering/local-workflow.md" "$BATS_TEST_TMPDIR/workflow.before"
+  rm "$TARGET_DIR/.kiro/agents/pm.json"
+  run "$KIRO_LOCAL_TASK_INIT" --restore
+  assert_success
+  assert [ -f "$TARGET_DIR/.kiro/agents/pm.json" ]
+  run cmp -s "$BATS_TEST_TMPDIR/workflow.before" "$TARGET_DIR/.kiro/steering/local-workflow.md"
+  assert_success
+}
+
+# ---------------------------------------------------------------------------
+# --workflow / --commands scope flags
+# ---------------------------------------------------------------------------
+
+@test "--commands installs agents without writing workflow doc" {
+  run "$KIRO_LOCAL_TASK_INIT" --commands
+  assert_success
+  assert [ ! -f "$TARGET_DIR/.kiro/steering/local-workflow.md" ]
+  for agent in pm planner worker; do
+    assert [ -f "$TARGET_DIR/.kiro/agents/$agent.json" ]
+  done
+}
+
+@test "--workflow installs workflow doc without writing agents" {
+  run "$KIRO_LOCAL_TASK_INIT" --workflow
+  assert_success
   assert [ -f "$TARGET_DIR/.kiro/steering/local-workflow.md" ]
+  assert [ ! -d "$TARGET_DIR/.kiro/agents" ]
 }
 
 @test "second run preserves existing tasks/README.md" {

--- a/tests/kiro_notion_task_init.bats
+++ b/tests/kiro_notion_task_init.bats
@@ -65,23 +65,70 @@ teardown() {
 }
 
 # ---------------------------------------------------------------------------
-# --force and overwrite guard
+# Overwrite policy: --force / --restore / default (TTY prompt / non-TTY keep)
 # ---------------------------------------------------------------------------
 
-@test "fails if .kiro/steering/notion-workflow.md already exists (no --force)" {
+@test "non-TTY default: existing workflow doc is kept silently (exit 0)" {
   run "$KIRO_TASK_INIT"
   assert_success
+  echo "USER EDIT" >> "$TARGET_DIR/.kiro/steering/notion-workflow.md"
   run "$KIRO_TASK_INIT"
-  assert_failure
-  assert_output --partial "already exists"
+  assert_success
+  assert_output --partial "kept"
+  run cat "$TARGET_DIR/.kiro/steering/notion-workflow.md"
+  assert_output --partial "USER EDIT"
 }
 
 @test "--force overwrites existing notion-workflow.md" {
   run "$KIRO_TASK_INIT"
   assert_success
+  echo "USER EDIT" >> "$TARGET_DIR/.kiro/steering/notion-workflow.md"
   run "$KIRO_TASK_INIT" --force
   assert_success
+  run cat "$TARGET_DIR/.kiro/steering/notion-workflow.md"
+  refute_output --partial "USER EDIT"
+}
+
+@test "--force + --restore is rejected" {
+  run "$KIRO_TASK_INIT" --force --restore
+  assert_failure
+  assert_output --partial "mutually exclusive"
+}
+
+# ---------------------------------------------------------------------------
+# --restore: fill missing only
+# ---------------------------------------------------------------------------
+
+@test "--restore restores a deleted agent without touching workflow" {
+  run "$KIRO_TASK_INIT"
+  assert_success
+  cp "$TARGET_DIR/.kiro/steering/notion-workflow.md" "$BATS_TEST_TMPDIR/workflow.before"
+  rm "$TARGET_DIR/.kiro/agents/pm.json"
+  run "$KIRO_TASK_INIT" --restore
+  assert_success
+  assert [ -f "$TARGET_DIR/.kiro/agents/pm.json" ]
+  run cmp -s "$BATS_TEST_TMPDIR/workflow.before" "$TARGET_DIR/.kiro/steering/notion-workflow.md"
+  assert_success
+}
+
+# ---------------------------------------------------------------------------
+# --workflow / --commands scope flags
+# ---------------------------------------------------------------------------
+
+@test "--commands installs agents without writing workflow doc" {
+  run "$KIRO_TASK_INIT" --commands
+  assert_success
+  assert [ ! -f "$TARGET_DIR/.kiro/steering/notion-workflow.md" ]
+  for agent in pm planner worker; do
+    assert [ -f "$TARGET_DIR/.kiro/agents/$agent.json" ]
+  done
+}
+
+@test "--workflow installs workflow doc without writing agents" {
+  run "$KIRO_TASK_INIT" --workflow
+  assert_success
   assert [ -f "$TARGET_DIR/.kiro/steering/notion-workflow.md" ]
+  assert [ ! -d "$TARGET_DIR/.kiro/agents" ]
 }
 
 # ---------------------------------------------------------------------------

--- a/tests/preserve_placeholders.bats
+++ b/tests/preserve_placeholders.bats
@@ -1,0 +1,97 @@
+#!/usr/bin/env bats
+# Unit tests for lib/preserve-placeholders.sh
+
+bats_load_library bats-support
+bats_load_library bats-assert
+
+load helpers/common
+
+PRESERVE_LIB="$REPO_ROOT_REAL/lib/preserve-placeholders.sh"
+
+setup() {
+  TMP_DIR=$(mktemp -d)
+  FILE="$TMP_DIR/workflow.md"
+}
+
+teardown() {
+  [[ -n "${TMP_DIR:-}" && -d "$TMP_DIR" ]] && rm -rf "$TMP_DIR"
+}
+
+# ---------------------------------------------------------------------------
+# Generic extractor
+# ---------------------------------------------------------------------------
+
+@test "extracts filled value from existing file" {
+  cat >"$FILE" <<'EOF'
+- **Owner**: `martin-conur` (GitHub user or org name)
+EOF
+  run bash -c "source '$PRESERVE_LIB'; extract_existing_value '$FILE' '^- \\*\\*Owner\\*\\*: \`([^\`]+)\`.*' '{OWNER}'"
+  assert_success
+  assert_output "martin-conur"
+}
+
+@test "returns empty when placeholder is still raw" {
+  cat >"$FILE" <<'EOF'
+- **Owner**: `{OWNER}` (GitHub user or org name)
+EOF
+  run bash -c "source '$PRESERVE_LIB'; extract_existing_value '$FILE' '^- \\*\\*Owner\\*\\*: \`([^\`]+)\`.*' '{OWNER}'"
+  assert_success
+  assert_output ""
+}
+
+@test "returns empty when file does not exist" {
+  run bash -c "source '$PRESERVE_LIB'; extract_existing_value '$TMP_DIR/nope.md' '.*' '{OWNER}'"
+  assert_success
+  assert_output ""
+}
+
+@test "returns empty when pattern matches nothing" {
+  cat >"$FILE" <<'EOF'
+unrelated content
+EOF
+  run bash -c "source '$PRESERVE_LIB'; extract_existing_value '$FILE' '^- \\*\\*Owner\\*\\*: \`([^\`]+)\`.*' '{OWNER}'"
+  assert_success
+  assert_output ""
+}
+
+@test "takes the first match when several lines match" {
+  cat >"$FILE" <<'EOF'
+- **Owner**: `first-owner` (...)
+- **Owner**: `second-owner` (duplicate)
+EOF
+  run bash -c "source '$PRESERVE_LIB'; extract_existing_value '$FILE' '^- \\*\\*Owner\\*\\*: \`([^\`]+)\`.*' '{OWNER}'"
+  assert_success
+  assert_output "first-owner"
+}
+
+# ---------------------------------------------------------------------------
+# Real-world placeholder shapes
+# ---------------------------------------------------------------------------
+
+@test "extracts {REPO} placeholder shape" {
+  cat >"$FILE" <<'EOF'
+- **Owner**: `martin-conur` (GitHub user or org name)
+- **Repo**: `task-force` (repository name)
+EOF
+  run bash -c "source '$PRESERVE_LIB'; extract_existing_value '$FILE' '^- \\*\\*Repo\\*\\*: \`([^\`]+)\`.*' '{REPO}'"
+  assert_success
+  assert_output "task-force"
+}
+
+@test "extracts {PROJECT} placeholder shape" {
+  cat >"$FILE" <<'EOF'
+- **Project number**: `7` (from the project URL: ...)
+EOF
+  run bash -c "source '$PRESERVE_LIB'; extract_existing_value '$FILE' '^- \\*\\*Project number\\*\\*: \`([^\`]+)\`.*' '{PROJECT}'"
+  assert_success
+  assert_output "7"
+}
+
+@test "extracts Jira {SITE} placeholder shape" {
+  cat >"$FILE" <<'EOF'
+- **Site**: `https://acme.atlassian.net`
+EOF
+  run bash -c "source '$PRESERVE_LIB'; extract_existing_value '$FILE' '^- \\*\\*Site\\*\\*: \`([^\`]+)\`.*' '{SITE}'"
+  assert_success
+  assert_output "https://acme.atlassian.net"
+}


### PR DESCRIPTION
## Summary

- Adds `--restore`, `--workflow`, `--commands` flags to every `task-init <impl>`.
- Changes the "target file exists" default: TTY now prompts per file (`[k]eep / [o]verwrite / [d]iff`), non-TTY silently keeps (exit 0). Previous behavior was hard-fail.
- Re-rendering the workflow doc now carries previously-filled `{OWNER}` / `{REPO}` / `{PROJECT}` / `{SITE}` / `{KEY}` / `{BOARD}` values forward automatically.

Closes #37.

## Implementation

Two new shared helpers:
- `lib/install-file.sh` — keep / overwrite / prompt / restore decision, used by every `bin/task-init`.
- `lib/preserve-placeholders.sh` — generic extractor for already-filled values; per-loadout patterns live in each `task-init`.

All 7 loadout `bin/task-init` scripts updated to source the helpers and respect the scope + policy flags.

## Test plan

- [x] `./run_tests.sh` — 520 tests pass, 0 failures (was 460, +60 new tests)
- [x] `bash tools/check-drift.sh` — 12/12 groups still byte-identical across loadouts
- [x] `shellcheck -x …` — exits 0 (matches main)
- [x] Manual smoke: install → delete a slash command → `--restore` rebuilds it without touching the workflow doc → `--commands --force` refreshes commands while leaving workflow + filled IDs intact
- [x] Non-TTY safety: `echo | task-init claude-gh` on an existing project exits 0 silently, no files modified

🤖 Generated with [Claude Code](https://claude.com/claude-code)