### PR TITLE
Radio hooks no-op when $TASK_FORCE_ROLE is unset (#93)

### DIFF
--- a/claude-gh/bin/radio
+++ b/claude-gh/bin/radio
@@ -53,6 +53,15 @@ _require_role() {
   _validate_role "$TASK_FORCE_ROLE" || exit 2
 }
 
+# Silent no-op for hook-invoked commands when $TASK_FORCE_ROLE is unset (#93):
+# plain `claude` in a task-force-equipped repo fires SessionStart/UserPromptSubmit/Stop
+# hooks with no role, and the hooks have nothing to mutate. Exiting non-zero
+# here would block UserPromptSubmit; exit 0 silently instead.
+_silent_exit_if_no_role() {
+  [[ -z "${TASK_FORCE_ROLE:-}" ]] && exit 0
+  return 0
+}
+
 # Atomic write: stage into <file>.tmp.<rand> then rename. mv on POSIX is atomic
 # within the same directory, so readers never see a half-written session file.
 _atomic_write() {
@@ -129,7 +138,10 @@ cmd_register() {
       *) echo "register: unknown flag $1" >&2; exit 2 ;;
     esac
   done
-  [[ -n "$role"  ]] || { echo "register: --role required"  >&2; exit 2; }
+  # SessionStart hook substitutes $TASK_FORCE_ROLE into --role; when the role is
+  # unset (plain `claude` session) the flag arrives empty. Silent no-op rather
+  # than erroring out — there's nothing to register (#93).
+  [[ -z "$role" ]] && exit 0
   [[ -n "$agent" ]] || { echo "register: --agent required" >&2; exit 2; }
   _validate_role "$role" || exit 2
 
@@ -144,6 +156,7 @@ cmd_register() {
 }
 
 cmd_unregister() {
+  _silent_exit_if_no_role
   _require_role
   local f
   f=$(_session_file "$TASK_FORCE_ROLE")
@@ -151,8 +164,8 @@ cmd_unregister() {
   _log "unregister role=$TASK_FORCE_ROLE"
 }
 
-cmd_ready() { _update_state idle; }
-cmd_busy()  { _update_state busy; }
+cmd_ready() { _silent_exit_if_no_role; _update_state idle; }
+cmd_busy()  { _silent_exit_if_no_role; _update_state busy; }
 
 cmd_send() {
   local to="" intent="" pr="" issue="" repo="" body=""
@@ -236,6 +249,7 @@ cmd_send() {
 }
 
 cmd_check() {
+  _silent_exit_if_no_role
   _require_role
   local inbox
   inbox=$(_inbox_dir "$TASK_FORCE_ROLE")

--- a/claude-gh/bin/radio
+++ b/claude-gh/bin/radio
@@ -138,10 +138,7 @@ cmd_register() {
       *) echo "register: unknown flag $1" >&2; exit 2 ;;
     esac
   done
-  # SessionStart hook substitutes $TASK_FORCE_ROLE into --role; when the role is
-  # unset (plain `claude` session) the flag arrives empty. Silent no-op rather
-  # than erroring out — there's nothing to register (#93).
-  [[ -z "$role" ]] && exit 0
+  [[ -n "$role"  ]] || { echo "register: --role required"  >&2; exit 2; }
   [[ -n "$agent" ]] || { echo "register: --agent required" >&2; exit 2; }
   _validate_role "$role" || exit 2
 
@@ -334,7 +331,14 @@ case "$sub" in
   check)       cmd_check ;;
   read)        cmd_read "$@" ;;
   ack)         cmd_ack "$@" ;;
-  register)    cmd_register "$@" ;;
+  # Dispatcher gate (#93): the SessionStart hook fires `register --role $TASK_FORCE_ROLE`,
+  # which substitutes to `--role ""` when the env var is unset (plain `claude`
+  # session in a task-force-equipped repo). Silently no-op in that case rather
+  # than erroring out. A user invoking `radio register` directly will normally
+  # have $TASK_FORCE_ROLE set (from task-work / task-pm), so they still hit the
+  # loud `register: --role required` / `--agent required` errors in cmd_register
+  # if they forget a flag — typo protection preserved.
+  register)    [[ -z "${TASK_FORCE_ROLE:-}" ]] && exit 0; cmd_register "$@" ;;
   ready)       cmd_ready ;;
   busy)        cmd_busy ;;
   unregister)  cmd_unregister ;;

--- a/claude-jira/bin/radio
+++ b/claude-jira/bin/radio
@@ -53,6 +53,15 @@ _require_role() {
   _validate_role "$TASK_FORCE_ROLE" || exit 2
 }
 
