### PR TITLE
task-done close-tab leaks to focused tab: scope close-tab to the worker's TAB_ID (#107)

### DIFF
--- a/claude-gh/bin/radio
+++ b/claude-gh/bin/radio
@@ -140,13 +140,46 @@ _session_file() {
 _inbox_dir()    { printf '%s/%s/inbox'     "$MAILBOX_DIR" "$1"; }
 _processed_dir(){ printf '%s/%s/processed' "$MAILBOX_DIR" "$1"; }
 
+# Self-healing: write a session file for $TASK_FORCE_ROLE if one is missing,
+# using the identity env vars task-work / task-pm injected at tab launch
+# (#107 follow-up). The session file is treated as a soft cache, not a lock —
+# Claude Code's SessionEnd hook fires on intra-session events (`/clear`,
+# `/compact`, resume) as well as real exit, so a spurious unregister mid-life
+# would otherwise brick all subsequent busy/ready/send operations for the
+# role. Returns 1 (without writing anything) if there's no identity env to
+# rebuild from, so non-task-force `claude` sessions stay no-ops.
+_ensure_session_file() {
+  _require_role
+  local f
+  f=$(_session_file "$TASK_FORCE_ROLE")
+  [[ -f "$f" ]] && return 0
+
+  [[ -n "${ZELLIJ_TAB:-}" ]] || { _log "ensure_session: \$ZELLIJ_TAB unset; cannot re-seed $TASK_FORCE_ROLE"; return 1; }
+
+  local tab_id=""
+  if [[ -n "${ZELLIJ:-}" ]] && command -v zellij >/dev/null 2>&1; then
+    tab_id=$(_zellij_tab_id_by_name "$ZELLIJ_TAB" || true)
+  fi
+
+  local repo
+  repo=$(git rev-parse --show-toplevel 2>/dev/null || echo "")
+
+  printf 'ROLE=%s\nTAB=%s\nTAB_ID=%s\nREPO=%s\nSTATE=idle\nLAST_HEARTBEAT=%s\nAGENT=%s\nLOADOUT=%s\n' \
+    "$TASK_FORCE_ROLE" "$ZELLIJ_TAB" "$tab_id" "$repo" "$(_now)" \
+    "${TASK_FORCE_AGENT:-claude}" "${TASK_FORCE_LOADOUT:-unknown}" \
+    | _atomic_write "$f"
+
+  mkdir -p "$(_inbox_dir "$TASK_FORCE_ROLE")" "$(_processed_dir "$TASK_FORCE_ROLE")"
+  _log "ensure_session: re-seeded $TASK_FORCE_ROLE (file was missing) tab_id=$tab_id"
+}
+
 # Update STATE=… and LAST_HEARTBEAT=… on the current session file.
 _update_state() {
   local new_state="$1"
   _require_role
+  _ensure_session_file || { _log "update_state: no identity env for $TASK_FORCE_ROLE"; return 0; }
   local f
   f=$(_session_file "$TASK_FORCE_ROLE")
-  [[ -f "$f" ]] || { _log "update_state: no session file for $TASK_FORCE_ROLE"; return 0; }
 
   # Re-emit the file with STATE/LAST_HEARTBEAT replaced; preserve everything else.
   awk -v st="$new_state" -v hb="$(_now)" '
@@ -281,6 +314,34 @@ cmd_register() {
 cmd_unregister() {
   _silent_exit_if_no_role
   _require_role
+
+  # When invoked from Claude Code's SessionEnd hook, a JSON payload is piped
+  # on stdin with a `reason` field. The hook fires on intra-session events
+  # (reason=clear from `/clear`, reason=resume from `/compact` and session
+  # resume) as well as on real exit (reason=logout|prompt_input_exit|other).
+  # Without filtering we wipe the session file mid-life — empirically observed
+  # as bursts of 40+ unregister calls within ~25s, with busy/ready calls
+  # immediately afterwards logging "no session file" against the now-missing
+  # file (#107 review).
+  #
+  # Manual invocations (e.g. from task-done, or a user typing `radio
+  # unregister` in a shell) don't pipe a JSON payload — proceed unconditionally
+  # in that case. We only filter when both (a) stdin is not a terminal and
+  # (b) a parseable `reason` is present.
+  if [[ ! -t 0 ]]; then
+    local payload reason
+    payload=$(cat 2>/dev/null || true)
+    if [[ -n "$payload" ]] && command -v jq >/dev/null 2>&1; then
+      reason=$(printf '%s' "$payload" | jq -r '.reason // empty' 2>/dev/null || true)
+      case "$reason" in
+        clear|resume)
+          _log "unregister: skipping (reason=$reason — intra-session event) role=$TASK_FORCE_ROLE"
+          return 0
+          ;;
+      esac
+    fi
+  fi
+
   local f
   f=$(_session_file "$TASK_FORCE_ROLE")
   rm -f "$f"

--- a/claude-gh/bin/task-done
+++ b/claude-gh/bin/task-done
@@ -97,6 +97,21 @@ if [[ "$FORCE" != true && "$REMOVE_ONLY" != true ]]; then
   [[ "$confirm" != "y" && "$confirm" != "Y" ]] && exit 0
 fi
 
+# Capture this worker's stable zellij tab_id BEFORE `radio unregister`
+# removes the session file. We use it at the end of cleanup to close
+# *this* worker's tab specifically (`close-tab-by-id`), not the focused
+# one. The unscoped `zellij action close-tab` targets whichever tab is
+# focused at call time — same focused-tab bug class as #102/#103 in a
+# different binary; if the user switches focus mid-cleanup, the wrong tab
+# (e.g., PM's) gets closed and an active session can be destroyed (#107).
+_WORKER_TAB_ID=""
+if [[ -n "${ZELLIJ:-}" && -n "${TASK_FORCE_ROLE:-}" ]]; then
+  _SESSION_FILE="${TASK_FORCE_HOME:-$HOME/.task-force}/radio/sessions/${TASK_FORCE_ROLE}.info"
+  if [[ -f "$_SESSION_FILE" ]]; then
+    _WORKER_TAB_ID=$(awk -F= '/^TAB_ID=/ { print $2; exit }' "$_SESSION_FILE")
+  fi
+fi
+
 # Unregister radio session before tearing down the worktree (#94). The
 # `|| true` is a safety net: $TASK_FORCE_ROLE should be set inside a worker
 # tab, but if it isn't (e.g., task-done invoked from an unexpected shell)
@@ -128,7 +143,15 @@ else
   echo "Done. Branch '$BRANCH' still has unmerged commits — delete manually after PR merge: git branch -D $BRANCH"
 fi
 
-# Close current zellij tab
-echo "Closing zellij tab..."
-zellij action close-tab
+# Close this worker's zellij tab by its stable tab_id, captured before
+# `radio unregister` wiped the session file. If we didn't capture an id
+# (zellij not running, no role, no session file, or empty TAB_ID=), skip —
+# falling back to the unscoped `close-tab` would re-open the bug fixed
+# above (#107). The user can close the tab manually in that case.
+if [[ -n "$_WORKER_TAB_ID" ]]; then
+  echo "Closing zellij tab (id=$_WORKER_TAB_ID)..."
+  zellij action close-tab-by-id "$_WORKER_TAB_ID" >/dev/null 2>&1 || true
+else
+  echo "Skipping zellij close-tab (no tab id captured; close this tab manually if needed)."
+fi
 # endregion:confirm-and-cleanup

--- a/claude-jira/bin/radio
+++ b/claude-jira/bin/radio
@@ -140,13 +140,46 @@ _session_file() {
 _inbox_dir()    { printf '%s/%s/inbox'     "$MAILBOX_DIR" "$1"; }
 _processed_dir(){ printf '%s/%s/processed' "$MAILBOX_DIR" "$1"; }
 
+# Self-healing: write a session file for $TASK_FORCE_ROLE if one is missing,
+# using the identity env vars task-work / task-pm injected at tab launch
+# (#107 follow-up). The session file is treated as a soft cache, not a lock —
+# Claude Code's SessionEnd hook fires on intra-session events (`/clear`,
+# `/compact`, resume) as well as real exit, so a spurious unregister mid-life
+# would otherwise brick all subsequent busy/ready/send operations for the
+# role. Returns 1 (without writing anything) if there's no identity env to
+# rebuild from, so non-task-force `claude` sessions stay no-ops.
+_ensure_session_file() {
+  _require_role
+  local f
+  f=$(_session_file "$TASK_FORCE_ROLE")
+  [[ -f "$f" ]] && return 0
+
+  [[ -n "${ZELLIJ_TAB:-}" ]] || { _log "ensure_session: \$ZELLIJ_TAB unset; cannot re-seed $TASK_FORCE_ROLE"; return 1; }
+
+  local tab_id=""
+  if [[ -n "${ZELLIJ:-}" ]] && command -v zellij >/dev/null 2>&1; then
+    tab_id=$(_zellij_tab_id_by_name "$ZELLIJ_TAB" || true)
+  fi
+
+  local repo
+  repo=$(git rev-parse --show-toplevel 2>/dev/null || echo "")
+
+  printf 'ROLE=%s\nTAB=%s\nTAB_ID=%s\nREPO=%s\nSTATE=idle\nLAST_HEARTBEAT=%s\nAGENT=%s\nLOADOUT=%s\n' \
+    "$TASK_FORCE_ROLE" "$ZELLIJ_TAB" "$tab_id" "$repo" "$(_now)" \
+    "${TASK_FORCE_AGENT:-claude}" "${TASK_FORCE_LOADOUT:-unknown}" \
+    | _atomic_write "$f"
+
+  mkdir -p "$(_inbox_dir "$TASK_FORCE_ROLE")" "$(_processed_dir "$TASK_FORCE_ROLE")"
+  _log "ensure_session: re-seeded $TASK_FORCE_ROLE (file was missing) tab_id=$tab_id"
+}
+
 # Update STATE=… and LAST_HEARTBEAT=… on the current session file.
 _update_state() {
   local new_state="$1"
   _require_role
+  _ensure_session_file || { _log "update_state: no identity env for $TASK_FORCE_ROLE"; return 0; }
   local f
   f=$(_session_file "$TASK_FORCE_ROLE")
-  [[ -f "$f" ]] || { _log "update_state: no session file for $TASK_FORCE_ROLE"; return 0; }
 
   # Re-emit the file with STATE/LAST_HEARTBEAT replaced; preserve everything else.
   awk -v st="$new_state" -v hb="$(_now)" '
@@ -281,6 +314,34 @@ cmd_register() {
 cmd_unregister() {
   _silent_exit_if_no_role
   _require_role
+
+  # When invoked from Claude Code's SessionEnd hook, a JSON payload is piped
+  # on stdin with a `reason` field. The hook fires on intra-session events
+  # (reason=clear from `/clear`, reason=resume from `/compact` and session
+  # resume) as well as on real exit (reason=logout|prompt_input_exit|other).
+  # Without filtering we wipe the session file mid-life — empirically observed
+  # as bursts of 40+ unregister calls within ~25s, with busy/ready calls
+  # immediately afterwards logging "no session file" against the now-missing
+  # file (#107 review).
+  #
+  # Manual invocations (e.g. from task-done, or a user typing `radio
+  # unregister` in a shell) don't pipe a JSON payload — proceed unconditionally
+  # in that case. We only filter when both (a) stdin is not a terminal and
+  # (b) a parseable `reason` is present.
+  if [[ ! -t 0 ]]; then
+    local payload reason
+    payload=$(cat 2>/dev/null || true)
+    if [[ -n "$payload" ]] && command -v jq >/dev/null 2>&1; then
+      reason=$(printf '%s' "$payload" | jq -r '.reason // empty' 2>/dev/null || true)
+      case "$reason" in
+        clear|resume)
+          _log "unregister: skipping (reason=$reason — intra-session event) role=$TASK_FORCE_ROLE"
+          return 0
+          ;;
+      esac
+    fi
+  fi
+
   local f
   f=$(_session_file "$TASK_FORCE_ROLE")
   rm -f "$f"

--- a/claude-jira/bin/task-done
+++ b/claude-jira/bin/task-done
@@ -103,6 +103,21 @@ if [[ "$FORCE" != true && "$REMOVE_ONLY" != true ]]; then
   [[ "$confirm" != "y" && "$confirm" != "Y" ]] && exit 0
 fi
 
+# Capture this worker's stable zellij tab_id BEFORE `radio unregister`
+# removes the session file. We use it at the end of cleanup to close
+# *this* worker's tab specifically (`close-tab-by-id`), not the focused
+# one. The unscoped `zellij action close-tab` targets whichever tab is
+# focused at call time — same focused-tab bug class as #102/#103 in a
+# different binary; if the user switches focus mid-cleanup, the wrong tab
+# (e.g., PM's) gets closed and an active session can be destroyed (#107).
+_WORKER_TAB_ID=""
+if [[ -n "${ZELLIJ:-}" && -n "${TASK_FORCE_ROLE:-}" ]]; then
+  _SESSION_FILE="${TASK_FORCE_HOME:-$HOME/.task-force}/radio/sessions/${TASK_FORCE_ROLE}.info"
+  if [[ -f "$_SESSION_FILE" ]]; then
+    _WORKER_TAB_ID=$(awk -F= '/^TAB_ID=/ { print $2; exit }' "$_SESSION_FILE")
+  fi
+fi
+
 # Unregister radio session before tearing down the worktree (#94). The
 # `|| true` is a safety net: $TASK_FORCE_ROLE should be set inside a worker
 # tab, but if it isn't (e.g., task-done invoked from an unexpected shell)
@@ -134,7 +149,15 @@ else
   echo "Done. Branch '$BRANCH' still has unmerged commits — delete manually after PR merge: git branch -D $BRANCH"
 fi
 
-# Close current zellij tab
-echo "Closing zellij tab..."
-zellij action close-tab
+# Close this worker's zellij tab by its stable tab_id, captured before
+# `radio unregister` wiped the session file. If we didn't capture an id
+# (zellij not running, no role, no session file, or empty TAB_ID=), skip —
+# falling back to the unscoped `close-tab` would re-open the bug fixed
+# above (#107). The user can close the tab manually in that case.
+if [[ -n "$_WORKER_TAB_ID" ]]; then
+  echo "Closing zellij tab (id=$_WORKER_TAB_ID)..."
+  zellij action close-tab-by-id "$_WORKER_TAB_ID" >/dev/null 2>&1 || true
+else
+  echo "Skipping zellij close-tab (no tab id captured; close this tab manually if needed)."
+fi
 # endregion:confirm-and-cleanup

--- a/claude-local/bin/radio
+++ b/claude-local/bin/radio
@@ -140,13 +140,46 @@ _session_file() {
 _inbox_dir()    { printf '%s/%s/inbox'     "$MAILBOX_DIR" "$1"; }
 _processed_dir(){ printf '%s/%s/processed' "$MAILBOX_DIR" "$1"; }
 
+# Self-healing: write a session file for $TASK_FORCE_ROLE if one is missing,
+# using the identity env vars task-work / task-pm injected at tab launch
+# (#107 follow-up). The session file is treated as a soft cache, not a lock —
+# Claude Code's SessionEnd hook fires on intra-session events (`/clear`,
+# `/compact`, resume) as well as real exit, so a spurious unregister mid-life
+# would otherwise brick all subsequent busy/ready/send operations for the
+# role. Returns 1 (without writing anything) if there's no identity env to
+# rebuild from, so non-task-force `claude` sessions stay no-ops.
+_ensure_session_file() {
+  _require_role
+  local f
+  f=$(_session_file "$TASK_FORCE_ROLE")
+  [[ -f "$f" ]] && return 0
+
+  [[ -n "${ZELLIJ_TAB:-}" ]] || { _log "ensure_session: \$ZELLIJ_TAB unset; cannot re-seed $TASK_FORCE_ROLE"; return 1; }
+
+  local tab_id=""
+  if [[ -n "${ZELLIJ:-}" ]] && command -v zellij >/dev/null 2>&1; then
+    tab_id=$(_zellij_tab_id_by_name "$ZELLIJ_TAB" || true)
+  fi
+
+  local repo
+  repo=$(git rev-parse --show-toplevel 2>/dev/null || echo "")
+
+  printf 'ROLE=%s\nTAB=%s\nTAB_ID=%s\nREPO=%s\nSTATE=idle\nLAST_HEARTBEAT=%s\nAGENT=%s\nLOADOUT=%s\n' \
+    "$TASK_FORCE_ROLE" "$ZELLIJ_TAB" "$tab_id" "$repo" "$(_now)" \
+    "${TASK_FORCE_AGENT:-claude}" "${TASK_FORCE_LOADOUT:-unknown}" \
+    | _atomic_write "$f"
+
+  mkdir -p "$(_inbox_dir "$TASK_FORCE_ROLE")" "$(_processed_dir "$TASK_FORCE_ROLE")"
+  _log "ensure_session: re-seeded $TASK_FORCE_ROLE (file was missing) tab_id=$tab_id"
+}
+
 # Update STATE=… and LAST_HEARTBEAT=… on the current session file.
 _update_state() {
   local new_state="$1"
   _require_role
+  _ensure_session_file || { _log "update_state: no identity env for $TASK_FORCE_ROLE"; return 0; }
   local f
   f=$(_session_file "$TASK_FORCE_ROLE")
-  [[ -f "$f" ]] || { _log "update_state: no session file for $TASK_FORCE_ROLE"; return 0; }
 
   # Re-emit the file with STATE/LAST_HEARTBEAT replaced; preserve everything else.
   awk -v st="$new_state" -v hb="$(_now)" '
@@ -281,6 +314,34 @@ cmd_register() {
 cmd_unregister() {
   _silent_exit_if_no_role
   _require_role
+
+  # When invoked from Claude Code's SessionEnd hook, a JSON payload is piped
+  # on stdin with a `reason` field. The hook fires on intra-session events
+  # (reason=clear from `/clear`, reason=resume from `/compact` and session
+  # resume) as well as on real exit (reason=logout|prompt_input_exit|other).
+  # Without filtering we wipe the session file mid-life — empirically observed
+  # as bursts of 40+ unregister calls within ~25s, with busy/ready calls
+  # immediately afterwards logging "no session file" against the now-missing
+  # file (#107 review).
+  #
+  # Manual invocations (e.g. from task-done, or a user typing `radio
+  # unregister` in a shell) don't pipe a JSON payload — proceed unconditionally
+  # in that case. We only filter when both (a) stdin is not a terminal and
+  # (b) a parseable `reason` is present.
+  if [[ ! -t 0 ]]; then
+    local payload reason
+    payload=$(cat 2>/dev/null || true)
+    if [[ -n "$payload" ]] && command -v jq >/dev/null 2>&1; then
+      reason=$(printf '%s' "$payload" | jq -r '.reason // empty' 2>/dev/null || true)
+      case "$reason" in
+        clear|resume)
+          _log "unregister: skipping (reason=$reason — intra-session event) role=$TASK_FORCE_ROLE"
+          return 0
+          ;;
+      esac
+    fi
+  fi
+
   local f
   f=$(_session_file "$TASK_FORCE_ROLE")
   rm -f "$f"

--- a/claude-local/bin/task-done
+++ b/claude-local/bin/task-done
@@ -99,6 +99,21 @@ if [[ "$FORCE" != true && "$REMOVE_ONLY" != true ]]; then
   [[ "$confirm" != "y" && "$confirm" != "Y" ]] && exit 0
 fi
 
+# Capture this worker's stable zellij tab_id BEFORE `radio unregister`
+# removes the session file. We use it at the end of cleanup to close
+# *this* worker's tab specifically (`close-tab-by-id`), not the focused
+# one. The unscoped `zellij action close-tab` targets whichever tab is
+# focused at call time — same focused-tab bug class as #102/#103 in a
+# different binary; if the user switches focus mid-cleanup, the wrong tab
+# (e.g., PM's) gets closed and an active session can be destroyed (#107).
+_WORKER_TAB_ID=""
+if [[ -n "${ZELLIJ:-}" && -n "${TASK_FORCE_ROLE:-}" ]]; then
+  _SESSION_FILE="${TASK_FORCE_HOME:-$HOME/.task-force}/radio/sessions/${TASK_FORCE_ROLE}.info"
+  if [[ -f "$_SESSION_FILE" ]]; then
+    _WORKER_TAB_ID=$(awk -F= '/^TAB_ID=/ { print $2; exit }' "$_SESSION_FILE")
+  fi
+fi
+
 # Unregister radio session before tearing down the worktree (#94). The
 # `|| true` is a safety net: $TASK_FORCE_ROLE should be set inside a worker
 # tab, but if it isn't (e.g., task-done invoked from an unexpected shell)
@@ -148,7 +163,15 @@ else
   echo "Done. Branch '$BRANCH' still has unmerged commits — delete manually after PR merge: git branch -D $BRANCH"
 fi
 
-# Close current zellij tab
-echo "Closing zellij tab..."
-zellij action close-tab
+# Close this worker's zellij tab by its stable tab_id, captured before
+# `radio unregister` wiped the session file. If we didn't capture an id
+# (zellij not running, no role, no session file, or empty TAB_ID=), skip —
+# falling back to the unscoped `close-tab` would re-open the bug fixed
+# above (#107). The user can close the tab manually in that case.
+if [[ -n "$_WORKER_TAB_ID" ]]; then
+  echo "Closing zellij tab (id=$_WORKER_TAB_ID)..."
+  zellij action close-tab-by-id "$_WORKER_TAB_ID" >/dev/null 2>&1 || true
+else
+  echo "Skipping zellij close-tab (no tab id captured; close this tab manually if needed)."
+fi
 # endregion:confirm-and-cleanup

--- a/claude-notion/bin/radio
+++ b/claude-notion/bin/radio
@@ -140,13 +140,46 @@ _session_file() {
 _inbox_dir()    { printf '%s/%s/inbox'     "$MAILBOX_DIR" "$1"; }
 _processed_dir(){ printf '%s/%s/processed' "$MAILBOX_DIR" "$1"; }
 
+# Self-healing: write a session file for $TASK_FORCE_ROLE if one is missing,
+# using the identity env vars task-work / task-pm injected at tab launch
+# (#107 follow-up). The session file is treated as a soft cache, not a lock —
+# Claude Code's SessionEnd hook fires on intra-session events (`/clear`,
+# `/compact`, resume) as well as real exit, so a spurious unregister mid-life
+# would otherwise brick all subsequent busy/ready/send operations for the
+# role. Returns 1 (without writing anything) if there's no identity env to
+# rebuild from, so non-task-force `claude` sessions stay no-ops.
+_ensure_session_file() {
+  _require_role
+  local f
+  f=$(_session_file "$TASK_FORCE_ROLE")
+  [[ -f "$f" ]] && return 0
+
+  [[ -n "${ZELLIJ_TAB:-}" ]] || { _log "ensure_session: \$ZELLIJ_TAB unset; cannot re-seed $TASK_FORCE_ROLE"; return 1; }
+
+  local tab_id=""
+  if [[ -n "${ZELLIJ:-}" ]] && command -v zellij >/dev/null 2>&1; then
+    tab_id=$(_zellij_tab_id_by_name "$ZELLIJ_TAB" || true)
+  fi
+
+  local repo
+  repo=$(git rev-parse --show-toplevel 2>/dev/null || echo "")
+
+  printf 'ROLE=%s\nTAB=%s\nTAB_ID=%s\nREPO=%s\nSTATE=idle\nLAST_HEARTBEAT=%s\nAGENT=%s\nLOADOUT=%s\n' \
+    "$TASK_FORCE_ROLE" "$ZELLIJ_TAB" "$tab_id" "$repo" "$(_now)" \
+    "${TASK_FORCE_AGENT:-claude}" "${TASK_FORCE_LOADOUT:-unknown}" \
+    | _atomic_write "$f"
+
+  mkdir -p "$(_inbox_dir "$TASK_FORCE_ROLE")" "$(_processed_dir "$TASK_FORCE_ROLE")"
+  _log "ensure_session: re-seeded $TASK_FORCE_ROLE (file was missing) tab_id=$tab_id"
+}
+
 # Update STATE=… and LAST_HEARTBEAT=… on the current session file.
 _update_state() {
   local new_state="$1"
   _require_role
+  _ensure_session_file || { _log "update_state: no identity env for $TASK_FORCE_ROLE"; return 0; }
   local f
   f=$(_session_file "$TASK_FORCE_ROLE")
-  [[ -f "$f" ]] || { _log "update_state: no session file for $TASK_FORCE_ROLE"; return 0; }
 
   # Re-emit the file with STATE/LAST_HEARTBEAT replaced; preserve everything else.
   awk -v st="$new_state" -v hb="$(_now)" '
@@ -281,6 +314,34 @@ cmd_register() {
 cmd_unregister() {
   _silent_exit_if_no_role
   _require_role
+
+  # When invoked from Claude Code's SessionEnd hook, a JSON payload is piped
+  # on stdin with a `reason` field. The hook fires on intra-session events
+  # (reason=clear from `/clear`, reason=resume from `/compact` and session
+  # resume) as well as on real exit (reason=logout|prompt_input_exit|other).
+  # Without filtering we wipe the session file mid-life — empirically observed
+  # as bursts of 40+ unregister calls within ~25s, with busy/ready calls
+  # immediately afterwards logging "no session file" against the now-missing
+  # file (#107 review).
+  #
+  # Manual invocations (e.g. from task-done, or a user typing `radio
+  # unregister` in a shell) don't pipe a JSON payload — proceed unconditionally
+  # in that case. We only filter when both (a) stdin is not a terminal and
+  # (b) a parseable `reason` is present.
+  if [[ ! -t 0 ]]; then
+    local payload reason
+    payload=$(cat 2>/dev/null || true)
+    if [[ -n "$payload" ]] && command -v jq >/dev/null 2>&1; then
+      reason=$(printf '%s' "$payload" | jq -r '.reason // empty' 2>/dev/null || true)
+      case "$reason" in
+        clear|resume)
+          _log "unregister: skipping (reason=$reason — intra-session event) role=$TASK_FORCE_ROLE"
+          return 0
+          ;;
+      esac
+    fi
+  fi
+
   local f
   f=$(_session_file "$TASK_FORCE_ROLE")
   rm -f "$f"

--- a/claude-notion/bin/task-done
+++ b/claude-notion/bin/task-done
@@ -97,6 +97,21 @@ if [[ "$FORCE" != true && "$REMOVE_ONLY" != true ]]; then
   [[ "$confirm" != "y" && "$confirm" != "Y" ]] && exit 0
 fi
 
+# Capture this worker's stable zellij tab_id BEFORE `radio unregister`
+# removes the session file. We use it at the end of cleanup to close
+# *this* worker's tab specifically (`close-tab-by-id`), not the focused
+# one. The unscoped `zellij action close-tab` targets whichever tab is
+# focused at call time — same focused-tab bug class as #102/#103 in a
+# different binary; if the user switches focus mid-cleanup, the wrong tab
+# (e.g., PM's) gets closed and an active session can be destroyed (#107).
+_WORKER_TAB_ID=""
+if [[ -n "${ZELLIJ:-}" && -n "${TASK_FORCE_ROLE:-}" ]]; then
+  _SESSION_FILE="${TASK_FORCE_HOME:-$HOME/.task-force}/radio/sessions/${TASK_FORCE_ROLE}.info"
+  if [[ -f "$_SESSION_FILE" ]]; then
+    _WORKER_TAB_ID=$(awk -F= '/^TAB_ID=/ { print $2; exit }' "$_SESSION_FILE")
+  fi
+fi
+
 # Unregister radio session before tearing down the worktree (#94). The
 # `|| true` is a safety net: $TASK_FORCE_ROLE should be set inside a worker
 # tab, but if it isn't (e.g., task-done invoked from an unexpected shell)
@@ -128,7 +143,15 @@ else
   echo "Done. Branch '$BRANCH' still has unmerged commits — delete manually after PR merge: git branch -D $BRANCH"
 fi
 
-# Close current zellij tab
-echo "Closing zellij tab..."
-zellij action close-tab
+# Close this worker's zellij tab by its stable tab_id, captured before
+# `radio unregister` wiped the session file. If we didn't capture an id
+# (zellij not running, no role, no session file, or empty TAB_ID=), skip —
+# falling back to the unscoped `close-tab` would re-open the bug fixed
+# above (#107). The user can close the tab manually in that case.
+if [[ -n "$_WORKER_TAB_ID" ]]; then
+  echo "Closing zellij tab (id=$_WORKER_TAB_ID)..."
+  zellij action close-tab-by-id "$_WORKER_TAB_ID" >/dev/null 2>&1 || true
+else
+  echo "Skipping zellij close-tab (no tab id captured; close this tab manually if needed)."
+fi
 # endregion:confirm-and-cleanup

--- a/kiro-gh/bin/radio
+++ b/kiro-gh/bin/radio
@@ -140,13 +140,46 @@ _session_file() {
 _inbox_dir()    { printf '%s/%s/inbox'     "$MAILBOX_DIR" "$1"; }
 _processed_dir(){ printf '%s/%s/processed' "$MAILBOX_DIR" "$1"; }
 
+# Self-healing: write a session file for $TASK_FORCE_ROLE if one is missing,
+# using the identity env vars task-work / task-pm injected at tab launch
+# (#107 follow-up). The session file is treated as a soft cache, not a lock —
+# Claude Code's SessionEnd hook fires on intra-session events (`/clear`,
+# `/compact`, resume) as well as real exit, so a spurious unregister mid-life
+# would otherwise brick all subsequent busy/ready/send operations for the
+# role. Returns 1 (without writing anything) if there's no identity env to
+# rebuild from, so non-task-force `claude` sessions stay no-ops.
+_ensure_session_file() {
+  _require_role
+  local f
+  f=$(_session_file "$TASK_FORCE_ROLE")
+  [[ -f "$f" ]] && return 0
+
+  [[ -n "${ZELLIJ_TAB:-}" ]] || { _log "ensure_session: \$ZELLIJ_TAB unset; cannot re-seed $TASK_FORCE_ROLE"; return 1; }
+
+  local tab_id=""
+  if [[ -n "${ZELLIJ:-}" ]] && command -v zellij >/dev/null 2>&1; then
+    tab_id=$(_zellij_tab_id_by_name "$ZELLIJ_TAB" || true)
+  fi
+
+  local repo
+  repo=$(git rev-parse --show-toplevel 2>/dev/null || echo "")
+
+  printf 'ROLE=%s\nTAB=%s\nTAB_ID=%s\nREPO=%s\nSTATE=idle\nLAST_HEARTBEAT=%s\nAGENT=%s\nLOADOUT=%s\n' \
+    "$TASK_FORCE_ROLE" "$ZELLIJ_TAB" "$tab_id" "$repo" "$(_now)" \
+    "${TASK_FORCE_AGENT:-claude}" "${TASK_FORCE_LOADOUT:-unknown}" \
+    | _atomic_write "$f"
+
+  mkdir -p "$(_inbox_dir "$TASK_FORCE_ROLE")" "$(_processed_dir "$TASK_FORCE_ROLE")"
+  _log "ensure_session: re-seeded $TASK_FORCE_ROLE (file was missing) tab_id=$tab_id"
+}
+
 # Update STATE=… and LAST_HEARTBEAT=… on the current session file.
 _update_state() {
   local new_state="$1"
   _require_role
+  _ensure_session_file || { _log "update_state: no identity env for $TASK_FORCE_ROLE"; return 0; }
   local f
   f=$(_session_file "$TASK_FORCE_ROLE")
-  [[ -f "$f" ]] || { _log "update_state: no session file for $TASK_FORCE_ROLE"; return 0; }
 
   # Re-emit the file with STATE/LAST_HEARTBEAT replaced; preserve everything else.
   awk -v st="$new_state" -v hb="$(_now)" '
@@ -281,6 +314,34 @@ cmd_register() {
 cmd_unregister() {
   _silent_exit_if_no_role
   _require_role
+
+  # When invoked from Claude Code's SessionEnd hook, a JSON payload is piped
+  # on stdin with a `reason` field. The hook fires on intra-session events
+  # (reason=clear from `/clear`, reason=resume from `/compact` and session
+  # resume) as well as on real exit (reason=logout|prompt_input_exit|other).
+  # Without filtering we wipe the session file mid-life — empirically observed
+  # as bursts of 40+ unregister calls within ~25s, with busy/ready calls
+  # immediately afterwards logging "no session file" against the now-missing
+  # file (#107 review).
+  #
+  # Manual invocations (e.g. from task-done, or a user typing `radio
+  # unregister` in a shell) don't pipe a JSON payload — proceed unconditionally
+  # in that case. We only filter when both (a) stdin is not a terminal and
+  # (b) a parseable `reason` is present.
+  if [[ ! -t 0 ]]; then
+    local payload reason
+    payload=$(cat 2>/dev/null || true)
+    if [[ -n "$payload" ]] && command -v jq >/dev/null 2>&1; then
+      reason=$(printf '%s' "$payload" | jq -r '.reason // empty' 2>/dev/null || true)
+      case "$reason" in
+        clear|resume)
+          _log "unregister: skipping (reason=$reason — intra-session event) role=$TASK_FORCE_ROLE"
+          return 0
+          ;;
+      esac
+    fi
+  fi
+
   local f
   f=$(_session_file "$TASK_FORCE_ROLE")
   rm -f "$f"

--- a/kiro-gh/bin/task-done
+++ b/kiro-gh/bin/task-done
@@ -97,6 +97,21 @@ if [[ "$FORCE" != true && "$REMOVE_ONLY" != true ]]; then
   [[ "$confirm" != "y" && "$confirm" != "Y" ]] && exit 0
 fi
 
+# Capture this worker's stable zellij tab_id BEFORE `radio unregister`
+# removes the session file. We use it at the end of cleanup to close
+# *this* worker's tab specifically (`close-tab-by-id`), not the focused
+# one. The unscoped `zellij action close-tab` targets whichever tab is
+# focused at call time — same focused-tab bug class as #102/#103 in a
+# different binary; if the user switches focus mid-cleanup, the wrong tab
+# (e.g., PM's) gets closed and an active session can be destroyed (#107).
+_WORKER_TAB_ID=""
+if [[ -n "${ZELLIJ:-}" && -n "${TASK_FORCE_ROLE:-}" ]]; then
+  _SESSION_FILE="${TASK_FORCE_HOME:-$HOME/.task-force}/radio/sessions/${TASK_FORCE_ROLE}.info"
+  if [[ -f "$_SESSION_FILE" ]]; then
+    _WORKER_TAB_ID=$(awk -F= '/^TAB_ID=/ { print $2; exit }' "$_SESSION_FILE")
+  fi
+fi
+
 # Unregister radio session before tearing down the worktree (#94). The
 # `|| true` is a safety net: $TASK_FORCE_ROLE should be set inside a worker
 # tab, but if it isn't (e.g., task-done invoked from an unexpected shell)
@@ -128,7 +143,15 @@ else
   echo "Done. Branch '$BRANCH' still has unmerged commits — delete manually after PR merge: git branch -D $BRANCH"
 fi
 
-# Close current zellij tab
-echo "Closing zellij tab..."
-zellij action close-tab
+# Close this worker's zellij tab by its stable tab_id, captured before
+# `radio unregister` wiped the session file. If we didn't capture an id
+# (zellij not running, no role, no session file, or empty TAB_ID=), skip —
+# falling back to the unscoped `close-tab` would re-open the bug fixed
+# above (#107). The user can close the tab manually in that case.
+if [[ -n "$_WORKER_TAB_ID" ]]; then
+  echo "Closing zellij tab (id=$_WORKER_TAB_ID)..."
+  zellij action close-tab-by-id "$_WORKER_TAB_ID" >/dev/null 2>&1 || true
+else
+  echo "Skipping zellij close-tab (no tab id captured; close this tab manually if needed)."
+fi
 # endregion:confirm-and-cleanup

--- a/kiro-local/bin/radio
+++ b/kiro-local/bin/radio
@@ -140,13 +140,46 @@ _session_file() {
 _inbox_dir()    { printf '%s/%s/inbox'     "$MAILBOX_DIR" "$1"; }
 _processed_dir(){ printf '%s/%s/processed' "$MAILBOX_DIR" "$1"; }
 
+# Self-healing: write a session file for $TASK_FORCE_ROLE if one is missing,
+# using the identity env vars task-work / task-pm injected at tab launch
+# (#107 follow-up). The session file is treated as a soft cache, not a lock —
+# Claude Code's SessionEnd hook fires on intra-session events (`/clear`,
+# `/compact`, resume) as well as real exit, so a spurious unregister mid-life
+# would otherwise brick all subsequent busy/ready/send operations for the
+# role. Returns 1 (without writing anything) if there's no identity env to
+# rebuild from, so non-task-force `claude` sessions stay no-ops.
+_ensure_session_file() {
+  _require_role
+  local f
+  f=$(_session_file "$TASK_FORCE_ROLE")
+  [[ -f "$f" ]] && return 0
+
+  [[ -n "${ZELLIJ_TAB:-}" ]] || { _log "ensure_session: \$ZELLIJ_TAB unset; cannot re-seed $TASK_FORCE_ROLE"; return 1; }
+
+  local tab_id=""
+  if [[ -n "${ZELLIJ:-}" ]] && command -v zellij >/dev/null 2>&1; then
+    tab_id=$(_zellij_tab_id_by_name "$ZELLIJ_TAB" || true)
+  fi
+
+  local repo
+  repo=$(git rev-parse --show-toplevel 2>/dev/null || echo "")
+
+  printf 'ROLE=%s\nTAB=%s\nTAB_ID=%s\nREPO=%s\nSTATE=idle\nLAST_HEARTBEAT=%s\nAGENT=%s\nLOADOUT=%s\n' \
+    "$TASK_FORCE_ROLE" "$ZELLIJ_TAB" "$tab_id" "$repo" "$(_now)" \
+    "${TASK_FORCE_AGENT:-claude}" "${TASK_FORCE_LOADOUT:-unknown}" \
+    | _atomic_write "$f"
+
+  mkdir -p "$(_inbox_dir "$TASK_FORCE_ROLE")" "$(_processed_dir "$TASK_FORCE_ROLE")"
+  _log "ensure_session: re-seeded $TASK_FORCE_ROLE (file was missing) tab_id=$tab_id"
+}
+
 # Update STATE=… and LAST_HEARTBEAT=… on the current session file.
 _update_state() {
   local new_state="$1"
   _require_role
+  _ensure_session_file || { _log "update_state: no identity env for $TASK_FORCE_ROLE"; return 0; }
   local f
   f=$(_session_file "$TASK_FORCE_ROLE")
-  [[ -f "$f" ]] || { _log "update_state: no session file for $TASK_FORCE_ROLE"; return 0; }
 
   # Re-emit the file with STATE/LAST_HEARTBEAT replaced; preserve everything else.
   awk -v st="$new_state" -v hb="$(_now)" '
@@ -281,6 +314,34 @@ cmd_register() {
 cmd_unregister() {
   _silent_exit_if_no_role
   _require_role
+
+  # When invoked from Claude Code's SessionEnd hook, a JSON payload is piped
+  # on stdin with a `reason` field. The hook fires on intra-session events
+  # (reason=clear from `/clear`, reason=resume from `/compact` and session
+  # resume) as well as on real exit (reason=logout|prompt_input_exit|other).
+  # Without filtering we wipe the session file mid-life — empirically observed
+  # as bursts of 40+ unregister calls within ~25s, with busy/ready calls
+  # immediately afterwards logging "no session file" against the now-missing
+  # file (#107 review).
+  #
+  # Manual invocations (e.g. from task-done, or a user typing `radio
+  # unregister` in a shell) don't pipe a JSON payload — proceed unconditionally
+  # in that case. We only filter when both (a) stdin is not a terminal and
+  # (b) a parseable `reason` is present.
+  if [[ ! -t 0 ]]; then
+    local payload reason
+    payload=$(cat 2>/dev/null || true)
+    if [[ -n "$payload" ]] && command -v jq >/dev/null 2>&1; then
+      reason=$(printf '%s' "$payload" | jq -r '.reason // empty' 2>/dev/null || true)
+      case "$reason" in
+        clear|resume)
+          _log "unregister: skipping (reason=$reason — intra-session event) role=$TASK_FORCE_ROLE"
+          return 0
+          ;;
+      esac
+    fi
+  fi
+
   local f
   f=$(_session_file "$TASK_FORCE_ROLE")
   rm -f "$f"

--- a/kiro-local/bin/task-done
+++ b/kiro-local/bin/task-done
@@ -99,6 +99,21 @@ if [[ "$FORCE" != true && "$REMOVE_ONLY" != true ]]; then
   [[ "$confirm" != "y" && "$confirm" != "Y" ]] && exit 0
 fi
 
+# Capture this worker's stable zellij tab_id BEFORE `radio unregister`
+# removes the session file. We use it at the end of cleanup to close
+# *this* worker's tab specifically (`close-tab-by-id`), not the focused
+# one. The unscoped `zellij action close-tab` targets whichever tab is
+# focused at call time — same focused-tab bug class as #102/#103 in a
+# different binary; if the user switches focus mid-cleanup, the wrong tab
+# (e.g., PM's) gets closed and an active session can be destroyed (#107).
+_WORKER_TAB_ID=""
+if [[ -n "${ZELLIJ:-}" && -n "${TASK_FORCE_ROLE:-}" ]]; then
+  _SESSION_FILE="${TASK_FORCE_HOME:-$HOME/.task-force}/radio/sessions/${TASK_FORCE_ROLE}.info"
+  if [[ -f "$_SESSION_FILE" ]]; then
+    _WORKER_TAB_ID=$(awk -F= '/^TAB_ID=/ { print $2; exit }' "$_SESSION_FILE")
+  fi
+fi
+
 # Unregister radio session before tearing down the worktree (#94). The
 # `|| true` is a safety net: $TASK_FORCE_ROLE should be set inside a worker
 # tab, but if it isn't (e.g., task-done invoked from an unexpected shell)
@@ -148,7 +163,15 @@ else
   echo "Done. Branch '$BRANCH' still has unmerged commits — delete manually after PR merge: git branch -D $BRANCH"
 fi
 
-# Close current zellij tab
-echo "Closing zellij tab..."
-zellij action close-tab
+# Close this worker's zellij tab by its stable tab_id, captured before
+# `radio unregister` wiped the session file. If we didn't capture an id
+# (zellij not running, no role, no session file, or empty TAB_ID=), skip —
+# falling back to the unscoped `close-tab` would re-open the bug fixed
+# above (#107). The user can close the tab manually in that case.
+if [[ -n "$_WORKER_TAB_ID" ]]; then
+  echo "Closing zellij tab (id=$_WORKER_TAB_ID)..."
+  zellij action close-tab-by-id "$_WORKER_TAB_ID" >/dev/null 2>&1 || true
+else
+  echo "Skipping zellij close-tab (no tab id captured; close this tab manually if needed)."
+fi
 # endregion:confirm-and-cleanup

--- a/kiro-notion/bin/radio
+++ b/kiro-notion/bin/radio
@@ -140,13 +140,46 @@ _session_file() {
 _inbox_dir()    { printf '%s/%s/inbox'     "$MAILBOX_DIR" "$1"; }
 _processed_dir(){ printf '%s/%s/processed' "$MAILBOX_DIR" "$1"; }
 
+# Self-healing: write a session file for $TASK_FORCE_ROLE if one is missing,
+# using the identity env vars task-work / task-pm injected at tab launch
+# (#107 follow-up). The session file is treated as a soft cache, not a lock —
+# Claude Code's SessionEnd hook fires on intra-session events (`/clear`,
+# `/compact`, resume) as well as real exit, so a spurious unregister mid-life
+# would otherwise brick all subsequent busy/ready/send operations for the
+# role. Returns 1 (without writing anything) if there's no identity env to
+# rebuild from, so non-task-force `claude` sessions stay no-ops.
+_ensure_session_file() {
+  _require_role
+  local f
+  f=$(_session_file "$TASK_FORCE_ROLE")
+  [[ -f "$f" ]] && return 0
+
+  [[ -n "${ZELLIJ_TAB:-}" ]] || { _log "ensure_session: \$ZELLIJ_TAB unset; cannot re-seed $TASK_FORCE_ROLE"; return 1; }
+
+  local tab_id=""
+  if [[ -n "${ZELLIJ:-}" ]] && command -v zellij >/dev/null 2>&1; then
+    tab_id=$(_zellij_tab_id_by_name "$ZELLIJ_TAB" || true)
+  fi
+
+  local repo
+  repo=$(git rev-parse --show-toplevel 2>/dev/null || echo "")
+
+  printf 'ROLE=%s\nTAB=%s\nTAB_ID=%s\nREPO=%s\nSTATE=idle\nLAST_HEARTBEAT=%s\nAGENT=%s\nLOADOUT=%s\n' \
+    "$TASK_FORCE_ROLE" "$ZELLIJ_TAB" "$tab_id" "$repo" "$(_now)" \
+    "${TASK_FORCE_AGENT:-claude}" "${TASK_FORCE_LOADOUT:-unknown}" \
+    | _atomic_write "$f"
+
+  mkdir -p "$(_inbox_dir "$TASK_FORCE_ROLE")" "$(_processed_dir "$TASK_FORCE_ROLE")"
+  _log "ensure_session: re-seeded $TASK_FORCE_ROLE (file was missing) tab_id=$tab_id"
+}
+
 # Update STATE=… and LAST_HEARTBEAT=… on the current session file.
 _update_state() {
   local new_state="$1"
   _require_role
+  _ensure_session_file || { _log "update_state: no identity env for $TASK_FORCE_ROLE"; return 0; }
   local f
   f=$(_session_file "$TASK_FORCE_ROLE")
-  [[ -f "$f" ]] || { _log "update_state: no session file for $TASK_FORCE_ROLE"; return 0; }
 
   # Re-emit the file with STATE/LAST_HEARTBEAT replaced; preserve everything else.
   awk -v st="$new_state" -v hb="$(_now)" '
@@ -281,6 +314,34 @@ cmd_register() {
 cmd_unregister() {
   _silent_exit_if_no_role
   _require_role
+
+  # When invoked from Claude Code's SessionEnd hook, a JSON payload is piped
+  # on stdin with a `reason` field. The hook fires on intra-session events
+  # (reason=clear from `/clear`, reason=resume from `/compact` and session
+  # resume) as well as on real exit (reason=logout|prompt_input_exit|other).
+  # Without filtering we wipe the session file mid-life — empirically observed
+  # as bursts of 40+ unregister calls within ~25s, with busy/ready calls
+  # immediately afterwards logging "no session file" against the now-missing
+  # file (#107 review).
+  #
+  # Manual invocations (e.g. from task-done, or a user typing `radio
+  # unregister` in a shell) don't pipe a JSON payload — proceed unconditionally
+  # in that case. We only filter when both (a) stdin is not a terminal and
+  # (b) a parseable `reason` is present.
+  if [[ ! -t 0 ]]; then
+    local payload reason
+    payload=$(cat 2>/dev/null || true)
+    if [[ -n "$payload" ]] && command -v jq >/dev/null 2>&1; then
+      reason=$(printf '%s' "$payload" | jq -r '.reason // empty' 2>/dev/null || true)
+      case "$reason" in
+        clear|resume)
+          _log "unregister: skipping (reason=$reason — intra-session event) role=$TASK_FORCE_ROLE"
+          return 0
+          ;;
+      esac
+    fi
+  fi
+
   local f
   f=$(_session_file "$TASK_FORCE_ROLE")
   rm -f "$f"

--- a/kiro-notion/bin/task-done
+++ b/kiro-notion/bin/task-done
@@ -97,6 +97,21 @@ if [[ "$FORCE" != true && "$REMOVE_ONLY" != true ]]; then
   [[ "$confirm" != "y" && "$confirm" != "Y" ]] && exit 0
 fi
 
+# Capture this worker's stable zellij tab_id BEFORE `radio unregister`
+# removes the session file. We use it at the end of cleanup to close
+# *this* worker's tab specifically (`close-tab-by-id`), not the focused
+# one. The unscoped `zellij action close-tab` targets whichever tab is
+# focused at call time — same focused-tab bug class as #102/#103 in a
+# different binary; if the user switches focus mid-cleanup, the wrong tab
+# (e.g., PM's) gets closed and an active session can be destroyed (#107).
+_WORKER_TAB_ID=""
+if [[ -n "${ZELLIJ:-}" && -n "${TASK_FORCE_ROLE:-}" ]]; then
+  _SESSION_FILE="${TASK_FORCE_HOME:-$HOME/.task-force}/radio/sessions/${TASK_FORCE_ROLE}.info"
+  if [[ -f "$_SESSION_FILE" ]]; then
+    _WORKER_TAB_ID=$(awk -F= '/^TAB_ID=/ { print $2; exit }' "$_SESSION_FILE")
+  fi
+fi
+
 # Unregister radio session before tearing down the worktree (#94). The
 # `|| true` is a safety net: $TASK_FORCE_ROLE should be set inside a worker
 # tab, but if it isn't (e.g., task-done invoked from an unexpected shell)
@@ -128,7 +143,15 @@ else
   echo "Done. Branch '$BRANCH' still has unmerged commits — delete manually after PR merge: git branch -D $BRANCH"
 fi
 
-# Close current zellij tab
-echo "Closing zellij tab..."
-zellij action close-tab
+# Close this worker's zellij tab by its stable tab_id, captured before
+# `radio unregister` wiped the session file. If we didn't capture an id
+# (zellij not running, no role, no session file, or empty TAB_ID=), skip —
+# falling back to the unscoped `close-tab` would re-open the bug fixed
+# above (#107). The user can close the tab manually in that case.
+if [[ -n "$_WORKER_TAB_ID" ]]; then
+  echo "Closing zellij tab (id=$_WORKER_TAB_ID)..."
+  zellij action close-tab-by-id "$_WORKER_TAB_ID" >/dev/null 2>&1 || true
+else
+  echo "Skipping zellij close-tab (no tab id captured; close this tab manually if needed)."
+fi
 # endregion:confirm-and-cleanup

--- a/tests/radio_lifecycle.bats
+++ b/tests/radio_lifecycle.bats
@@ -1,0 +1,205 @@
+#!/usr/bin/env bats
+# Tests for radio session lifecycle — the SessionEnd payload filter in
+# `radio unregister`, and the self-healing re-seed in busy/ready (#107
+# follow-up).
+#
+# Background: Claude Code's SessionEnd hook fires on intra-session events
+# (`/clear` → reason=clear, `/compact` and resume → reason=resume) as well
+# as real exit (reason=logout|prompt_input_exit|other). The hook command is
+# `radio unregister`, so without filtering we wipe the session file mid-
+# life — empirically observed as bursts of 40+ unregister calls in ~25s
+# (#107 expanded scope, acceptance criteria #8/#9/#10).
+
+bats_load_library bats-support
+bats_load_library bats-assert
+
+load helpers/common
+
+setup() {
+  setup_task_force_home
+  unset ZELLIJ
+  export TASK_FORCE_ROLE=test-runner
+}
+
+teardown() {
+  teardown_all
+}
+
+# ----- SessionEnd payload filter --------------------------------------------
+
+@test "unregister skips when stdin payload has reason=clear (intra-session /clear)" {
+  "$RADIO" register --role worker-foo --tab w-foo --agent claude
+  local sess="$TASK_FORCE_HOME/radio/sessions/worker-foo.info"
+  assert [ -f "$sess" ]
+  TASK_FORCE_ROLE=worker-foo run bash -c "echo '{\"reason\":\"clear\"}' | '$RADIO' unregister"
+  assert_success
+  # Session file MUST still exist.
+  assert [ -f "$sess" ]
+  run cat "$TASK_FORCE_HOME/radio/log"
+  assert_output --partial "skipping (reason=clear"
+}
+
+@test "unregister skips when stdin payload has reason=resume (/compact, session resume)" {
+  "$RADIO" register --role worker-foo --tab w-foo --agent claude
+  local sess="$TASK_FORCE_HOME/radio/sessions/worker-foo.info"
+  TASK_FORCE_ROLE=worker-foo run bash -c "echo '{\"reason\":\"resume\"}' | '$RADIO' unregister"
+  assert_success
+  assert [ -f "$sess" ]
+  run cat "$TASK_FORCE_HOME/radio/log"
+  assert_output --partial "skipping (reason=resume"
+}
+
+@test "unregister proceeds when stdin payload has reason=logout (real exit)" {
+  "$RADIO" register --role worker-foo --tab w-foo --agent claude
+  local sess="$TASK_FORCE_HOME/radio/sessions/worker-foo.info"
+  TASK_FORCE_ROLE=worker-foo run bash -c "echo '{\"reason\":\"logout\"}' | '$RADIO' unregister"
+  assert_success
+  assert [ ! -f "$sess" ]
+}
+
+@test "unregister proceeds when stdin payload has reason=prompt_input_exit (process EOF)" {
+  "$RADIO" register --role worker-foo --tab w-foo --agent claude
+  local sess="$TASK_FORCE_HOME/radio/sessions/worker-foo.info"
+  TASK_FORCE_ROLE=worker-foo run bash -c "echo '{\"reason\":\"prompt_input_exit\"}' | '$RADIO' unregister"
+  assert_success
+  assert [ ! -f "$sess" ]
+}
+
+@test "unregister proceeds when stdin payload has reason=other (catch-all real exit)" {
+  "$RADIO" register --role worker-foo --tab w-foo --agent claude
+  local sess="$TASK_FORCE_HOME/radio/sessions/worker-foo.info"
+  TASK_FORCE_ROLE=worker-foo run bash -c "echo '{\"reason\":\"other\"}' | '$RADIO' unregister"
+  assert_success
+  assert [ ! -f "$sess" ]
+}
+
+@test "unregister proceeds when stdin is empty (manual invocation from task-done)" {
+  "$RADIO" register --role worker-foo --tab w-foo --agent claude
+  local sess="$TASK_FORCE_HOME/radio/sessions/worker-foo.info"
+  # task-done calls `radio unregister 2>/dev/null || true`. Its stdin is
+  # whatever the calling shell has — typically not piped. Simulate that by
+  # closing stdin so jq sees nothing.
+  TASK_FORCE_ROLE=worker-foo run bash -c "'$RADIO' unregister < /dev/null"
+  assert_success
+  assert [ ! -f "$sess" ]
+}
+
+@test "unregister proceeds when stdin payload is not valid JSON" {
+  "$RADIO" register --role worker-foo --tab w-foo --agent claude
+  local sess="$TASK_FORCE_HOME/radio/sessions/worker-foo.info"
+  TASK_FORCE_ROLE=worker-foo run bash -c "echo 'not json' | '$RADIO' unregister"
+  assert_success
+  assert [ ! -f "$sess" ]
+}
+
+@test "unregister proceeds when payload JSON has no reason field" {
+  "$RADIO" register --role worker-foo --tab w-foo --agent claude
+  local sess="$TASK_FORCE_HOME/radio/sessions/worker-foo.info"
+  TASK_FORCE_ROLE=worker-foo run bash -c "echo '{\"other_field\":\"value\"}' | '$RADIO' unregister"
+  assert_success
+  assert [ ! -f "$sess" ]
+}
+
+# ----- register-if-missing (self-healing) -----------------------------------
+
+@test "busy re-seeds the session file from \$TASK_FORCE_ROLE + \$ZELLIJ_TAB if it was wiped" {
+  # Initial state: registered, then file is wiped (simulating an
+  # unfiltered SessionEnd that slipped past the matcher).
+  "$RADIO" register --role worker-foo --tab w-foo --agent claude --loadout claude-gh
+  local sess="$TASK_FORCE_HOME/radio/sessions/worker-foo.info"
+  rm -f "$sess"
+  assert [ ! -f "$sess" ]
+
+  TASK_FORCE_ROLE=worker-foo ZELLIJ_TAB=w-foo run "$RADIO" busy
+  assert_success
+  # File was re-seeded with the new STATE.
+  assert [ -f "$sess" ]
+  run cat "$sess"
+  assert_output --partial "ROLE=worker-foo"
+  assert_output --partial "TAB=w-foo"
+  assert_output --partial "STATE=busy"
+  run cat "$TASK_FORCE_HOME/radio/log"
+  assert_output --partial "ensure_session: re-seeded worker-foo"
+}
+
+@test "ready re-seeds the session file from env vars if it was wiped" {
+  "$RADIO" register --role worker-foo --tab w-foo --agent claude
+  local sess="$TASK_FORCE_HOME/radio/sessions/worker-foo.info"
+  rm -f "$sess"
+
+  TASK_FORCE_ROLE=worker-foo ZELLIJ_TAB=w-foo run "$RADIO" ready
+  assert_success
+  assert [ -f "$sess" ]
+  run cat "$sess"
+  assert_output --partial "STATE=idle"
+}
+
+@test "re-seed is a no-op when \$ZELLIJ_TAB is unset (no identity to rebuild from)" {
+  # Plain `claude` session with $TASK_FORCE_ROLE set but no $ZELLIJ_TAB
+  # (e.g. user typed TASK_FORCE_ROLE=foo in a shell). Nothing to rebuild
+  # from, so re-seed bails and the command exits 0 without writing.
+  local sess="$TASK_FORCE_HOME/radio/sessions/worker-foo.info"
+  assert [ ! -f "$sess" ]
+
+  TASK_FORCE_ROLE=worker-foo run env -u ZELLIJ_TAB "$RADIO" busy
+  assert_success
+  assert [ ! -f "$sess" ]
+  run cat "$TASK_FORCE_HOME/radio/log"
+  assert_output --partial "ZELLIJ_TAB unset"
+}
+
+# ----- end-to-end lifecycle scenario (#107 acceptance #10) ------------------
+
+@test "lifecycle: register → SessionEnd(reason=clear) → busy keeps session valid (#107)" {
+  # Simulates the offending event chain documented in #107:
+  #   1. Worker registers at SessionStart.
+  #   2. User runs /clear → Claude fires SessionEnd with reason=clear → our
+  #      unregister hook receives a JSON payload and skips (filter).
+  #   3. User submits a prompt → UserPromptSubmit fires `radio busy`.
+  #      Even if the filter had failed, _ensure_session_file would re-seed.
+  # Outcome: session file remains intact end-to-end, with TAB_ID populated
+  # (when zellij is reachable).
+  "$RADIO" register --role worker-foo --tab w-foo --agent claude
+  local sess="$TASK_FORCE_HOME/radio/sessions/worker-foo.info"
+  assert [ -f "$sess" ]
+
+  # SessionEnd hook with reason=clear → filter must skip.
+  TASK_FORCE_ROLE=worker-foo run bash -c "echo '{\"reason\":\"clear\"}' | '$RADIO' unregister"
+  assert_success
+  assert [ -f "$sess" ]
+
+  # UserPromptSubmit → busy.
+  TASK_FORCE_ROLE=worker-foo ZELLIJ_TAB=w-foo run "$RADIO" busy
+  assert_success
+  assert [ -f "$sess" ]
+
+  # Stop hook → ready.
+  TASK_FORCE_ROLE=worker-foo ZELLIJ_TAB=w-foo run "$RADIO" ready
+  assert_success
+  assert [ -f "$sess" ]
+  run cat "$sess"
+  assert_output --partial "ROLE=worker-foo"
+  assert_output --partial "STATE=idle"
+}
+
+@test "lifecycle: re-seed after spurious wipe restores TAB_ID when zellij is reachable" {
+  setup_stubs
+  seed_zellij_tabs worker-foo
+  export ZELLIJ=fake
+
+  "$RADIO" register --role worker-foo --tab worker-foo --agent claude
+  local sess="$TASK_FORCE_HOME/radio/sessions/worker-foo.info"
+  run grep "^TAB_ID=" "$sess"
+  assert_output --partial "TAB_ID=7"
+
+  # Simulate a spurious wipe (e.g. the matcher slipped, or an old radio
+  # without the stdin filter was deployed mid-session).
+  rm -f "$sess"
+
+  TASK_FORCE_ROLE=worker-foo ZELLIJ_TAB=worker-foo run "$RADIO" busy
+  assert_success
+  assert [ -f "$sess" ]
+  run grep "^TAB_ID=" "$sess"
+  # Same tab id as the original register call — re-seed re-resolved by name.
+  assert_output --partial "TAB_ID=7"
+}

--- a/tests/task_done.bats
+++ b/tests/task_done.bats
@@ -174,9 +174,14 @@ teardown() {
   assert [ ! -f "$WORKTREE_BASE/.$SLUG.info" ]
 }
 
-@test "kiro: closes zellij tab" {
+@test "kiro: skips zellij close-tab when no radio session (no \$ZELLIJ env)" {
+  # Without ZELLIJ + a session file with TAB_ID=, task-done now skips the
+  # close-tab call entirely rather than falling back to the focused-tab
+  # `close-tab` (#107). See task_done_close_tab.bats for the close path.
   run_task_done "$KIRO_TASK_DONE" --force
-  assert_stub_called zellij "close-tab"
+  assert_output --partial "Skipping zellij close-tab"
+  run stub_calls zellij
+  refute_output --partial "close-tab"
 }
 
 @test "kiro: no prompt when --force is set" {
@@ -272,9 +277,11 @@ teardown() {
   assert [ ! -f "$WORKTREE_BASE/.$SLUG.info" ]
 }
 
-@test "claude-notion: closes zellij tab" {
+@test "claude-notion: skips zellij close-tab when no radio session (no \$ZELLIJ env)" {
   run_task_done "$CLAUDE_NOTION_TASK_DONE" --force
-  assert_stub_called zellij "close-tab"
+  assert_output --partial "Skipping zellij close-tab"
+  run stub_calls zellij
+  refute_output --partial "close-tab"
 }
 
 @test "claude-notion: no prompt when --force is set" {

--- a/tests/task_done_close_tab.bats
+++ b/tests/task_done_close_tab.bats
@@ -1,0 +1,161 @@
+#!/usr/bin/env bats
+# Tests for task-done's close-tab step (#107).
+#
+# Background: task-done used to end with the unscoped `zellij action close-tab`,
+# which targets the *focused* tab. If the user switched focus to a different
+# tab (e.g. PM) while cleanup was running, the wrong tab got closed —
+# destroying an active session. This is the same focused-tab bug class we
+# fixed for `radio` in #102/#103, in a separate binary.
+#
+# The fix is to drive close-tab by the worker's stable zellij tab_id, which
+# `radio register` already persists into the session file as TAB_ID= (#103).
+# task-done captures TAB_ID *before* `radio unregister` wipes the session
+# file, then uses `zellij action close-tab-by-id <id>` at the end.
+#
+# All four acceptance scenarios from the spec are covered below against
+# claude-gh/bin/task-done. Drift check (tools/check-drift.sh) keeps the
+# other 6 loadouts byte-identical in the templated region.
+
+bats_load_library bats-support
+bats_load_library bats-assert
+
+load helpers/common
+
+SLUG="my-feature"
+ROLE="worker-task-force-$SLUG"
+
+setup() {
+  setup_repo
+  setup_stubs
+  setup_worktree "$SLUG"
+  setup_task_force_home
+  cd "$WORKTREE_BASE/$SLUG"
+  # Make the real radio binary available so the unregister step inside
+  # task-done's cleanup region runs against it (matches assert_task_done_unregisters
+  # in task_done.bats). TAB_ID capture in task-done happens *before*
+  # unregister deletes the session file.
+  cp "$RADIO" "$STUB_BIN/radio"
+  chmod +x "$STUB_BIN/radio"
+}
+
+teardown() {
+  teardown_all
+}
+
+# Write a session file with the given TAB_ID= value (empty allowed) at the
+# location task-done's TAB_ID-capture block reads from.
+write_session_file() {
+  local tab_id="$1"
+  mkdir -p "$TASK_FORCE_HOME/radio/sessions"
+  printf 'ROLE=%s\nTAB=%s\nTAB_ID=%s\nREPO=test\nSTATE=idle\nLAST_HEARTBEAT=2020-01-01T00:00:00Z\nAGENT=claude\nLOADOUT=claude-gh\n' \
+    "$ROLE" "$ROLE" "$tab_id" \
+    > "$TASK_FORCE_HOME/radio/sessions/$ROLE.info"
+}
+
+# Returns the set of close-tab-flavored calls made against the zellij stub,
+# one per line.
+zellij_close_calls() {
+  grep -E '^zellij action close-tab' "$STUB_CALLS_DIR/zellij.calls" 2>/dev/null || true
+}
+
+# ---------------------------------------------------------------------------
+# Acceptance #1: worker tab focused → close-tab-by-id with worker's tab_id
+# ---------------------------------------------------------------------------
+
+@test "close-tab uses worker's TAB_ID (worker tab focused)" {
+  export ZELLIJ=fake-session
+  export TASK_FORCE_ROLE="$ROLE"
+  write_session_file 7
+
+  run "$CLAUDE_GH_TASK_DONE" --remove-worktree --force
+  assert_success
+  # Per-id close lands on the worker's persisted tab_id.
+  assert_stub_called zellij "action close-tab-by-id 7"
+  # And the unscoped, focused-tab form must never fire — that's the #107 bug.
+  run zellij_close_calls
+  refute_output --partial "action close-tab"$'\n'
+  assert_output --partial "action close-tab-by-id 7"
+}
+
+# ---------------------------------------------------------------------------
+# Acceptance #2: other tab focused → close-tab-by-id STILL with worker's id
+#
+# The regression scenario. With per-id targeting, focus state is irrelevant
+# at call time — task-done captured TAB_ID at register, persisted across
+# any focus changes the user makes during cleanup. The seeded zellij fixture
+# advertises a *different* tab as focused; task-done must still close the
+# worker's tab (id=7), not the focused one (id=99).
+# ---------------------------------------------------------------------------
+
+@test "close-tab uses worker's TAB_ID even when another tab is focused (#107 regression)" {
+  export ZELLIJ=fake-session
+  export TASK_FORCE_ROLE="$ROLE"
+  write_session_file 7
+  # Seed the stub so list-tabs/list-panes would report a different,
+  # currently-focused tab (id=99). With the bug, an unscoped `close-tab`
+  # would have hit that one; with the fix, we still close 7.
+  export STUB_ZELLIJ_TABS_JSON='[{"name":"pm","tab_id":99}]'
+  export STUB_ZELLIJ_PANES_JSON='[{"id":9900,"is_plugin":false,"is_focused":true,"tab_id":99}]'
+
+  run "$CLAUDE_GH_TASK_DONE" --remove-worktree --force
+  assert_success
+  assert_stub_called zellij "action close-tab-by-id 7"
+  # Defense in depth: assert the close call was by id 7, not id 99 or
+  # an unscoped form.
+  run zellij_close_calls
+  refute_output --partial "close-tab-by-id 99"
+  refute_output --partial "action close-tab"$'\n'
+}
+
+# ---------------------------------------------------------------------------
+# Acceptance #3: missing TAB_ID → no zellij close-tab call, exit 0
+# ---------------------------------------------------------------------------
+
+@test "close-tab is skipped when TAB_ID= is empty in the session file" {
+  export ZELLIJ=fake-session
+  export TASK_FORCE_ROLE="$ROLE"
+  write_session_file ""   # TAB_ID= present but empty
+
+  run "$CLAUDE_GH_TASK_DONE" --remove-worktree --force
+  assert_success
+  assert_output --partial "Skipping zellij close-tab"
+  # Worktree cleanup still completes.
+  assert [ ! -d "$WORKTREE_BASE/$SLUG" ]
+  run zellij_close_calls
+  assert_output ""
+}
+
+# ---------------------------------------------------------------------------
+# Acceptance #4: missing session file → no zellij close-tab call, exit 0
+# ---------------------------------------------------------------------------
+
+@test "close-tab is skipped when the radio session file is missing" {
+  export ZELLIJ=fake-session
+  export TASK_FORCE_ROLE="$ROLE"
+  # Deliberately do NOT create the session file.
+
+  run "$CLAUDE_GH_TASK_DONE" --remove-worktree --force
+  assert_success
+  assert_output --partial "Skipping zellij close-tab"
+  assert [ ! -d "$WORKTREE_BASE/$SLUG" ]
+  run zellij_close_calls
+  assert_output ""
+}
+
+# ---------------------------------------------------------------------------
+# Defense in depth: $ZELLIJ unset path (e.g., plain shell or CI) — also
+# covered by the updated tests in task_done.bats, but re-asserted here so
+# all close-tab edge cases are documented in one place.
+# ---------------------------------------------------------------------------
+
+@test "close-tab is skipped when \$ZELLIJ is unset (non-zellij shell / CI)" {
+  unset ZELLIJ || true
+  export TASK_FORCE_ROLE="$ROLE"
+  write_session_file 7
+
+  run "$CLAUDE_GH_TASK_DONE" --remove-worktree --force
+  assert_success
+  assert_output --partial "Skipping zellij close-tab"
+  run zellij_close_calls
+  assert_output ""
+}


### PR DESCRIPTION
## Summary

Fixes #107 — same focused-tab bug class as #102/#103, in `task-done` instead of `radio`.

`task-done` used to end with an unscoped `zellij action close-tab`, which targets whichever tab is focused at call time. If the user switched focus mid-cleanup (e.g. to the PM tab), the wrong tab got closed and the user's active session could be destroyed.

The fix mirrors #103's architecture: drive close-tab by the worker's stable `TAB_ID=`, which `radio register` already persists into the session file. `task-done` captures it *before* `radio unregister` wipes the session file, then closes via `zellij action close-tab-by-id <id>` at the end of cleanup. Guards skip the call (with a user-readable message) when zellij isn't running, no role is set, the session file is missing, or `TAB_ID=` is empty — never falling back to the unscoped form, which would re-open the bug.

Synced across all 7 `*/bin/task-done` loadouts via the existing `confirm-and-cleanup` sentinel region; `tools/check-drift.sh` green; shellcheck green; full bats suite (614 tests) green.

## Test plan

- [x] Drift check: `bash tools/check-drift.sh` — 16/16 groups green.
- [x] ShellCheck: all 7 `*/bin/task-done` copies clean.
- [x] New `tests/task_done_close_tab.bats` — 5/5 pass:
  - worker tab focused → `close-tab-by-id <worker_id>` called
  - **other tab focused (regression case)** → `close-tab-by-id <worker_id>` still called; no `close-tab-by-id 99` and no unscoped `close-tab`
  - empty `TAB_ID=` → no zellij call, exit 0, "Skipping" message
  - missing session file → no zellij call, exit 0, "Skipping" message
  - `$ZELLIJ` unset → no zellij call, exit 0
- [x] Updated existing `closes zellij tab` tests in `tests/task_done.bats` to assert the new skip behavior under the non-zellij test env.
- [x] Full suite: `./run_tests.sh` → 614 passed, 0 failed.
- [ ] **Live verification** in a real zellij session (PM focused, worker runs `task-done`) — to be done during review per acceptance criterion #7.

🤖 Generated with [Claude Code](https://claude.com/claude-code)