### PR TITLE
Auto-unregister radio sessions on session/worker end (#94)

### DIFF
--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -29,6 +29,16 @@
           }
         ]
       }
+    ],
+    "SessionEnd": [
+      {
+        "hooks": [
+          {
+            "type": "command",
+            "command": "radio unregister"
+          }
+        ]
+      }
     ]
   },
   "permissions": {

--- a/claude-gh/bin/task-done
+++ b/claude-gh/bin/task-done
@@ -97,6 +97,13 @@ if [[ "$FORCE" != true && "$REMOVE_ONLY" != true ]]; then
   [[ "$confirm" != "y" && "$confirm" != "Y" ]] && exit 0
 fi
 
+# Unregister radio session before tearing down the worktree (#94). The
+# `|| true` is a safety net: $TASK_FORCE_ROLE should be set inside a worker
+# tab, but if it isn't (e.g., task-done invoked from an unexpected shell)
+# the no-op must not abort cleanup. `radio unregister` itself already
+# silently exits when $TASK_FORCE_ROLE is unset (#93).
+radio unregister 2>/dev/null || true
+
 # Move out of worktree before removing it
 cd "$MAIN_WORKTREE"
 

--- a/claude-gh/bin/task-init
+++ b/claude-gh/bin/task-init
@@ -249,6 +249,7 @@ _radio_install_hooks() {
   local register_cmd="radio register --role \$TASK_FORCE_ROLE --tab \$ZELLIJ_TAB --repo \$(git rev-parse --show-toplevel 2>/dev/null) --agent claude --loadout $loadout"
   local busy_cmd="radio busy"
   local stop_cmd="radio ready && radio check"
+  local end_cmd="radio unregister"
 
   mkdir -p "$(dirname "$settings_file")"
   [[ -f "$settings_file" ]] || printf '%s\n' '{}' >"$settings_file"
@@ -261,6 +262,7 @@ _radio_install_hooks() {
     --arg sess "$register_cmd" \
     --arg ups  "$busy_cmd" \
     --arg stop "$stop_cmd" \
+    --arg endcmd  "$end_cmd" \
     '
     def add_radio(arr; cmd):
       if (arr // []) | any((.hooks // []) | any((.command // "") | startswith("radio "))) then arr
@@ -270,6 +272,7 @@ _radio_install_hooks() {
     | .hooks.SessionStart     = add_radio(.hooks.SessionStart;     $sess)
     | .hooks.UserPromptSubmit = add_radio(.hooks.UserPromptSubmit; $ups)
     | .hooks.Stop             = add_radio(.hooks.Stop;             $stop)
+    | .hooks.SessionEnd       = add_radio(.hooks.SessionEnd;       $endcmd)
     | .permissions //= {}
     | .permissions.allow //= []
     | .permissions.allow = (

--- a/claude-jira/bin/task-done
+++ b/claude-jira/bin/task-done
@@ -103,6 +103,13 @@ if [[ "$FORCE" != true && "$REMOVE_ONLY" != true ]]; then
   [[ "$confirm" != "y" && "$confirm" != "Y" ]] && exit 0
 fi
 
+# Unregister radio session before tearing down the worktree (#94). The
+# `|| true` is a safety net: $TASK_FORCE_ROLE should be set inside a worker
+# tab, but if it isn't (e.g., task-done invoked from an unexpected shell)
+# the no-op must not abort cleanup. `radio unregister` itself already
+# silently exits when $TASK_FORCE_ROLE is unset (#93).
+radio unregister 2>/dev/null || true
+
 # Move out of worktree before removing it
 cd "$MAIN_WORKTREE"
 

--- a/claude-jira/bin/task-init
+++ b/claude-jira/bin/task-init
@@ -218,6 +218,7 @@ _radio_install_hooks() {
   local register_cmd="radio register --role \$TASK_FORCE_ROLE --tab \$ZELLIJ_TAB --repo \$(git rev-parse --show-toplevel 2>/dev/null) --agent claude --loadout $loadout"
   local busy_cmd="radio busy"
   local stop_cmd="radio ready && radio check"
+  local end_cmd="radio unregister"
 
   mkdir -p "$(dirname "$settings_file")"
   [[ -f "$settings_file" ]] || printf '%s\n' '{}' >"$settings_file"
@@ -233,6 +234,7 @@ _radio_install_hooks() {
     --arg sess "$register_cmd" \
     --arg ups  "$busy_cmd" \
     --arg stop "$stop_cmd" \
+    --arg endcmd  "$end_cmd" \
     '
     def add_radio(arr; cmd):
       if (arr // []) | any((.hooks // []) | any((.command // "") | startswith("radio "))) then arr
@@ -242,6 +244,7 @@ _radio_install_hooks() {
     | .hooks.SessionStart     = add_radio(.hooks.SessionStart;     $sess)
     | .hooks.UserPromptSubmit = add_radio(.hooks.UserPromptSubmit; $ups)
     | .hooks.Stop             = add_radio(.hooks.Stop;             $stop)
+    | .hooks.SessionEnd       = add_radio(.hooks.SessionEnd;       $endcmd)
     | .permissions //= {}
     | .permissions.allow //= []
     | .permissions.allow = (

--- a/claude-local/bin/task-done
+++ b/claude-local/bin/task-done
@@ -99,6 +99,13 @@ if [[ "$FORCE" != true && "$REMOVE_ONLY" != true ]]; then
   [[ "$confirm" != "y" && "$confirm" != "Y" ]] && exit 0
 fi
 
+# Unregister radio session before tearing down the worktree (#94). The
+# `|| true` is a safety net: $TASK_FORCE_ROLE should be set inside a worker
+# tab, but if it isn't (e.g., task-done invoked from an unexpected shell)
+# the no-op must not abort cleanup. `radio unregister` itself already
+# silently exits when $TASK_FORCE_ROLE is unset (#93).
+radio unregister 2>/dev/null || true
+
 # Move out of worktree before removing it
 cd "$MAIN_WORKTREE"
 

--- a/claude-local/bin/task-init
+++ b/claude-local/bin/task-init
@@ -243,6 +243,7 @@ _radio_install_hooks() {
   local register_cmd="radio register --role \$TASK_FORCE_ROLE --tab \$ZELLIJ_TAB --repo \$(git rev-parse --show-toplevel 2>/dev/null) --agent claude --loadout $loadout"
   local busy_cmd="radio busy"
   local stop_cmd="radio ready && radio check"
+  local end_cmd="radio unregister"
 
   mkdir -p "$(dirname "$settings_file")"
   [[ -f "$settings_file" ]] || printf '%s\n' '{}' >"$settings_file"
@@ -252,6 +253,7 @@ _radio_install_hooks() {
     --arg sess "$register_cmd" \
     --arg ups  "$busy_cmd" \
     --arg stop "$stop_cmd" \
+    --arg endcmd  "$end_cmd" \
     '
     def add_radio(arr; cmd):
       if (arr // []) | any((.hooks // []) | any((.command // "") | startswith("radio "))) then arr
@@ -261,6 +263,7 @@ _radio_install_hooks() {
     | .hooks.SessionStart     = add_radio(.hooks.SessionStart;     $sess)
     | .hooks.UserPromptSubmit = add_radio(.hooks.UserPromptSubmit; $ups)
     | .hooks.Stop             = add_radio(.hooks.Stop;             $stop)
+    | .hooks.SessionEnd       = add_radio(.hooks.SessionEnd;       $endcmd)
     | .permissions //= {}
     | .permissions.allow //= []
     | .permissions.allow = (

--- a/claude-notion/bin/task-done
+++ b/claude-notion/bin/task-done
@@ -97,6 +97,13 @@ if [[ "$FORCE" != true && "$REMOVE_ONLY" != true ]]; then
   [[ "$confirm" != "y" && "$confirm" != "Y" ]] && exit 0
 fi
 
+# Unregister radio session before tearing down the worktree (#94). The
+# `|| true` is a safety net: $TASK_FORCE_ROLE should be set inside a worker
+# tab, but if it isn't (e.g., task-done invoked from an unexpected shell)
+# the no-op must not abort cleanup. `radio unregister` itself already
+# silently exits when $TASK_FORCE_ROLE is unset (#93).
+radio unregister 2>/dev/null || true
+
 # Move out of worktree before removing it
 cd "$MAIN_WORKTREE"
 

--- a/claude-notion/bin/task-init
+++ b/claude-notion/bin/task-init
@@ -173,6 +173,7 @@ _radio_install_hooks() {
   local register_cmd="radio register --role \$TASK_FORCE_ROLE --tab \$ZELLIJ_TAB --repo \$(git rev-parse --show-toplevel 2>/dev/null) --agent claude --loadout $loadout"
   local busy_cmd="radio busy"
   local stop_cmd="radio ready && radio check"
+  local end_cmd="radio unregister"
 
   mkdir -p "$(dirname "$settings_file")"
   [[ -f "$settings_file" ]] || printf '%s\n' '{}' >"$settings_file"
@@ -189,6 +190,7 @@ _radio_install_hooks() {
     --arg sess "$register_cmd" \
     --arg ups  "$busy_cmd" \
     --arg stop "$stop_cmd" \
+    --arg endcmd  "$end_cmd" \
     '
     def add_radio(arr; cmd):
       if (arr // []) | any((.hooks // []) | any((.command // "") | startswith("radio "))) then arr
@@ -198,6 +200,7 @@ _radio_install_hooks() {
     | .hooks.SessionStart     = add_radio(.hooks.SessionStart;     $sess)
     | .hooks.UserPromptSubmit = add_radio(.hooks.UserPromptSubmit; $ups)
     | .hooks.Stop             = add_radio(.hooks.Stop;             $stop)
+    | .hooks.SessionEnd       = add_radio(.hooks.SessionEnd;       $endcmd)
     | .permissions //= {}
     | .permissions.allow //= []
     | .permissions.allow = (

--- a/kiro-gh/bin/task-done
+++ b/kiro-gh/bin/task-done
@@ -97,6 +97,13 @@ if [[ "$FORCE" != true && "$REMOVE_ONLY" != true ]]; then
   [[ "$confirm" != "y" && "$confirm" != "Y" ]] && exit 0
 fi
 
+# Unregister radio session before tearing down the worktree (#94). The
+# `|| true` is a safety net: $TASK_FORCE_ROLE should be set inside a worker
+# tab, but if it isn't (e.g., task-done invoked from an unexpected shell)
+# the no-op must not abort cleanup. `radio unregister` itself already
+# silently exits when $TASK_FORCE_ROLE is unset (#93).
+radio unregister 2>/dev/null || true
+
 # Move out of worktree before removing it
 cd "$MAIN_WORKTREE"
 

--- a/kiro-gh/bin/task-init
+++ b/kiro-gh/bin/task-init
@@ -233,6 +233,10 @@ EOF
     "radio register --role \$TASK_FORCE_ROLE --tab \$ZELLIJ_TAB --repo \$(git rev-parse --show-toplevel 2>/dev/null) --agent kiro --loadout ${loadout}"
   _write_hook "radio-busy"     "userPromptSubmit" "radio busy"
   _write_hook "radio-ready"    "agentStop"        "radio ready && radio check"
+  # Note: kiro has no session-end trigger (agentStop fires per-turn, not on
+  # session close), so the Claude SessionEnd → `radio unregister` beat has
+  # no direct kiro analog. The worker happy path is still covered: task-done
+  # invokes `radio unregister` before removing the worktree (issue #94).
 }
 
 if [[ "$SCOPE" != "workflow" && "$SCOPE" != "commands" ]]; then

--- a/kiro-local/bin/task-done
+++ b/kiro-local/bin/task-done
@@ -99,6 +99,13 @@ if [[ "$FORCE" != true && "$REMOVE_ONLY" != true ]]; then
   [[ "$confirm" != "y" && "$confirm" != "Y" ]] && exit 0
 fi
 
+# Unregister radio session before tearing down the worktree (#94). The
+# `|| true` is a safety net: $TASK_FORCE_ROLE should be set inside a worker
+# tab, but if it isn't (e.g., task-done invoked from an unexpected shell)
+# the no-op must not abort cleanup. `radio unregister` itself already
+# silently exits when $TASK_FORCE_ROLE is unset (#93).
+radio unregister 2>/dev/null || true
+
 # Move out of worktree before removing it
 cd "$MAIN_WORKTREE"
 

--- a/kiro-local/bin/task-init
+++ b/kiro-local/bin/task-init
@@ -234,6 +234,10 @@ EOF
     "radio register --role \$TASK_FORCE_ROLE --tab \$ZELLIJ_TAB --repo \$(git rev-parse --show-toplevel 2>/dev/null) --agent kiro --loadout ${loadout}"
   _write_hook "radio-busy"     "userPromptSubmit" "radio busy"
   _write_hook "radio-ready"    "agentStop"        "radio ready && radio check"
+  # Note: kiro has no session-end trigger (agentStop fires per-turn, not on
+  # session close), so the Claude SessionEnd → `radio unregister` beat has
+  # no direct kiro analog. The worker happy path is still covered: task-done
+  # invokes `radio unregister` before removing the worktree (issue #94).
 }
 
 if [[ "$SCOPE" != "workflow" && "$SCOPE" != "commands" ]]; then

--- a/kiro-notion/bin/task-done
+++ b/kiro-notion/bin/task-done
@@ -97,6 +97,13 @@ if [[ "$FORCE" != true && "$REMOVE_ONLY" != true ]]; then
   [[ "$confirm" != "y" && "$confirm" != "Y" ]] && exit 0
 fi
 
+# Unregister radio session before tearing down the worktree (#94). The
+# `|| true` is a safety net: $TASK_FORCE_ROLE should be set inside a worker
+# tab, but if it isn't (e.g., task-done invoked from an unexpected shell)
+# the no-op must not abort cleanup. `radio unregister` itself already
+# silently exits when $TASK_FORCE_ROLE is unset (#93).
+radio unregister 2>/dev/null || true
+
 # Move out of worktree before removing it
 cd "$MAIN_WORKTREE"
 

--- a/kiro-notion/bin/task-init
+++ b/kiro-notion/bin/task-init
@@ -167,6 +167,10 @@ EOF
     "radio register --role \$TASK_FORCE_ROLE --tab \$ZELLIJ_TAB --repo \$(git rev-parse --show-toplevel 2>/dev/null) --agent kiro --loadout ${loadout}"
   _write_hook "radio-busy"     "userPromptSubmit" "radio busy"
   _write_hook "radio-ready"    "agentStop"        "radio ready && radio check"
+  # Note: kiro has no session-end trigger (agentStop fires per-turn, not on
+  # session close), so the Claude SessionEnd → `radio unregister` beat has
+  # no direct kiro analog. The worker happy path is still covered: task-done
+  # invokes `radio unregister` before removing the worktree (issue #94).
 }
 
 if [[ "$SCOPE" != "workflow" && "$SCOPE" != "commands" ]]; then

--- a/tests/claude_gh_task_init.bats
+++ b/tests/claude_gh_task_init.bats
@@ -353,14 +353,21 @@ teardown() {
 # radio hooks: settings.json merge
 # ---------------------------------------------------------------------------
 
-@test "writes 3 radio hook entries into .claude/settings.json" {
+@test "writes 4 radio hook entries into .claude/settings.json" {
   run "$CLAUDE_GH_TASK_INIT"
   assert_success
   assert [ -f "$TARGET_DIR/.claude/settings.json" ]
-  for event in SessionStart UserPromptSubmit Stop; do
+  for event in SessionStart UserPromptSubmit Stop SessionEnd; do
     run jq -r ".hooks.$event[0].hooks[0].command" "$TARGET_DIR/.claude/settings.json"
     assert_output --partial "radio"
   done
+}
+
+@test "SessionEnd hook calls 'radio unregister' (#94)" {
+  run "$CLAUDE_GH_TASK_INIT"
+  assert_success
+  run jq -r '.hooks.SessionEnd[0].hooks[0].command' "$TARGET_DIR/.claude/settings.json"
+  assert_output "radio unregister"
 }
 
 @test "SessionStart hook command embeds the loadout name" {
@@ -397,7 +404,7 @@ EOF
   assert_success
   run "$CLAUDE_GH_TASK_INIT" --force
   assert_success
-  for event in SessionStart UserPromptSubmit Stop; do
+  for event in SessionStart UserPromptSubmit Stop SessionEnd; do
     run jq -r ".hooks.$event | length" "$TARGET_DIR/.claude/settings.json"
     assert_output "1"
   done

--- a/tests/radio.bats
+++ b/tests/radio.bats
@@ -63,6 +63,17 @@ teardown() {
   assert [ ! -f "$TASK_FORCE_HOME/radio/sessions/pm.info" ]
 }
 
+@test "lifecycle: register → unregister leaves the sessions dir empty (#94)" {
+  # Guards against orphan accumulation. The SessionEnd hook + task-done both
+  # call `radio unregister`; this test pins the contract that a clean cycle
+  # leaves no session file behind.
+  "$RADIO" register --role worker-foo --tab w-foo --agent claude --loadout claude-gh
+  assert [ -f "$TASK_FORCE_HOME/radio/sessions/worker-foo.info" ]
+  TASK_FORCE_ROLE=worker-foo "$RADIO" unregister
+  run bash -c "ls '$TASK_FORCE_HOME/radio/sessions/' 2>/dev/null | wc -l | tr -d ' '"
+  assert_output "0"
+}
+
 # ----- silent no-op when $TASK_FORCE_ROLE is unset (#93) --------------------
 # Hook-invoked commands (radio busy/ready/check/unregister and `register --role ""`
 # from the SessionStart hook) must NOT block a plain `claude` session in a

--- a/tests/task_done.bats
+++ b/tests/task_done.bats
@@ -411,3 +411,69 @@ add_submodule_to_worktree() {
   refute_output --partial "removal failed"
   assert [ ! -d "$WORKTREE_BASE/$SLUG" ]
 }
+
+# ---------------------------------------------------------------------------
+# Radio session unregister on cleanup (issue #94)
+# task-done must call `radio unregister` so worker session files don't
+# accumulate as orphans in ~/.task-force/radio/sessions/.
+# ---------------------------------------------------------------------------
+
+# Pre-register a radio session for the current "worker" role, then assert
+# task-done removes it. Uses the real radio binary on PATH and an isolated
+# $TASK_FORCE_HOME tempdir so the host's session dir is untouched.
+assert_task_done_unregisters() {
+  local script="$1"
+  local role="worker-task-force-$SLUG"
+
+  setup_task_force_home
+  cp "$RADIO" "$STUB_BIN/radio"
+  chmod +x "$STUB_BIN/radio"
+  export TASK_FORCE_ROLE="$role"
+
+  "$RADIO" register --role "$role" --tab "$role" --agent claude --loadout claude-gh
+  assert [ -f "$TASK_FORCE_HOME/radio/sessions/$role.info" ]
+
+  run bash -c "echo y | $script --force"
+  assert_success
+  assert [ ! -f "$TASK_FORCE_HOME/radio/sessions/$role.info" ]
+}
+
+@test "kiro: task-done unregisters the radio session" {
+  assert_task_done_unregisters "$KIRO_TASK_DONE"
+}
+
+@test "jira: task-done unregisters the radio session" {
+  assert_task_done_unregisters "$JIRA_TASK_DONE"
+}
+
+@test "claude-notion: task-done unregisters the radio session" {
+  assert_task_done_unregisters "$CLAUDE_NOTION_TASK_DONE"
+}
+
+@test "claude-gh: task-done unregisters the radio session" {
+  assert_task_done_unregisters "$CLAUDE_GH_TASK_DONE"
+}
+
+@test "kiro-gh: task-done unregisters the radio session" {
+  assert_task_done_unregisters "$KIRO_GH_TASK_DONE"
+}
+
+@test "claude-local: task-done unregisters the radio session" {
+  assert_task_done_unregisters "$CLAUDE_LOCAL_TASK_DONE"
+}
+
+@test "kiro-local: task-done unregisters the radio session" {
+  assert_task_done_unregisters "$KIRO_LOCAL_TASK_DONE"
+}
+
+@test "task-done cleanup tolerates radio binary missing from PATH (#94)" {
+  # The `|| true` safety net: if radio isn't installed (or PATH doesn't
+  # include it), cleanup must still succeed.
+  setup_task_force_home
+  export TASK_FORCE_ROLE="worker-task-force-$SLUG"
+  # Note: deliberately do NOT install radio into $STUB_BIN here.
+
+  run bash -c "echo y | $CLAUDE_GH_TASK_DONE --force"
+  assert_success
+  assert [ ! -d "$WORKTREE_BASE/$SLUG" ]
+}


### PR DESCRIPTION
## Summary

Closes #94. Plugs two lifecycle gaps that let radio session files orphan in `~/.task-force/radio/sessions/`:

- **SessionEnd hook** — Claude's `SessionEnd` event now calls `radio unregister`, so a normal `/exit` (or natural shutdown) cleans up. Wired into both the dogfood `.claude/settings.json` and the claude-* `task-init` jq merge.
- **task-done cleanup** — `task-done` now calls `radio unregister 2>/dev/null || true` in the shared `confirm-and-cleanup` region before tearing down the worktree. Replicated byte-identical across all 7 loadouts (drift-checked).

Kiro has no session-end trigger (`agentStop` fires per turn, not on close), so kiro relies on `task-done` for unregister cleanup; a comment documents the gap.

## Test plan

- [x] `tools/check-drift.sh` — 16 groups still in sync
- [x] `./run_tests.sh` — 589/589 pass, including:
  - `radio.bats`: new "register → unregister leaves sessions dir empty" lifecycle test
  - `task_done.bats`: new tests verifying `radio unregister` runs across all 7 loadouts + a "missing radio binary" safety-net test
  - `claude_gh_task_init.bats`: updated to assert all 4 hooks (incl. SessionEnd) are templated
- [ ] Manual smoke (will run after merge): `task-pm` → `/exit` removes the session file; `task-work foo` → `task-done --remove-worktree` removes the worker session.

🤖 Generated with [Claude Code](https://claude.com/claude-code)