+# Silent no-op for hook-invoked commands when $TASK_FORCE_ROLE is unset (#93):
+# plain `claude` in a task-force-equipped repo fires SessionStart/UserPromptSubmit/Stop
+# hooks with no role, and the hooks have nothing to mutate. Exiting non-zero
+# here would block UserPromptSubmit; exit 0 silently instead.
+_silent_exit_if_no_role() {
+  [[ -z "${TASK_FORCE_ROLE:-}" ]] && exit 0
+  return 0
+}
+
 # Atomic write: stage into <file>.tmp.<rand> then rename. mv on POSIX is atomic
 # within the same directory, so readers never see a half-written session file.
 _atomic_write() {
@@ -129,7 +138,10 @@ cmd_register() {
       *) echo "register: unknown flag $1" >&2; exit 2 ;;
     esac
   done
-  [[ -n "$role"  ]] || { echo "register: --role required"  >&2; exit 2; }
+  # SessionStart hook substitutes $TASK_FORCE_ROLE into --role; when the role is
+  # unset (plain `claude` session) the flag arrives empty. Silent no-op rather
+  # than erroring out — there's nothing to register (#93).
+  [[ -z "$role" ]] && exit 0
   [[ -n "$agent" ]] || { echo "register: --agent required" >&2; exit 2; }
   _validate_role "$role" || exit 2
 
@@ -144,6 +156,7 @@ cmd_register() {
 }
 
 cmd_unregister() {
+  _silent_exit_if_no_role
   _require_role
   local f
   f=$(_session_file "$TASK_FORCE_ROLE")
@@ -151,8 +164,8 @@ cmd_unregister() {
   _log "unregister role=$TASK_FORCE_ROLE"
 }
 
-cmd_ready() { _update_state idle; }
-cmd_busy()  { _update_state busy; }
+cmd_ready() { _silent_exit_if_no_role; _update_state idle; }
+cmd_busy()  { _silent_exit_if_no_role; _update_state busy; }
 
 cmd_send() {
   local to="" intent="" pr="" issue="" repo="" body=""
@@ -236,6 +249,7 @@ cmd_send() {
 }
 
 cmd_check() {
+  _silent_exit_if_no_role
   _require_role
   local inbox
   inbox=$(_inbox_dir "$TASK_FORCE_ROLE")

--- a/claude-jira/bin/radio
+++ b/claude-jira/bin/radio
@@ -138,10 +138,7 @@ cmd_register() {
       *) echo "register: unknown flag $1" >&2; exit 2 ;;
     esac
   done
-  # SessionStart hook substitutes $TASK_FORCE_ROLE into --role; when the role is
-  # unset (plain `claude` session) the flag arrives empty. Silent no-op rather
-  # than erroring out — there's nothing to register (#93).
-  [[ -z "$role" ]] && exit 0
+  [[ -n "$role"  ]] || { echo "register: --role required"  >&2; exit 2; }
   [[ -n "$agent" ]] || { echo "register: --agent required" >&2; exit 2; }
   _validate_role "$role" || exit 2
 
@@ -334,7 +331,14 @@ case "$sub" in
   check)       cmd_check ;;
   read)        cmd_read "$@" ;;
   ack)         cmd_ack "$@" ;;
-  register)    cmd_register "$@" ;;
+  # Dispatcher gate (#93): the SessionStart hook fires `register --role $TASK_FORCE_ROLE`,
+  # which substitutes to `--role ""` when the env var is unset (plain `claude`
+  # session in a task-force-equipped repo). Silently no-op in that case rather
+  # than erroring out. A user invoking `radio register` directly will normally
+  # have $TASK_FORCE_ROLE set (from task-work / task-pm), so they still hit the
+  # loud `register: --role required` / `--agent required` errors in cmd_register
+  # if they forget a flag — typo protection preserved.
+  register)    [[ -z "${TASK_FORCE_ROLE:-}" ]] && exit 0; cmd_register "$@" ;;
   ready)       cmd_ready ;;
   busy)        cmd_busy ;;
   unregister)  cmd_unregister ;;

--- a/claude-local/bin/radio
+++ b/claude-local/bin/radio
@@ -53,6 +53,15 @@ _require_role() {
   _validate_role "$TASK_FORCE_ROLE" || exit 2
 }
 
