### PR TITLE
Reflect radio idle/busy state via emoji in zellij tab name (#95)

### DIFF
--- a/claude-gh/bin/radio
+++ b/claude-gh/bin/radio
@@ -122,6 +122,49 @@ _update_state() {
       if (!seen_hb)    print "LAST_HEARTBEAT=" hb
     }
   ' "$f" | _atomic_write "$f"
+
+  _rename_tab "$new_state"
+}
+
+# Prefix the current zellij tab with an emoji reflecting STATE. No-op silently
+# if zellij isn't running, $ZELLIJ is unset, or we have no TAB= in the session
+# file. On success, also rewrite TAB= in the session file so `go-to-tab-name`
+# lookups in `radio send` continue to match the visible tab name (#95).
+_rename_tab() {
+  local new_state="$1"
+  [[ -n "${ZELLIJ:-}" ]] || return 0
+  command -v zellij >/dev/null 2>&1 || return 0
+  [[ -n "${TASK_FORCE_ROLE:-}" ]] || return 0
+
+  local f base prefix new_name
+  f=$(_session_file "$TASK_FORCE_ROLE")
+  [[ -f "$f" ]] || return 0
+
+  base=$(_session_field "$f" TAB || true)
+  [[ -n "$base" ]] || return 0
+
+  # Strip any existing emoji prefix so repeated calls don't stack them (e.g.
+  # the previous run persisted `⏸️ pm` into TAB=; without stripping we'd
+  # rename to `⏸️ ⏸️ pm`).
+  base="${base#⏸️ }"
+  base="${base#▶️ }"
+
+  case "$new_state" in
+    idle) prefix="⏸️ " ;;
+    busy) prefix="▶️ " ;;
+    *)    return 0 ;;
+  esac
+  new_name="${prefix}${base}"
+
+  zellij action rename-tab "$new_name" >/dev/null 2>&1 || return 0
+
+  # Persist the new visible name back to the session file so wake-up
+  # (`go-to-tab-name` in cmd_send) finds the tab by its current name.
+  awk -v t="$new_name" '
+    /^TAB=/ { print "TAB=" t; seen=1; next }
+    { print }
+    END { if (!seen) print "TAB=" t }
+  ' "$f" | _atomic_write "$f"
 }
 
 # ----- subcommands ----------------------------------------------------------
@@ -150,6 +193,11 @@ cmd_register() {
 
   mkdir -p "$(_inbox_dir "$role")" "$(_processed_dir "$role")"
   _log "register role=$role tab=$tab agent=$agent loadout=$loadout"
+
+  # First paint of the idle prefix without waiting for a Stop hook cycle (#95).
+  # _rename_tab reads $TASK_FORCE_ROLE, which the SessionStart hook sets to the
+  # same value as --role here (`radio register --role $TASK_FORCE_ROLE …`).
+  _rename_tab idle
 }
 
 cmd_unregister() {

--- a/claude-jira/bin/radio
+++ b/claude-jira/bin/radio
@@ -122,6 +122,49 @@ _update_state() {
       if (!seen_hb)    print "LAST_HEARTBEAT=" hb
     }
   ' "$f" | _atomic_write "$f"
+
+  _rename_tab "$new_state"
+}
+
+# Prefix the current zellij tab with an emoji reflecting STATE. No-op silently
+# if zellij isn't running, $ZELLIJ is unset, or we have no TAB= in the session
+# file. On success, also rewrite TAB= in the session file so `go-to-tab-name`
+# lookups in `radio send` continue to match the visible tab name (#95).
+_rename_tab() {
+  local new_state="$1"
+  [[ -n "${ZELLIJ:-}" ]] || return 0
+  command -v zellij >/dev/null 2>&1 || return 0
+  [[ -n "${TASK_FORCE_ROLE:-}" ]] || return 0
+
+  local f base prefix new_name
+  f=$(_session_file "$TASK_FORCE_ROLE")
+  [[ -f "$f" ]] || return 0
+
+  base=$(_session_field "$f" TAB || true)
+  [[ -n "$base" ]] || return 0
+
+  # Strip any existing emoji prefix so repeated calls don't stack them (e.g.
+  # the previous run persisted `⏸️ pm` into TAB=; without stripping we'd
+  # rename to `⏸️ ⏸️ pm`).
+  base="${base#⏸️ }"
+  base="${base#▶️ }"
+
+  case "$new_state" in
+    idle) prefix="⏸️ " ;;
+    busy) prefix="▶️ " ;;
+    *)    return 0 ;;
+  esac
+  new_name="${prefix}${base}"
+
+  zellij action rename-tab "$new_name" >/dev/null 2>&1 || return 0
+
+  # Persist the new visible name back to the session file so wake-up
+  # (`go-to-tab-name` in cmd_send) finds the tab by its current name.
+  awk -v t="$new_name" '
+    /^TAB=/ { print "TAB=" t; seen=1; next }
+    { print }
+    END { if (!seen) print "TAB=" t }
+  ' "$f" | _atomic_write "$f"
 }
 
 # ----- subcommands ----------------------------------------------------------
