### PR TITLE
task-init: seed Bash(radio *) into permissions.allow (all claude loadouts)

### DIFF
--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -46,7 +46,8 @@
       "Bash(gh project list *)",
       "Bash(gh project view *)",
       "Bash(gh repo view *)",
-      "Bash(gh search issues *)"
+      "Bash(gh search issues *)",
+      "Bash(radio *)"
     ]
   }
 }

--- a/claude-gh/bin/task-init
+++ b/claude-gh/bin/task-init
@@ -287,7 +287,8 @@ _radio_install_hooks() {
           "Bash(gh pr list *)",
           "Bash(gh label list *)",
           "Bash(gh auth status)",
-          "Bash(gh repo view *)"
+          "Bash(gh repo view *)",
+          "Bash(radio *)"
         ] | unique
       )
     ' "$settings_file" >"$tmp"

--- a/claude-jira/bin/task-init
+++ b/claude-jira/bin/task-init
@@ -254,7 +254,8 @@ _radio_install_hooks() {
           "mcp__atlassian__getJiraProjectIssueTypesMetadata",
           "mcp__atlassian__getIssueLinkTypes",
           "mcp__atlassian__lookupJiraAccountId",
-          "mcp__atlassian__atlassianUserInfo"
+          "mcp__atlassian__atlassianUserInfo",
+          "Bash(radio *)"
         ] | unique
       )
     ' "$settings_file" >"$tmp"

--- a/claude-local/bin/task-init
+++ b/claude-local/bin/task-init
@@ -223,10 +223,13 @@ fi
 # Pre-existing user hooks (e.g. ./scripts/pre-tool-lint.sh on Stop) are
 # preserved.
 #