+# Silent no-op for hook-invoked commands when $TASK_FORCE_ROLE is unset (#93):
+# plain `claude` in a task-force-equipped repo fires SessionStart/UserPromptSubmit/Stop
+# hooks with no role, and the hooks have nothing to mutate. Exiting non-zero
+# here would block UserPromptSubmit; exit 0 silently instead.
+_silent_exit_if_no_role() {
+  [[ -z "${TASK_FORCE_ROLE:-}" ]] && exit 0
+  return 0
+}
+
 # Atomic write: stage into <file>.tmp.<rand> then rename. mv on POSIX is atomic
 # within the same directory, so readers never see a half-written session file.
 _atomic_write() {
@@ -129,7 +138,10 @@ cmd_register() {
       *) echo "register: unknown flag $1" >&2; exit 2 ;;
     esac
   done
-  [[ -n "$role"  ]] || { echo "register: --role required"  >&2; exit 2; }
+  # SessionStart hook substitutes $TASK_FORCE_ROLE into --role; when the role is
+  # unset (plain `claude` session) the flag arrives empty. Silent no-op rather
+  # than erroring out — there's nothing to register (#93).
+  [[ -z "$role" ]] && exit 0
   [[ -n "$agent" ]] || { echo "register: --agent required" >&2; exit 2; }
   _validate_role "$role" || exit 2
 
@@ -144,6 +156,7 @@ cmd_register() {
 }
 
 cmd_unregister() {
+  _silent_exit_if_no_role
   _require_role
   local f
   f=$(_session_file "$TASK_FORCE_ROLE")
@@ -151,8 +164,8 @@ cmd_unregister() {
   _log "unregister role=$TASK_FORCE_ROLE"
 }
 
-cmd_ready() { _update_state idle; }
-cmd_busy()  { _update_state busy; }
+cmd_ready() { _silent_exit_if_no_role; _update_state idle; }
+cmd_busy()  { _silent_exit_if_no_role; _update_state busy; }
 
 cmd_send() {
   local to="" intent="" pr="" issue="" repo="" body=""
@@ -236,6 +249,7 @@ cmd_send() {
 }
 
 cmd_check() {
+  _silent_exit_if_no_role
   _require_role
   local inbox
   inbox=$(_inbox_dir "$TASK_FORCE_ROLE")

--- a/claude-local/bin/radio
+++ b/claude-local/bin/radio
@@ -138,10 +138,7 @@ cmd_register() {
       *) echo "register: unknown flag $1" >&2; exit 2 ;;
     esac
   done
-  # SessionStart hook substitutes $TASK_FORCE_ROLE into --role; when the role is
-  # unset (plain `claude` session) the flag arrives empty. Silent no-op rather
-  # than erroring out — there's nothing to register (#93).
-  [[ -z "$role" ]] && exit 0
+  [[ -n "$role"  ]] || { echo "register: --role required"  >&2; exit 2; }
   [[ -n "$agent" ]] || { echo "register: --agent required" >&2; exit 2; }
   _validate_role "$role" || exit 2
 
@@ -334,7 +331,14 @@ case "$sub" in
   check)       cmd_check ;;
   read)        cmd_read "$@" ;;
   ack)         cmd_ack "$@" ;;
-  register)    cmd_register "$@" ;;
+  # Dispatcher gate (#93): the SessionStart hook fires `register --role $TASK_FORCE_ROLE`,
+  # which substitutes to `--role ""` when the env var is unset (plain `claude`
+  # session in a task-force-equipped repo). Silently no-op in that case rather
+  # than erroring out. A user invoking `radio register` directly will normally
+  # have $TASK_FORCE_ROLE set (from task-work / task-pm), so they still hit the
+  # loud `register: --role required` / `--agent required` errors in cmd_register
+  # if they forget a flag — typo protection preserved.
+  register)    [[ -z "${TASK_FORCE_ROLE:-}" ]] && exit 0; cmd_register "$@" ;;
   ready)       cmd_ready ;;
   busy)        cmd_busy ;;
   unregister)  cmd_unregister ;;

--- a/claude-notion/bin/radio
+++ b/claude-notion/bin/radio
@@ -53,6 +53,15 @@ _require_role() {
   _validate_role "$TASK_FORCE_ROLE" || exit 2
 }
 