@@ -150,6 +193,11 @@ cmd_register() {
 
   mkdir -p "$(_inbox_dir "$role")" "$(_processed_dir "$role")"
   _log "register role=$role tab=$tab agent=$agent loadout=$loadout"
+
+  # First paint of the idle prefix without waiting for a Stop hook cycle (#95).
+  # _rename_tab reads $TASK_FORCE_ROLE, which the SessionStart hook sets to the
+  # same value as --role here (`radio register --role $TASK_FORCE_ROLE …`).
+  _rename_tab idle
 }
 
 cmd_unregister() {

--- a/claude-local/bin/radio
+++ b/claude-local/bin/radio
@@ -122,6 +122,49 @@ _update_state() {
       if (!seen_hb)    print "LAST_HEARTBEAT=" hb
     }
   ' "$f" | _atomic_write "$f"
+
+  _rename_tab "$new_state"
+}
+
+# Prefix the current zellij tab with an emoji reflecting STATE. No-op silently
+# if zellij isn't running, $ZELLIJ is unset, or we have no TAB= in the session
+# file. On success, also rewrite TAB= in the session file so `go-to-tab-name`
+# lookups in `radio send` continue to match the visible tab name (#95).
+_rename_tab() {
+  local new_state="$1"
+  [[ -n "${ZELLIJ:-}" ]] || return 0
+  command -v zellij >/dev/null 2>&1 || return 0
+  [[ -n "${TASK_FORCE_ROLE:-}" ]] || return 0
+
+  local f base prefix new_name
+  f=$(_session_file "$TASK_FORCE_ROLE")
+  [[ -f "$f" ]] || return 0
+
+  base=$(_session_field "$f" TAB || true)
+  [[ -n "$base" ]] || return 0
+
+  # Strip any existing emoji prefix so repeated calls don't stack them (e.g.
+  # the previous run persisted `⏸️ pm` into TAB=; without stripping we'd
+  # rename to `⏸️ ⏸️ pm`).
+  base="${base#⏸️ }"
+  base="${base#▶️ }"
+
+  case "$new_state" in
+    idle) prefix="⏸️ " ;;
+    busy) prefix="▶️ " ;;
+    *)    return 0 ;;
+  esac
+  new_name="${prefix}${base}"
+
+  zellij action rename-tab "$new_name" >/dev/null 2>&1 || return 0
+
+  # Persist the new visible name back to the session file so wake-up
+  # (`go-to-tab-name` in cmd_send) finds the tab by its current name.
+  awk -v t="$new_name" '
+    /^TAB=/ { print "TAB=" t; seen=1; next }
+    { print }
+    END { if (!seen) print "TAB=" t }
+  ' "$f" | _atomic_write "$f"
 }
 
 # ----- subcommands ----------------------------------------------------------
