### PR TITLE
task/shellcheck fix

### DIFF
--- a/claude-gh/bin/task-init
+++ b/claude-gh/bin/task-init
@@ -120,6 +120,9 @@ mkdir -p "$REPO_ROOT/.claude"
 # an existing workflow file when the user did not pass a flag and the variable
 # is still empty (interactive prompts run after this so the user can still
 # override).
+# Backticks in the regex patterns match the literal backticks rendered in the
+# markdown workflow doc (`OWNER`). shellcheck would otherwise warn SC2016.
+# shellcheck disable=SC2016
 _preserve_placeholders() {
   local existing="$1"
   [[ -f "$existing" ]] || return 0

--- a/claude-jira/bin/task-init
+++ b/claude-jira/bin/task-init
@@ -102,6 +102,9 @@ CLAUDE_MD="$REPO_ROOT/CLAUDE.md"
 
 mkdir -p "$REPO_ROOT/.claude"
 
+# Backticks in the regex patterns match the literal backticks rendered in the
+# markdown workflow doc (`SITE`). shellcheck would otherwise warn SC2016.
+# shellcheck disable=SC2016
 _preserve_placeholders() {
   local existing="$1"
   [[ -f "$existing" ]] || return 0

--- a/kiro-gh/bin/task-init
+++ b/kiro-gh/bin/task-init
@@ -111,6 +111,9 @@ TARGET="$REPO_ROOT/.kiro/steering/gh-workflow.md"
 
 mkdir -p "$REPO_ROOT/.kiro/steering"
 
+# Backticks in the regex patterns match the literal backticks rendered in the
+# markdown workflow doc (`OWNER`). shellcheck would otherwise warn SC2016.
+# shellcheck disable=SC2016
 _preserve_placeholders() {
   local existing="$1"
   [[ -f "$existing" ]] || return 0


### PR DESCRIPTION
- **installer prompts: enable readline so arrow keys work (#23) (#67)**
- **task-init: preserve user edits in workflow file when re-initing (#37) (#68)**
- **PM↔worker messaging: low-latency push via zellij + hook-gated idle state (#70)**
- **ShellCheck CI failing: SC2016 on _preserve_placeholders regex backticks: silence false positive with per-function disable**