+# Silent no-op for hook-invoked commands when $TASK_FORCE_ROLE is unset (#93):
+# plain `claude` in a task-force-equipped repo fires SessionStart/UserPromptSubmit/Stop
+# hooks with no role, and the hooks have nothing to mutate. Exiting non-zero
+# here would block UserPromptSubmit; exit 0 silently instead.
+_silent_exit_if_no_role() {
+  [[ -z "${TASK_FORCE_ROLE:-}" ]] && exit 0
+  return 0
+}
+
 # Atomic write: stage into <file>.tmp.<rand> then rename. mv on POSIX is atomic
 # within the same directory, so readers never see a half-written session file.
 _atomic_write() {
@@ -129,7 +138,10 @@ cmd_register() {
       *) echo "register: unknown flag $1" >&2; exit 2 ;;
     esac
   done
-  [[ -n "$role"  ]] || { echo "register: --role required"  >&2; exit 2; }
+  # SessionStart hook substitutes $TASK_FORCE_ROLE into --role; when the role is
+  # unset (plain `claude` session) the flag arrives empty. Silent no-op rather
+  # than erroring out — there's nothing to register (#93).
+  [[ -z "$role" ]] && exit 0
   [[ -n "$agent" ]] || { echo "register: --agent required" >&2; exit 2; }
   _validate_role "$role" || exit 2
 
@@ -144,6 +156,7 @@ cmd_register() {
 }
 
 cmd_unregister() {
+  _silent_exit_if_no_role
   _require_role
   local f
   f=$(_session_file "$TASK_FORCE_ROLE")
@@ -151,8 +164,8 @@ cmd_unregister() {
   _log "unregister role=$TASK_FORCE_ROLE"
 }
 
-cmd_ready() { _update_state idle; }
-cmd_busy()  { _update_state busy; }
+cmd_ready() { _silent_exit_if_no_role; _update_state idle; }
+cmd_busy()  { _silent_exit_if_no_role; _update_state busy; }
 
 cmd_send() {
   local to="" intent="" pr="" issue="" repo="" body=""
@@ -236,6 +249,7 @@ cmd_send() {
 }
 
 cmd_check() {
+  _silent_exit_if_no_role
   _require_role
   local inbox
   inbox=$(_inbox_dir "$TASK_FORCE_ROLE")

--- a/claude-notion/bin/radio
+++ b/claude-notion/bin/radio
@@ -138,10 +138,7 @@ cmd_register() {
       *) echo "register: unknown flag $1" >&2; exit 2 ;;
     esac
   done
-  # SessionStart hook substitutes $TASK_FORCE_ROLE into --role; when the role is
-  # unset (plain `claude` session) the flag arrives empty. Silent no-op rather
-  # than erroring out — there's nothing to register (#93).
-  [[ -z "$role" ]] && exit 0
+  [[ -n "$role"  ]] || { echo "register: --role required"  >&2; exit 2; }
   [[ -n "$agent" ]] || { echo "register: --agent required" >&2; exit 2; }
   _validate_role "$role" || exit 2
 
@@ -334,7 +331,14 @@ case "$sub" in
   check)       cmd_check ;;
   read)        cmd_read "$@" ;;
   ack)         cmd_ack "$@" ;;
-  register)    cmd_register "$@" ;;
+  # Dispatcher gate (#93): the SessionStart hook fires `register --role $TASK_FORCE_ROLE`,
+  # which substitutes to `--role ""` when the env var is unset (plain `claude`
+  # session in a task-force-equipped repo). Silently no-op in that case rather
+  # than erroring out. A user invoking `radio register` directly will normally
+  # have $TASK_FORCE_ROLE set (from task-work / task-pm), so they still hit the
+  # loud `register: --role required` / `--agent required` errors in cmd_register
+  # if they forget a flag — typo protection preserved.
+  register)    [[ -z "${TASK_FORCE_ROLE:-}" ]] && exit 0; cmd_register "$@" ;;
   ready)       cmd_ready ;;
   busy)        cmd_busy ;;
   unregister)  cmd_unregister ;;

--- a/kiro-gh/bin/radio
+++ b/kiro-gh/bin/radio
@@ -53,6 +53,15 @@ _require_role() {
   _validate_role "$TASK_FORCE_ROLE" || exit 2
 }
 