@@ -150,6 +193,11 @@ cmd_register() {
 
   mkdir -p "$(_inbox_dir "$role")" "$(_processed_dir "$role")"
   _log "register role=$role tab=$tab agent=$agent loadout=$loadout"
+
+  # First paint of the idle prefix without waiting for a Stop hook cycle (#95).
+  # _rename_tab reads $TASK_FORCE_ROLE, which the SessionStart hook sets to the
+  # same value as --role here (`radio register --role $TASK_FORCE_ROLE …`).
+  _rename_tab idle
 }
 
 cmd_unregister() {

--- a/claude-notion/bin/radio
+++ b/claude-notion/bin/radio
@@ -122,6 +122,49 @@ _update_state() {
       if (!seen_hb)    print "LAST_HEARTBEAT=" hb
     }
   ' "$f" | _atomic_write "$f"
+
+  _rename_tab "$new_state"
+}
+
+# Prefix the current zellij tab with an emoji reflecting STATE. No-op silently
+# if zellij isn't running, $ZELLIJ is unset, or we have no TAB= in the session
+# file. On success, also rewrite TAB= in the session file so `go-to-tab-name`
+# lookups in `radio send` continue to match the visible tab name (#95).
+_rename_tab() {
+  local new_state="$1"
+  [[ -n "${ZELLIJ:-}" ]] || return 0
+  command -v zellij >/dev/null 2>&1 || return 0
+  [[ -n "${TASK_FORCE_ROLE:-}" ]] || return 0
+
+  local f base prefix new_name
+  f=$(_session_file "$TASK_FORCE_ROLE")
+  [[ -f "$f" ]] || return 0
+
+  base=$(_session_field "$f" TAB || true)
+  [[ -n "$base" ]] || return 0
+
+  # Strip any existing emoji prefix so repeated calls don't stack them (e.g.
+  # the previous run persisted `⏸️ pm` into TAB=; without stripping we'd
+  # rename to `⏸️ ⏸️ pm`).
+  base="${base#⏸️ }"
+  base="${base#▶️ }"
+
+  case "$new_state" in
+    idle) prefix="⏸️ " ;;
+    busy) prefix="▶️ " ;;
+    *)    return 0 ;;
+  esac
+  new_name="${prefix}${base}"
+
+  zellij action rename-tab "$new_name" >/dev/null 2>&1 || return 0
+
+  # Persist the new visible name back to the session file so wake-up
+  # (`go-to-tab-name` in cmd_send) finds the tab by its current name.
+  awk -v t="$new_name" '
+    /^TAB=/ { print "TAB=" t; seen=1; next }
+    { print }
+    END { if (!seen) print "TAB=" t }
+  ' "$f" | _atomic_write "$f"
 }
 
 # ----- subcommands ----------------------------------------------------------