-# No permissions.allow seeding: claude-local has no external tracker. PM /
-# planner / worker reads are filesystem operations covered by Claude Code's
-# built-in Read / Grep / Glob tools (which don't need allow-list entries).
-# The PM's only shell-out is `task-board`, locally installed and routine.
+# No tracker-related permissions.allow seeding: claude-local has no external
+# tracker. PM / planner / worker reads are filesystem operations covered by
+# Claude Code's built-in Read / Grep / Glob tools (which don't need allow-list
+# entries). The PM's only shell-out is `task-board`, locally installed and
+# routine. The one exception is `Bash(radio *)`: the hooks installed here drive
+# local-only IPC with no external blast radius, so agent-initiated radio calls
+# are auto-allowed to keep PM↔worker coordination from prompting.
 _radio_install_hooks() {
   local settings_file="$REPO_ROOT/.claude/settings.json"
   local loadout="claude-local"
@@ -258,6 +261,13 @@ _radio_install_hooks() {
     | .hooks.SessionStart     = add_radio(.hooks.SessionStart;     $sess)
     | .hooks.UserPromptSubmit = add_radio(.hooks.UserPromptSubmit; $ups)
     | .hooks.Stop             = add_radio(.hooks.Stop;             $stop)
+    | .permissions //= {}
+    | .permissions.allow //= []
+    | .permissions.allow = (
+        .permissions.allow + [
+          "Bash(radio *)"
+        ] | unique
+      )
     ' "$settings_file" >"$tmp"
   mv -f "$tmp" "$settings_file"
   echo "✓ Merged radio hooks into $settings_file"

--- a/claude-notion/bin/task-init
+++ b/claude-notion/bin/task-init
@@ -210,7 +210,8 @@ _radio_install_hooks() {
           "mcp__notion__notion-get-teams",
           "mcp__notion__notion-get-users",
           "mcp__notion__notion-get-user",
-          "mcp__notion__notion-get-self"
+          "mcp__notion__notion-get-self",
+          "Bash(radio *)"
         ] | unique
       )
     ' "$settings_file" >"$tmp"

--- a/tests/claude_gh_task_init.bats
+++ b/tests/claude_gh_task_init.bats
@@ -415,6 +415,7 @@ EOF
   assert_output --partial "Bash(gh project view *)"
   assert_output --partial "Bash(gh search issues *)"
   assert_output --partial "Bash(gh pr view *)"
+  assert_output --partial "Bash(radio *)"
   # Mutations must NOT be auto-allowed.
   refute_output --partial "gh issue edit"
   refute_output --partial "gh pr merge"

--- a/tests/claude_local_task_init.bats
+++ b/tests/claude_local_task_init.bats
@@ -235,6 +235,45 @@ teardown() {
 }
 
 # ---------------------------------------------------------------------------
+# Radio allow-list seeding into .claude/settings.json
+# ---------------------------------------------------------------------------
+
+@test "seeds Bash(radio *) into permissions.allow" {
+  run "$CLAUDE_LOCAL_TASK_INIT"
+  assert_success
+  run jq -r '.permissions.allow[]' "$TARGET_DIR/.claude/settings.json"
+  assert_output --partial "Bash(radio *)"
+}
+
+@test "idempotent: re-run does not duplicate the radio allow-list entry" {
+  run "$CLAUDE_LOCAL_TASK_INIT"
+  assert_success
+  local before
+  before=$(jq -r '.permissions.allow | length' "$TARGET_DIR/.claude/settings.json")
+  run "$CLAUDE_LOCAL_TASK_INIT" --force
+  assert_success
+  local after
+  after=$(jq -r '.permissions.allow | length' "$TARGET_DIR/.claude/settings.json")
+  assert_equal "$before" "$after"
+}
+
+@test "preserves a pre-existing user permissions.allow entry" {
+  mkdir -p "$TARGET_DIR/.claude"
+  cat > "$TARGET_DIR/.claude/settings.json" <<'EOF'
+{
+  "permissions": {
+    "allow": ["Bash(custom *)"]
+  }
+}
+EOF
+  run "$CLAUDE_LOCAL_TASK_INIT"
+  assert_success
+  run jq -r '.permissions.allow[]' "$TARGET_DIR/.claude/settings.json"
+  assert_output --partial "Bash(custom *)"
+  assert_output --partial "Bash(radio *)"
+}
+
+# ---------------------------------------------------------------------------
 # Error cases
 # ---------------------------------------------------------------------------
 

--- a/tests/claude_notion_task_init.bats
+++ b/tests/claude_notion_task_init.bats
@@ -235,6 +235,7 @@ teardown() {
   assert_output --partial "mcp__notion__notion-search"
   assert_output --partial "mcp__notion__notion-fetch"
   assert_output --partial "mcp__notion__notion-query-data-sources"
+  assert_output --partial "Bash(radio *)"
   # Writes must NOT be auto-allowed.
   refute_output --partial "notion-create-pages"
   refute_output --partial "notion-update-page"

--- a/tests/jira_task_init.bats
+++ b/tests/jira_task_init.bats
@@ -251,6 +251,7 @@ teardown() {
   assert_output --partial "mcp__atlassian__getJiraIssue"
   assert_output --partial "mcp__atlassian__searchJiraIssuesUsingJql"
   assert_output --partial "mcp__atlassian__getVisibleJiraProjects"
+  assert_output --partial "Bash(radio *)"
   # Writes must NOT be auto-allowed.
   refute_output --partial "createJiraIssue"
   refute_output --partial "editJiraIssue"


### PR DESCRIPTION
## Summary

Closes #83.

Radio is local-only IPC with no external blast radius — agent-initiated
`radio send` / `check` / `ack` / `read` / `orphans` shouldn't hit the
permissions system. (Hooks already bypass it, so `register` / `busy` /
`ready` / `check` from `SessionStart` / `UserPromptSubmit` / `Stop` were
already silent — only PM↔worker handoffs were prompting.)

- `claude-gh`, `claude-jira`, `claude-notion` `bin/task-init`: append
  `Bash(radio *)` to the seeded `permissions.allow` jq filter. Existing
  `| unique` keeps it idempotent.
- `claude-local/bin/task-init`: this loadout previously seeded nothing
  into `permissions.allow` (no external tracker). Start seeding for radio
  specifically — the rest of the comment is preserved, with a note
  explaining radio is the one exception because the hooks install it
  locally.
- Refreshed dogfooded `.claude/settings.json` via `task-init claude-gh --force --hooks`.
- Added bats assertions to all four suites:
  - `tests/claude_gh_task_init.bats`, `jira_task_init.bats`,
    `claude_notion_task_init.bats`: extended the existing
    "seeds … into permissions.allow" tests with `assert_output --partial "Bash(radio *)"`.
  - `tests/claude_local_task_init.bats` had no allow-list tests; added
    three new ones (seed, idempotent, preserves pre-existing).

## Test plan

- [x] `./run_tests.sh claude_gh_task_init` — green (37/37)
- [x] `./run_tests.sh jira_task_init` — green (22/22)
- [x] `./run_tests.sh claude_notion_task_init` — green (22/22)
- [x] `./run_tests.sh claude_local_task_init` — green (25/25)
- [x] `bash tools/check-drift.sh` — clean (16 groups)
- [x] CI shellcheck invocation (`shellcheck -x install.sh task-init … */bin/*`) — clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)