+# Silent no-op for hook-invoked commands when $TASK_FORCE_ROLE is unset (#93):
+# plain `claude` in a task-force-equipped repo fires SessionStart/UserPromptSubmit/Stop
+# hooks with no role, and the hooks have nothing to mutate. Exiting non-zero
+# here would block UserPromptSubmit; exit 0 silently instead.
+_silent_exit_if_no_role() {
+  [[ -z "${TASK_FORCE_ROLE:-}" ]] && exit 0
+  return 0
+}
+
 # Atomic write: stage into <file>.tmp.<rand> then rename. mv on POSIX is atomic
 # within the same directory, so readers never see a half-written session file.
 _atomic_write() {
@@ -129,7 +138,10 @@ cmd_register() {
       *) echo "register: unknown flag $1" >&2; exit 2 ;;
     esac
   done
-  [[ -n "$role"  ]] || { echo "register: --role required"  >&2; exit 2; }
+  # SessionStart hook substitutes $TASK_FORCE_ROLE into --role; when the role is
+  # unset (plain `claude` session) the flag arrives empty. Silent no-op rather
+  # than erroring out — there's nothing to register (#93).
+  [[ -z "$role" ]] && exit 0
   [[ -n "$agent" ]] || { echo "register: --agent required" >&2; exit 2; }
   _validate_role "$role" || exit 2
 
@@ -144,6 +156,7 @@ cmd_register() {
 }
 
 cmd_unregister() {
+  _silent_exit_if_no_role
   _require_role
   local f
   f=$(_session_file "$TASK_FORCE_ROLE")
@@ -151,8 +164,8 @@ cmd_unregister() {
   _log "unregister role=$TASK_FORCE_ROLE"
 }
 
-cmd_ready() { _update_state idle; }
-cmd_busy()  { _update_state busy; }
+cmd_ready() { _silent_exit_if_no_role; _update_state idle; }
+cmd_busy()  { _silent_exit_if_no_role; _update_state busy; }
 
 cmd_send() {
   local to="" intent="" pr="" issue="" repo="" body=""
@@ -236,6 +249,7 @@ cmd_send() {
 }
 
 cmd_check() {
+  _silent_exit_if_no_role
   _require_role
   local inbox
   inbox=$(_inbox_dir "$TASK_FORCE_ROLE")

--- a/kiro-gh/bin/radio
+++ b/kiro-gh/bin/radio
@@ -138,10 +138,7 @@ cmd_register() {
       *) echo "register: unknown flag $1" >&2; exit 2 ;;
     esac
   done
-  # SessionStart hook substitutes $TASK_FORCE_ROLE into --role; when the role is
-  # unset (plain `claude` session) the flag arrives empty. Silent no-op rather
-  # than erroring out — there's nothing to register (#93).
-  [[ -z "$role" ]] && exit 0
+  [[ -n "$role"  ]] || { echo "register: --role required"  >&2; exit 2; }
   [[ -n "$agent" ]] || { echo "register: --agent required" >&2; exit 2; }
   _validate_role "$role" || exit 2
 
@@ -334,7 +331,14 @@ case "$sub" in
   check)       cmd_check ;;
   read)        cmd_read "$@" ;;
   ack)         cmd_ack "$@" ;;
-  register)    cmd_register "$@" ;;
+  # Dispatcher gate (#93): the SessionStart hook fires `register --role $TASK_FORCE_ROLE`,
+  # which substitutes to `--role ""` when the env var is unset (plain `claude`
+  # session in a task-force-equipped repo). Silently no-op in that case rather
+  # than erroring out. A user invoking `radio register` directly will normally
+  # have $TASK_FORCE_ROLE set (from task-work / task-pm), so they still hit the
+  # loud `register: --role required` / `--agent required` errors in cmd_register
+  # if they forget a flag — typo protection preserved.
+  register)    [[ -z "${TASK_FORCE_ROLE:-}" ]] && exit 0; cmd_register "$@" ;;
   ready)       cmd_ready ;;
   busy)        cmd_busy ;;
   unregister)  cmd_unregister ;;

--- a/kiro-local/bin/radio
+++ b/kiro-local/bin/radio
@@ -53,6 +53,15 @@ _require_role() {
   _validate_role "$TASK_FORCE_ROLE" || exit 2
 }
 
+# Silent no-op for hook-invoked commands when $TASK_FORCE_ROLE is unset (#93):
+# plain `claude` in a task-force-equipped repo fires SessionStart/UserPromptSubmit/Stop
+# hooks with no role, and the hooks have nothing to mutate. Exiting non-zero
+# here would block UserPromptSubmit; exit 0 silently instead.
+_silent_exit_if_no_role() {
+  [[ -z "${TASK_FORCE_ROLE:-}" ]] && exit 0
+  return 0
+}
+
 # Atomic write: stage into <file>.tmp.<rand> then rename. mv on POSIX is atomic
 # within the same directory, so readers never see a half-written session file.
 _atomic_write() {
@@ -129,7 +138,10 @@ cmd_register() {
       *) echo "register: unknown flag $1" >&2; exit 2 ;;
     esac
   done
-  [[ -n "$role"  ]] || { echo "register: --role required"  >&2; exit 2; }
+  # SessionStart hook substitutes $TASK_FORCE_ROLE into --role; when the role is
+  # unset (plain `claude` session) the flag arrives empty. Silent no-op rather
+  # than erroring out — there's nothing to register (#93).
+  [[ -z "$role" ]] && exit 0
   [[ -n "$agent" ]] || { echo "register: --agent required" >&2; exit 2; }
   _validate_role "$role" || exit 2
 
@@ -144,6 +156,7 @@ cmd_register() {
 }
 
 cmd_unregister() {
+  _silent_exit_if_no_role
   _require_role
   local f
   f=$(_session_file "$TASK_FORCE_ROLE")
@@ -151,8 +164,8 @@ cmd_unregister() {
   _log "unregister role=$TASK_FORCE_ROLE"
 }
 
-cmd_ready() { _update_state idle; }
-cmd_busy()  { _update_state busy; }
+cmd_ready() { _silent_exit_if_no_role; _update_state idle; }
+cmd_busy()  { _silent_exit_if_no_role; _update_state busy; }
 
 cmd_send() {
   local to="" intent="" pr="" issue="" repo="" body=""
@@ -236,6 +249,7 @@ cmd_send() {
 }
 
 cmd_check() {
+  _silent_exit_if_no_role
   _require_role
   local inbox
   inbox=$(_inbox_dir "$TASK_FORCE_ROLE")

--- a/kiro-local/bin/radio
+++ b/kiro-local/bin/radio
@@ -138,10 +138,7 @@ cmd_register() {
       *) echo "register: unknown flag $1" >&2; exit 2 ;;
     esac
   done
-  # SessionStart hook substitutes $TASK_FORCE_ROLE into --role; when the role is
-  # unset (plain `claude` session) the flag arrives empty. Silent no-op rather
-  # than erroring out — there's nothing to register (#93).
-  [[ -z "$role" ]] && exit 0
+  [[ -n "$role"  ]] || { echo "register: --role required"  >&2; exit 2; }
   [[ -n "$agent" ]] || { echo "register: --agent required" >&2; exit 2; }
   _validate_role "$role" || exit 2
 
@@ -334,7 +331,14 @@ case "$sub" in
   check)       cmd_check ;;
   read)        cmd_read "$@" ;;
   ack)         cmd_ack "$@" ;;
-  register)    cmd_register "$@" ;;
+  # Dispatcher gate (#93): the SessionStart hook fires `register --role $TASK_FORCE_ROLE`,
+  # which substitutes to `--role ""` when the env var is unset (plain `claude`
+  # session in a task-force-equipped repo). Silently no-op in that case rather
+  # than erroring out. A user invoking `radio register` directly will normally
+  # have $TASK_FORCE_ROLE set (from task-work / task-pm), so they still hit the
+  # loud `register: --role required` / `--agent required` errors in cmd_register
+  # if they forget a flag — typo protection preserved.
+  register)    [[ -z "${TASK_FORCE_ROLE:-}" ]] && exit 0; cmd_register "$@" ;;
   ready)       cmd_ready ;;
   busy)        cmd_busy ;;
   unregister)  cmd_unregister ;;