@@ -150,6 +193,11 @@ cmd_register() {
 
   mkdir -p "$(_inbox_dir "$role")" "$(_processed_dir "$role")"
   _log "register role=$role tab=$tab agent=$agent loadout=$loadout"
+
+  # First paint of the idle prefix without waiting for a Stop hook cycle (#95).
+  # _rename_tab reads $TASK_FORCE_ROLE, which the SessionStart hook sets to the
+  # same value as --role here (`radio register --role $TASK_FORCE_ROLE …`).
+  _rename_tab idle
 }
 
 cmd_unregister() {

--- a/kiro-gh/bin/radio
+++ b/kiro-gh/bin/radio
@@ -122,6 +122,49 @@ _update_state() {
       if (!seen_hb)    print "LAST_HEARTBEAT=" hb
     }
   ' "$f" | _atomic_write "$f"
+
+  _rename_tab "$new_state"
+}
+
+# Prefix the current zellij tab with an emoji reflecting STATE. No-op silently
+# if zellij isn't running, $ZELLIJ is unset, or we have no TAB= in the session
+# file. On success, also rewrite TAB= in the session file so `go-to-tab-name`
+# lookups in `radio send` continue to match the visible tab name (#95).
+_rename_tab() {
+  local new_state="$1"
+  [[ -n "${ZELLIJ:-}" ]] || return 0
+  command -v zellij >/dev/null 2>&1 || return 0
+  [[ -n "${TASK_FORCE_ROLE:-}" ]] || return 0
+
+  local f base prefix new_name
+  f=$(_session_file "$TASK_FORCE_ROLE")
+  [[ -f "$f" ]] || return 0
+
+  base=$(_session_field "$f" TAB || true)
+  [[ -n "$base" ]] || return 0
+
+  # Strip any existing emoji prefix so repeated calls don't stack them (e.g.
+  # the previous run persisted `⏸️ pm` into TAB=; without stripping we'd
+  # rename to `⏸️ ⏸️ pm`).
+  base="${base#⏸️ }"
+  base="${base#▶️ }"
+
+  case "$new_state" in
+    idle) prefix="⏸️ " ;;
+    busy) prefix="▶️ " ;;
+    *)    return 0 ;;
+  esac
+  new_name="${prefix}${base}"
+
+  zellij action rename-tab "$new_name" >/dev/null 2>&1 || return 0
+
+  # Persist the new visible name back to the session file so wake-up
+  # (`go-to-tab-name` in cmd_send) finds the tab by its current name.
+  awk -v t="$new_name" '
+    /^TAB=/ { print "TAB=" t; seen=1; next }
+    { print }
+    END { if (!seen) print "TAB=" t }
+  ' "$f" | _atomic_write "$f"
 }
 
 # ----- subcommands ----------------------------------------------------------
@@ -150,6 +193,11 @@ cmd_register() {
 
   mkdir -p "$(_inbox_dir "$role")" "$(_processed_dir "$role")"
   _log "register role=$role tab=$tab agent=$agent loadout=$loadout"
+
+  # First paint of the idle prefix without waiting for a Stop hook cycle (#95).
+  # _rename_tab reads $TASK_FORCE_ROLE, which the SessionStart hook sets to the
+  # same value as --role here (`radio register --role $TASK_FORCE_ROLE …`).
+  _rename_tab idle
 }
 
 cmd_unregister() {

--- a/kiro-local/bin/radio
+++ b/kiro-local/bin/radio
@@ -122,6 +122,49 @@ _update_state() {
       if (!seen_hb)    print "LAST_HEARTBEAT=" hb
     }
   ' "$f" | _atomic_write "$f"
+
+  _rename_tab "$new_state"
+}
+
+# Prefix the current zellij tab with an emoji reflecting STATE. No-op silently
+# if zellij isn't running, $ZELLIJ is unset, or we have no TAB= in the session
+# file. On success, also rewrite TAB= in the session file so `go-to-tab-name`
+# lookups in `radio send` continue to match the visible tab name (#95).
+_rename_tab() {
+  local new_state="$1"
+  [[ -n "${ZELLIJ:-}" ]] || return 0
+  command -v zellij >/dev/null 2>&1 || return 0
+  [[ -n "${TASK_FORCE_ROLE:-}" ]] || return 0
+
+  local f base prefix new_name
+  f=$(_session_file "$TASK_FORCE_ROLE")
+  [[ -f "$f" ]] || return 0
+
+  base=$(_session_field "$f" TAB || true)
+  [[ -n "$base" ]] || return 0
+
+  # Strip any existing emoji prefix so repeated calls don't stack them (e.g.
+  # the previous run persisted `⏸️ pm` into TAB=; without stripping we'd
+  # rename to `⏸️ ⏸️ pm`).
+  base="${base#⏸️ }"
+  base="${base#▶️ }"
+
+  case "$new_state" in
+    idle) prefix="⏸️ " ;;
+    busy) prefix="▶️ " ;;
+    *)    return 0 ;;
+  esac
+  new_name="${prefix}${base}"
+
+  zellij action rename-tab "$new_name" >/dev/null 2>&1 || return 0
+
+  # Persist the new visible name back to the session file so wake-up
+  # (`go-to-tab-name` in cmd_send) finds the tab by its current name.
+  awk -v t="$new_name" '
+    /^TAB=/ { print "TAB=" t; seen=1; next }
+    { print }
+    END { if (!seen) print "TAB=" t }
+  ' "$f" | _atomic_write "$f"
 }
 
 # ----- subcommands ----------------------------------------------------------
