### PR TITLE
CI: require ShellCheck / Bats / Drift status checks on main branch protection

### DIFF
--- a/README.md
+++ b/README.md
@@ -435,6 +435,40 @@ Add script path variables to `tests/helpers/common.bash`. The runner picks up ev
 
 ---
 
+## Maintaining task-force
+
+`main` is protected via the GitHub API (not a YAML file), so the config lives off-repo. The current rules:
+
+- Required status checks (all four must be green before merge): `ShellCheck`, `Bats tests (ubuntu-latest)`, `Bats tests (macos-latest)`, `Loadout drift check`
+- `strict=true` — PR branch must be up-to-date with `main`
+- `enforce_admins=true` — the maintainer can't bypass either
+- Force-pushes and branch deletion blocked
+
+Re-apply (or restore after an accidental clear):
+
+```bash
+gh api -X PUT repos/martin-conur/task-force/branches/main/protection --input - <<'JSON'
+{
+  "required_status_checks": {
+    "strict": true,
+    "contexts": [
+      "ShellCheck",
+      "Bats tests (ubuntu-latest)",
+      "Bats tests (macos-latest)",
+      "Loadout drift check"
+    ]
+  },
+  "enforce_admins": true,
+  "required_pull_request_reviews": null,
+  "restrictions": null
+}
+JSON
+```
+
+Inspect: `gh api repos/martin-conur/task-force/branches/main/protection | jq`.
+
+---
+
 ## License
 
 [MIT](LICENSE) © Martin Conur


### PR DESCRIPTION
## Summary

- Applied branch protection on `main` via `gh api` (no YAML — GitHub branch protection lives off-repo). Required status checks: `ShellCheck`, `Bats tests (ubuntu-latest)`, `Bats tests (macos-latest)`, `Loadout drift check`. `strict=true`, `enforce_admins=true`, force-push + branch deletion blocked.
- README gains a "Maintaining task-force" section with the re-apply incantation so the rules are reproducible if cleared.

Closes #73

## Verification

```bash
gh api repos/martin-conur/task-force/branches/main/protection \
  | jq '{contexts: .required_status_checks.contexts, strict: .required_status_checks.strict, enforce_admins: .enforce_admins.enabled}'
```

Returns the expected four contexts, `strict: true`, `enforce_admins: true`.

## Test plan

- [ ] CI is green on this PR (proves the four expected check names match what GitHub reports)
- [ ] Merge button stays disabled until all four checks pass (this PR is itself the first test of the new rule)
- [ ] After merge, `gh api .../protection` still returns the four contexts (sanity check)

🤖 Generated with [Claude Code](https://claude.com/claude-code)