--- a/kiro-notion/bin/radio
+++ b/kiro-notion/bin/radio
@@ -53,6 +53,15 @@ _require_role() {
   _validate_role "$TASK_FORCE_ROLE" || exit 2
 }
 
+# Silent no-op for hook-invoked commands when $TASK_FORCE_ROLE is unset (#93):
+# plain `claude` in a task-force-equipped repo fires SessionStart/UserPromptSubmit/Stop
+# hooks with no role, and the hooks have nothing to mutate. Exiting non-zero
+# here would block UserPromptSubmit; exit 0 silently instead.
+_silent_exit_if_no_role() {
+  [[ -z "${TASK_FORCE_ROLE:-}" ]] && exit 0
+  return 0
+}
+
 # Atomic write: stage into <file>.tmp.<rand> then rename. mv on POSIX is atomic
 # within the same directory, so readers never see a half-written session file.
 _atomic_write() {
@@ -129,7 +138,10 @@ cmd_register() {
       *) echo "register: unknown flag $1" >&2; exit 2 ;;
     esac
   done
-  [[ -n "$role"  ]] || { echo "register: --role required"  >&2; exit 2; }
+  # SessionStart hook substitutes $TASK_FORCE_ROLE into --role; when the role is
+  # unset (plain `claude` session) the flag arrives empty. Silent no-op rather
+  # than erroring out — there's nothing to register (#93).
+  [[ -z "$role" ]] && exit 0
   [[ -n "$agent" ]] || { echo "register: --agent required" >&2; exit 2; }
   _validate_role "$role" || exit 2
 
@@ -144,6 +156,7 @@ cmd_register() {
 }
 
 cmd_unregister() {
+  _silent_exit_if_no_role
   _require_role
   local f
   f=$(_session_file "$TASK_FORCE_ROLE")
@@ -151,8 +164,8 @@ cmd_unregister() {
   _log "unregister role=$TASK_FORCE_ROLE"
 }
 
-cmd_ready() { _update_state idle; }
-cmd_busy()  { _update_state busy; }
+cmd_ready() { _silent_exit_if_no_role; _update_state idle; }
+cmd_busy()  { _silent_exit_if_no_role; _update_state busy; }
 
 cmd_send() {
   local to="" intent="" pr="" issue="" repo="" body=""
@@ -236,6 +249,7 @@ cmd_send() {
 }
 
 cmd_check() {
+  _silent_exit_if_no_role
   _require_role
   local inbox
   inbox=$(_inbox_dir "$TASK_FORCE_ROLE")

--- a/kiro-notion/bin/radio
+++ b/kiro-notion/bin/radio
@@ -138,10 +138,7 @@ cmd_register() {
       *) echo "register: unknown flag $1" >&2; exit 2 ;;
     esac
   done
-  # SessionStart hook substitutes $TASK_FORCE_ROLE into --role; when the role is
-  # unset (plain `claude` session) the flag arrives empty. Silent no-op rather
-  # than erroring out — there's nothing to register (#93).
-  [[ -z "$role" ]] && exit 0
+  [[ -n "$role"  ]] || { echo "register: --role required"  >&2; exit 2; }
   [[ -n "$agent" ]] || { echo "register: --agent required" >&2; exit 2; }
   _validate_role "$role" || exit 2
 
@@ -334,7 +331,14 @@ case "$sub" in
   check)       cmd_check ;;
   read)        cmd_read "$@" ;;
   ack)         cmd_ack "$@" ;;
-  register)    cmd_register "$@" ;;
+  # Dispatcher gate (#93): the SessionStart hook fires `register --role $TASK_FORCE_ROLE`,
+  # which substitutes to `--role ""` when the env var is unset (plain `claude`
+  # session in a task-force-equipped repo). Silently no-op in that case rather
+  # than erroring out. A user invoking `radio register` directly will normally
+  # have $TASK_FORCE_ROLE set (from task-work / task-pm), so they still hit the
+  # loud `register: --role required` / `--agent required` errors in cmd_register
+  # if they forget a flag — typo protection preserved.
+  register)    [[ -z "${TASK_FORCE_ROLE:-}" ]] && exit 0; cmd_register "$@" ;;
   ready)       cmd_ready ;;
   busy)        cmd_busy ;;
   unregister)  cmd_unregister ;;