@@ -150,6 +193,11 @@ cmd_register() {
 
   mkdir -p "$(_inbox_dir "$role")" "$(_processed_dir "$role")"
   _log "register role=$role tab=$tab agent=$agent loadout=$loadout"
+
+  # First paint of the idle prefix without waiting for a Stop hook cycle (#95).
+  # _rename_tab reads $TASK_FORCE_ROLE, which the SessionStart hook sets to the
+  # same value as --role here (`radio register --role $TASK_FORCE_ROLE …`).
+  _rename_tab idle
 }
 
 cmd_unregister() {

--- a/kiro-notion/bin/radio
+++ b/kiro-notion/bin/radio
@@ -122,6 +122,49 @@ _update_state() {
       if (!seen_hb)    print "LAST_HEARTBEAT=" hb
     }
   ' "$f" | _atomic_write "$f"
+
+  _rename_tab "$new_state"
+}
+
+# Prefix the current zellij tab with an emoji reflecting STATE. No-op silently
+# if zellij isn't running, $ZELLIJ is unset, or we have no TAB= in the session
+# file. On success, also rewrite TAB= in the session file so `go-to-tab-name`
+# lookups in `radio send` continue to match the visible tab name (#95).
+_rename_tab() {
+  local new_state="$1"
+  [[ -n "${ZELLIJ:-}" ]] || return 0
+  command -v zellij >/dev/null 2>&1 || return 0
+  [[ -n "${TASK_FORCE_ROLE:-}" ]] || return 0
+
+  local f base prefix new_name
+  f=$(_session_file "$TASK_FORCE_ROLE")
+  [[ -f "$f" ]] || return 0
+
+  base=$(_session_field "$f" TAB || true)
+  [[ -n "$base" ]] || return 0
+
+  # Strip any existing emoji prefix so repeated calls don't stack them (e.g.
+  # the previous run persisted `⏸️ pm` into TAB=; without stripping we'd
+  # rename to `⏸️ ⏸️ pm`).
+  base="${base#⏸️ }"
+  base="${base#▶️ }"
+
+  case "$new_state" in
+    idle) prefix="⏸️ " ;;
+    busy) prefix="▶️ " ;;
+    *)    return 0 ;;
+  esac
+  new_name="${prefix}${base}"
+
+  zellij action rename-tab "$new_name" >/dev/null 2>&1 || return 0
+
+  # Persist the new visible name back to the session file so wake-up
+  # (`go-to-tab-name` in cmd_send) finds the tab by its current name.
+  awk -v t="$new_name" '
+    /^TAB=/ { print "TAB=" t; seen=1; next }
+    { print }
+    END { if (!seen) print "TAB=" t }
+  ' "$f" | _atomic_write "$f"
 }
 
 # ----- subcommands ----------------------------------------------------------
