### PR TITLE
README: sync radio + workflow sections with canonical handoff model (#87)

### DIFF
--- a/README.md
+++ b/README.md
@@ -358,6 +358,24 @@ Spawn workers with `task-work tasks/NNN-slug.md`. Same Kiro shortcuts as `kiro-n
 
 Once you've installed a Claude loadout, `task-init` auto-installs **radio** — a low-latency mailbox CLI under `~/.task-force/radio/` that lets the PM agent and worker agents ping each other directly. No human courier, seconds-level wake-up when the recipient tab is idle, queue-and-defer when busy. The `kiro-*` loadouts install the equivalent hooks under `.kiro/hooks/` instead.
 
+Radio is the **canonical** coordination channel between the planner, PM, and workers — every role transition in the workflow runs through it. The PM / planner / worker prompts shell out to `radio send` at every documented handoff point.
+
+### The handoff cycle
+
+These are the five transitions that make up a full PR cycle. Each one is a single `radio send` call, baked into the corresponding agent's prompt:
+
+| From    | When                            | Command                                                                |
+|---------|---------------------------------|------------------------------------------------------------------------|
+| Planner | spec written into the issue     | `radio send --to pm --intent spec-ready --issue <N>`                   |
+| Worker  | PR opened                       | `radio send --to pm --intent review-requested --pr <N>`                |
+| Worker  | new commits pushed after review | `radio send --to pm --intent re-review-requested --pr <N>`             |
+| PM      | review requested changes        | `radio send --to <worker-role> --intent changes-requested --pr <N>`    |
+| PM      | PR merged                       | `radio send --to <worker-role> --intent approved-and-merged --pr <N>`  |
+
+PR review *content* still lives in `gh pr comment` / `gh pr review` (or the equivalent on Jira / Notion / local); radio only carries the routing ping.
+
+Role names are addressable strings, not free-form: the PM is `pm`, and each worker is `worker-<reponame>-<slug>` (e.g. `worker-task-force-issue-42`). List live ones with `ls ~/.task-force/radio/sessions/`.
+
 ### Command surface
 
 | Command | What it does |
@@ -370,13 +388,9 @@ Once you've installed a Claude loadout, `task-init` auto-installs **radio** — 
 | `radio ready` / `radio busy`        | Toggle this session's `STATE` field — drives the wake-up vs. queue decision on the sender side |
 | `radio orphans`                     | List session files whose heartbeat is >1h stale |
 
-Intents are free-form labels — `review-requested`, `re-review-requested`, `changes-requested`, `approved`, etc. PR review *content* still lives in `gh pr comment` / `gh pr review`; radio only carries the routing ping.
-
 ### How wake-up works
 
 `radio send` reads the recipient's session file. If `STATE=idle`, it focuses the recipient's zellij tab via `zellij action go-to-tab-name` and on the recipient's next turn end, the `Stop` hook (`radio ready && radio check`) surfaces the new message. If `STATE=busy`, the message is queued silently — no failed wake attempt, no interrupting the recipient mid-turn.
-
-Role names are addressable strings, not free-form: the PM is `pm`, and each worker is `worker-<reponame>-<slug>` (e.g. `worker-task-force-issue-42`). List live ones with `ls ~/.task-force/radio/sessions/`.
 
 ### The hooks that make it work
 
@@ -402,7 +416,7 @@ If a tab dies unexpectedly (or Claude resumes without re-firing `SessionStart`),
 
 ## The normal workflow
 
-Here's what an end-to-end PR cycle looks like once everything is wired up:
+Here's what an end-to-end PR cycle looks like once everything is wired up. Eight beats, each handed off via radio:
 
 **1. Spin up the PM.** In any zellij tab:
 
@@ -412,7 +426,7 @@ task-pm
 
 Renames the current tab to `pm`, registers via the `SessionStart` hook, and starts the PM agent in-place.
 
-**2. PM grooms the backlog and picks an issue.** From the PM tab:
+**2. PM grooms the backlog and dispatches a worker.** From the PM tab:
 
 ```text
 /pm show me the backlog          # or: gh issue list --state open
@@ -425,15 +439,25 @@ PM picks one and spawns a worker:
 task-work issue-42 https://github.com/<owner>/<repo>/issues/42 --auto
 ```
 
-This creates a worktree, opens a new zellij tab, and launches the worker agent (`--auto` runs it under auto-approve since the issue body is self-contained).
+This creates a worktree, opens a new zellij tab, and launches the worker agent. `--auto` is the recommended default — it runs the worker under auto-approve since PM-filed specs should be self-contained.
 
-**3. Worker implements.** In the worker tab the agent reads the spec, edits files, runs tests, commits with the issue title as a prefix, and opens the PR:
+**3. Planner (optional).** If the issue needs a design pass first, the PM dispatches a planner instead (`task-work … --plan`). The planner reads the code, writes the spec into the issue body, and ends with:
+
+```bash
+radio send --to pm --intent spec-ready --issue 42
+```
+
+PM's tab gets focused; on the next turn the PM picks it up and dispatches a worker for the same issue.
+
+**4. Worker implements.** In the worker tab the agent reads the spec, edits files, runs tests, and commits with the issue title as a prefix.
+
+**5. Worker opens the PR, bumps Status, pings PM.** Once the implementation is in, the worker opens the PR:
 
 ```bash
 gh pr create --base main --head task/issue-42 --fill
 ```
 
-**4. Worker pings PM.** Once the worker is done it's idle, so the `Stop` hook fires `radio ready`. The worker can nudge the PM directly:
+Then bumps the project Status field to `In Review` (or keeps it at `In Progress` if the project has no In Review column — the worker reads the mapping from `.claude/gh-workflow.md`), and pings the PM:
 
 ```bash
 radio send --to pm --intent review-requested --pr 42
@@ -441,7 +465,9 @@ radio send --to pm --intent review-requested --pr 42
 
 PM's zellij tab gets focused; on its next turn end the `Stop` hook's `radio check` surfaces the ping.
 
-**5. PM reviews the PR.** From the PM tab:
+**6. Worker idles.** The worker stops here. It does **not** run `task-done` yet — cleanup waits for PM's explicit go-ahead in step 8.
+
+**7. PM reviews. Round-trip if needed.** From the PM tab:
 
 ```bash
 gh pr view 42
@@ -449,7 +475,7 @@ gh pr diff 42
 gh pr review 42 --comment --body "…"   # or: gh pr comment 42 --body "…"
 ```
 
-**6. Round-trip until merge.** PM requests changes (worker roles are `worker-<reponame>-<slug>`; see `ls ~/.task-force/radio/sessions/`):
+If requesting changes (worker roles are `worker-<reponame>-<slug>`; see `ls ~/.task-force/radio/sessions/`):
 
 ```bash
 radio send --to worker-task-force-issue-42 --intent changes-requested --pr 42
@@ -461,19 +487,16 @@ The worker tab is focused, picks up the comments, pushes fixes, and pings back:
 radio send --to pm --intent re-review-requested --pr 42
 ```
 
-**7. Merge + cleanup.** PM merges:
+Loop until the PR is clean.
+
+**8. PM merges and signals cleanup.** PM squash-merges, then radios the worker:
 
 ```bash
 gh pr merge 42 --squash --delete-branch
+radio send --to worker-task-force-issue-42 --intent approved-and-merged --pr 42
 ```
 
-In the worker tab:
-
-```bash
-task-done --remove-worktree
-```
-
-That removes the worktree and closes the zellij tab. Done.
+On its next turn the worker sees the ping, sets the project Status field to `Done`, and runs `task-done --remove-worktree` itself — removing the worktree and closing its own zellij tab. Done.
 
 ---
 


### PR DESCRIPTION
## Summary

Closes #87 — the README's radio + workflow sections were stale relative to the canonical model that #82 and #84 baked into every loadout's steering docs.

- **Radio section**: added the 5-row handoff table (planner `spec-ready` → worker `review-requested` / `re-review-requested` → PM `changes-requested` / `approved-and-merged`) and reframed radio as canonical, not ad-hoc.
- **Workflow walkthrough**: rewritten from 7 steps to 8. Planner handoff is now its own beat (step 3). Worker bumps `Status=In Review` after opening the PR (step 5). Worker idles after the ping (step 6). Cleanup is radio-driven: PM merges and signals `approved-and-merged`, worker self-runs `task-done --remove-worktree` on its next turn (step 8) — no more "tell the worker to run task-done."

Per-loadout sections (claude-local, kiro-local, etc.) are untouched, as specified.

## Test plan

- [ ] Re-read README from L355 onward and confirm the full handoff cycle matches `.claude/gh-workflow.md`.
- [ ] Confirm step 5 mentions `Status=In Review` and step 8 shows the radio-driven cleanup path.
- [ ] Spot-check that per-loadout sections at L261 (`claude-local`) and L333 (`kiro-local`) are unchanged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)