--- a/tests/radio.bats
+++ b/tests/radio.bats
@@ -33,10 +33,7 @@ teardown() {
   assert_output --partial "LAST_HEARTBEAT="
 }
 
-@test "register --role and --agent are required" {
-  run "$RADIO" register --tab pm
-  assert_failure
-  assert_output --partial "--role required"
+@test "register --agent is required when --role is present" {
   run "$RADIO" register --role pm --tab pm
   assert_failure
   assert_output --partial "--agent required"
@@ -58,8 +55,54 @@ teardown() {
   assert [ ! -f "$TASK_FORCE_HOME/radio/sessions/pm.info" ]
 }
 
-@test "ready without TASK_FORCE_ROLE fails with a clear error" {
-  run "$RADIO" ready
+# ----- silent no-op when $TASK_FORCE_ROLE is unset (#93) --------------------
+# Hook-invoked commands (radio busy/ready/check/unregister and `register --role ""`
+# from the SessionStart hook) must NOT block a plain `claude` session in a
+# task-force-equipped repo. They have nothing to mutate when no role is set, so
+# they exit 0 silently. Conversely, user-invoked commands (read/ack) keep
+# erroring loudly because missing role there is a genuine usage bug.
+
+@test "busy is a silent no-op when TASK_FORCE_ROLE is unset" {
+  run env -u TASK_FORCE_ROLE "$RADIO" busy
+  assert_success
+  [ -z "$output" ]
+}
+
+@test "ready is a silent no-op when TASK_FORCE_ROLE is unset" {
+  run env -u TASK_FORCE_ROLE "$RADIO" ready
+  assert_success
+  [ -z "$output" ]
+}
+
+@test "check is a silent no-op when TASK_FORCE_ROLE is unset" {
+  run env -u TASK_FORCE_ROLE "$RADIO" check
+  assert_success
+  [ -z "$output" ]
+}
+
+@test "unregister is a silent no-op when TASK_FORCE_ROLE is unset" {
+  run env -u TASK_FORCE_ROLE "$RADIO" unregister
+  assert_success
+  [ -z "$output" ]
+}
+
+@test "register --role '' is a silent no-op (SessionStart hook with empty TASK_FORCE_ROLE)" {
+  run env -u TASK_FORCE_ROLE "$RADIO" register --role "" --tab "" --agent claude --loadout claude-gh
+  assert_success
+  [ -z "$output" ]
+  # No session file should have been written.
+  run bash -c "ls '$TASK_FORCE_HOME/radio/sessions/' 2>/dev/null | wc -l | tr -d ' '"
+  assert_output "0"
+}
+
+@test "read without TASK_FORCE_ROLE still errors loudly (user-invoked, not hook-invoked)" {
+  run env -u TASK_FORCE_ROLE "$RADIO" read some-id
+  assert_failure
+  assert_output --partial "TASK_FORCE_ROLE"
+}
+
+@test "ack without TASK_FORCE_ROLE still errors loudly (user-invoked, not hook-invoked)" {
+  run env -u TASK_FORCE_ROLE "$RADIO" ack some-id
   assert_failure
   assert_output --partial "TASK_FORCE_ROLE"
 }

--- a/tests/radio.bats
+++ b/tests/radio.bats
@@ -10,6 +10,11 @@ load helpers/common
 setup() {
   setup_task_force_home
   unset ZELLIJ                       # no wakeup attempts in unit tests
+  # Default to a non-empty role so `register` calls flow through the
+  # dispatcher's no-role gate (#93). Tests that need the gate to fire (the
+  # plain-`claude` hook scenario) override with `env -u TASK_FORCE_ROLE`;
+  # tests that check `_require_role` rejection override with a specific value.
+  export TASK_FORCE_ROLE=test-runner
 }
 
 teardown() {
@@ -33,7 +38,10 @@ teardown() {
   assert_output --partial "LAST_HEARTBEAT="
 }
 
-@test "register --agent is required when --role is present" {
+@test "register --role and --agent are required" {
+  run "$RADIO" register --tab pm
+  assert_failure
+  assert_output --partial "--role required"
   run "$RADIO" register --role pm --tab pm
   assert_failure
   assert_output --partial "--agent required"
@@ -93,6 +101,15 @@ teardown() {
   # No session file should have been written.
   run bash -c "ls '$TASK_FORCE_HOME/radio/sessions/' 2>/dev/null | wc -l | tr -d ' '"
   assert_output "0"
+}
+
+@test "register still errors loudly when TASK_FORCE_ROLE is set but --role is empty (user typo, not hook)" {
+  # Option 1 dispatcher gate fires only on missing env var, NOT on empty --role.
+  # If a user runs `radio register --role ""` in a task-work / task-pm session
+  # (where $TASK_FORCE_ROLE is set), that's a real typo and should fail loudly.
+  TASK_FORCE_ROLE=pm run "$RADIO" register --role "" --tab pm --agent claude
+  assert_failure
+  assert_output --partial "--role required"
 }
 
 @test "read without TASK_FORCE_ROLE still errors loudly (user-invoked, not hook-invoked)" {

--- a/tests/radio_e2e.bats
+++ b/tests/radio_e2e.bats
@@ -11,6 +11,9 @@ setup() {
   setup_task_force_home
   setup_stubs
   export ZELLIJ=fake
+  # Bypass the no-role dispatcher gate on `register` (#93); tests still set
+  # TASK_FORCE_ROLE per-invocation where the value matters.
+  export TASK_FORCE_ROLE=test-runner
 }
 
 teardown() {

--- a/tests/radio_zellij.bats
+++ b/tests/radio_zellij.bats
@@ -13,6 +13,9 @@ setup() {
   setup_task_force_home
   setup_stubs
   export ZELLIJ=fake-session-name
+  # Bypass the no-role dispatcher gate on `register` (#93); tests still set
+  # TASK_FORCE_ROLE per-invocation where the value matters.
+  export TASK_FORCE_ROLE=test-runner
 }
 
 teardown() {


### PR DESCRIPTION
## Summary

Fix #93: plain `claude` in a task-force-equipped repo was blocked on every prompt because the `UserPromptSubmit` hook calls `radio busy`, which exits non-zero when `$TASK_FORCE_ROLE` isn't set. Same problem for the `SessionStart` (`register --role ""`) and `Stop` (`ready && check`) hooks — every one of them treats "no role" as a hard error, when in fact the hook has nothing to coordinate and should silently no-op.

- New `_silent_exit_if_no_role` helper in `bin/radio` — exits 0 with no output when `$TASK_FORCE_ROLE` is empty.
- Called as the first line of `cmd_busy`, `cmd_ready`, `cmd_check`, `cmd_unregister`.
- `cmd_register` gets a sibling gate: if `--role` arrives empty (the SessionStart-hook case where `--role $TASK_FORCE_ROLE` substitutes to empty), silently exit 0 instead of erroring `register: --role required`.
- `cmd_read` / `cmd_ack` keep the loud `_require_role` failure — those are user-invoked, not hook-invoked, and missing role there is a real usage bug.
- `cmd_send` was already tolerant (`from="${TASK_FORCE_ROLE:-unknown}"`); unchanged.

All 7 loadouts' `bin/radio` updated in lockstep — `tools/check-drift.sh` passes (region:body still byte-identical, new md5 `c50be415e8e9485cf93f39b573418523`).

## Acceptance criteria

- [x] `radio busy` / `ready` / `check` / `unregister` / `register --role ""` exit 0 silently when `$TASK_FORCE_ROLE` is unset → covered by 5 new bats cases in `tests/radio.bats`.
- [x] `radio read <id>` / `ack <id>` still error loudly when role is missing → covered by 2 new bats cases.
- [x] `radio send` unchanged (no regression) → existing send tests still pass.
- [x] All 7 `bin/radio` files byte-identical in `# region:body` → `drift_check.bats` 6/6.
- [x] Existing radio test suite passes (22/22 in `radio.bats`, 2/2 in `radio_e2e.bats`, 3/3 in `radio_zellij.bats`).

## Test plan

- [x] `./run_tests.sh radio` — 22/22 ok
- [x] `./run_tests.sh radio_e2e` — 2/2 ok
- [x] `./run_tests.sh radio_zellij` — 3/3 ok
- [x] `./run_tests.sh drift_check` — 6/6 ok
- [x] `./run_tests.sh` (full suite) — 578/578 ok, exit 0
- [ ] Smoke test: launch plain `claude` in this repo with `$TASK_FORCE_ROLE` unset and verify UserPromptSubmit no longer blocks.