@@ -150,6 +193,11 @@ cmd_register() {
 
   mkdir -p "$(_inbox_dir "$role")" "$(_processed_dir "$role")"
   _log "register role=$role tab=$tab agent=$agent loadout=$loadout"
+
+  # First paint of the idle prefix without waiting for a Stop hook cycle (#95).
+  # _rename_tab reads $TASK_FORCE_ROLE, which the SessionStart hook sets to the
+  # same value as --role here (`radio register --role $TASK_FORCE_ROLE …`).
+  _rename_tab idle
 }
 
 cmd_unregister() {

--- a/tests/radio_tab_state.bats
+++ b/tests/radio_tab_state.bats
@@ -1,0 +1,120 @@
+#!/usr/bin/env bats
+# Tests for _rename_tab — the idle/busy emoji prefix on the zellij tab name
+# and the matching TAB= sync in the session file (#95).
+#
+# `_rename_tab` is a private helper; we exercise it indirectly through
+# `radio register` (first-paint idle prefix) and `radio busy` / `radio ready`
+# (state-driven flips). The zellij stub records every invocation so we can
+# assert that rename-tab fires with the expected emoji-prefixed name.
+
+bats_load_library bats-support
+bats_load_library bats-assert
+
+load helpers/common
+
+# The visible-name emojis. Kept as constants so the assertions read clearly
+# and we don't repeat the literal UTF-8 sequences across cases.
+PAUSE='⏸️ '
+PLAY='▶️ '
+
+setup() {
+  setup_task_force_home
+  setup_stubs
+  export ZELLIJ=fake-session
+  # Bypass the no-role dispatcher gate on `register` (#93); per-test overrides
+  # set TASK_FORCE_ROLE where the value matters.
+  export TASK_FORCE_ROLE=test-runner
+}
+
+teardown() {
+  teardown_all
+}
+
+# ----- no-op paths ----------------------------------------------------------
+
+@test "register: no rename-tab when \$ZELLIJ is unset" {
+  unset ZELLIJ
+  TASK_FORCE_ROLE=pm "$RADIO" register --role pm --tab pm --agent claude
+  run stub_calls zellij
+  refute_output --partial "rename-tab"
+  # And TAB= stays at the bare slug.
+  run grep "^TAB=" "$TASK_FORCE_HOME/radio/sessions/pm.info"
+  assert_output "TAB=pm"
+}
+
+@test "register: no rename-tab when zellij is not on PATH" {
+  # Drop the stub dir from PATH so `command -v zellij` fails.
+  PATH="/usr/bin:/bin" TASK_FORCE_ROLE=pm "$RADIO" register --role pm --tab pm --agent claude
+  run stub_calls zellij
+  refute_output --partial "rename-tab"
+  run grep "^TAB=" "$TASK_FORCE_HOME/radio/sessions/pm.info"
+  assert_output "TAB=pm"
+}
+
+@test "busy/ready: no rename-tab when session file has no TAB= field" {
+  # Hand-craft a session file with no TAB= line.
+  mkdir -p "$TASK_FORCE_HOME/radio/sessions"
+  printf 'ROLE=pm\nSTATE=idle\nLAST_HEARTBEAT=2020-01-01T00:00:00Z\nAGENT=claude\nLOADOUT=\n' \
+    > "$TASK_FORCE_HOME/radio/sessions/pm.info"
+  TASK_FORCE_ROLE=pm "$RADIO" busy
+  run stub_calls zellij
+  refute_output --partial "rename-tab"
+}
+
+# ----- first paint at register ---------------------------------------------
+
+@test "register paints the idle prefix on the tab and syncs TAB=" {
+  TASK_FORCE_ROLE=pm "$RADIO" register --role pm --tab pm --agent claude
+  assert_stub_called zellij "action rename-tab ${PAUSE}pm"
+  run grep "^TAB=" "$TASK_FORCE_HOME/radio/sessions/pm.info"
+  assert_output "TAB=${PAUSE}pm"
+}
+
+# ----- busy / ready flips ---------------------------------------------------
+
+@test "busy flips tab to the play prefix and updates TAB=" {
+  TASK_FORCE_ROLE=pm "$RADIO" register --role pm --tab pm --agent claude
+  TASK_FORCE_ROLE=pm "$RADIO" busy
+  assert_stub_called zellij "action rename-tab ${PLAY}pm"
+  run grep "^TAB=" "$TASK_FORCE_HOME/radio/sessions/pm.info"
+  assert_output "TAB=${PLAY}pm"
+}
+
+@test "ready flips tab back to the pause prefix and updates TAB=" {
+  TASK_FORCE_ROLE=pm "$RADIO" register --role pm --tab pm --agent claude
+  TASK_FORCE_ROLE=pm "$RADIO" busy
+  TASK_FORCE_ROLE=pm "$RADIO" ready
+  run grep "^TAB=" "$TASK_FORCE_HOME/radio/sessions/pm.info"
+  assert_output "TAB=${PAUSE}pm"
+}
+
+# ----- no prefix stacking ---------------------------------------------------
+
+@test "consecutive idle→busy→idle flips do not stack emoji prefixes" {
+  TASK_FORCE_ROLE=pm "$RADIO" register --role pm --tab pm --agent claude
+  TASK_FORCE_ROLE=pm "$RADIO" busy
+  TASK_FORCE_ROLE=pm "$RADIO" ready
+  TASK_FORCE_ROLE=pm "$RADIO" busy
+  TASK_FORCE_ROLE=pm "$RADIO" ready
+
+  # Final TAB= should be exactly "<pause> pm", not "<pause><play> pm" etc.
+  run grep "^TAB=" "$TASK_FORCE_HOME/radio/sessions/pm.info"
+  assert_output "TAB=${PAUSE}pm"
+
+  # And the most recent rename-tab call should target the same name.
+  run bash -c "grep 'rename-tab' '$STUB_CALLS_DIR/zellij.calls' | tail -1"
+  assert_output "zellij action rename-tab ${PAUSE}pm"
+}
+
+# ----- TAB= sync keeps wake-up working --------------------------------------
+
+@test "send finds the recipient's tab after rename (TAB= sync verified)" {
+  # Register pm — first-paint rewrites TAB= to "<pause> pm".
+  TASK_FORCE_ROLE=pm "$RADIO" register --role pm --tab pm --agent claude
+
+  # Worker sends to pm; wake-up reads TAB= from pm.info and calls
+  # `zellij action go-to-tab-name <renamed>`. If TAB= sync were broken
+  # this would attempt the bare slug `pm` instead.
+  TASK_FORCE_ROLE=worker-foo "$RADIO" send --to pm --intent review-requested --body "PR up"
+  assert_stub_called zellij "action go-to-tab-name ${PAUSE}pm"
+}


### PR DESCRIPTION
## Summary

- `radio` now renames the current zellij tab with `⏸️`/`▶️` prefix on every STATE flip so parallel workers are visually distinguishable from the tab bar (closes #95).
- `cmd_register` paints the idle prefix immediately on session-file creation; `_update_state` calls `_rename_tab` after the awk so STATE flips track on the tab.
- The helper also rewrites `TAB=` in the session file so `radio send`'s `zellij action go-to-tab-name` lookup keeps matching the visible name.
- Strip-prefix logic prevents stacking on repeated flips; silent no-op when `$ZELLIJ` is unset, zellij isn't on PATH, `TASK_FORCE_ROLE` is unset, or the session file has no `TAB=`.
- Body block replicated across all 7 `bin/radio` files; drift check green.

Depends on #93 (already shipped: aa4eef9).

## Test plan

- [x] `./run_tests.sh radio_tab_state` — 8 new tests green
- [x] `./run_tests.sh radio` / `radio_zellij` / `radio_e2e` — all existing radio tests green
- [x] `./run_tests.sh drift_check` + `bash tools/check-drift.sh` — green
- [x] Full bats suite: 597 tests, all passing (exit 0)
- [ ] Manual: after `task-pm`, tab reads `⏸️ pm`; submitting a prompt flips to `▶️ pm`; turn completion flips back
- [ ] Manual: PM-to-worker `radio send` wake-up still finds the renamed tab
- [ ] Manual: plain `claude` in a task-force repo (no `$TASK_FORCE_ROLE`) — no errors, no tab rename

🤖 Generated with [Claude Code](https://claude.com/claude-code)