### PR TITLE
Radio: distinguish 'awaiting user input' from 'actively working' in tab state (#106)

### DIFF
--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -20,6 +20,16 @@
         ]
       }
     ],
+    "PreToolUse": [
+      {
+        "hooks": [
+          {
+            "type": "command",
+            "command": "radio busy"
+          }
+        ]
+      }
+    ],
     "Notification": [
       {
         "hooks": [

--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -20,6 +20,16 @@
         ]
       }
     ],
+    "Notification": [
+      {
+        "hooks": [
+          {
+            "type": "command",
+            "command": "radio awaiting"
+          }
+        ]
+      }
+    ],
     "Stop": [
       {
         "hooks": [

--- a/README.md
+++ b/README.md
@@ -412,7 +412,8 @@ The `awaiting` glyph is driven by Claude Code's `Notification` hook, which fires
 |-------------------|-------------------------------|--------------------------------------------------------------|
 | `SessionStart`    | `radio register`              | Claims the role's session file for this tab                  |
 | `UserPromptSubmit`| `radio busy`                  | Marks the session busy while a turn is running               |
-| `Notification`    | `radio awaiting`              | Marks the session awaiting input on a permission/Ask prompt  |
+| `PreToolUse`      | `radio busy`                  | Flips back to busy when Claude resumes work after a permission "Allow" (no `UserPromptSubmit` fires in that case) |
+| `Notification`    | `radio awaiting`              | Marks the session awaiting input on a permission/Ask prompt (stdin payload filter skips idle-wait pings) |
 | `Stop`            | `radio ready && radio check`  | Marks idle and surfaces any queued messages                  |
 | `SessionEnd`      | `radio unregister`            | Cleans up the session file on real exit (intra-session events filtered) |
 

--- a/README.md
+++ b/README.md
@@ -385,24 +385,38 @@ Role names are addressable strings, not free-form: the PM is `pm`, and each work
 | `radio read <id>`                   | Print one message |
 | `radio ack <id>`                    | Mark it acknowledged so it stops showing up in `check` |
 | `radio register` / `radio unregister` | Add/remove this tab's session file (`~/.task-force/radio/sessions/<role>.info`) |
-| `radio ready` / `radio busy`        | Toggle this session's `STATE` field — drives the wake-up vs. queue decision on the sender side |
+| `radio ready` / `radio busy` / `radio awaiting` | Toggle this session's `STATE` field — drives the tab glyph (⏸️ / ▶️ / ❓︎) and the wake-up vs. queue decision on the sender side |
 | `radio orphans`                     | List session files whose heartbeat is >1h stale |
+
+### Tab states
+
+Each registered session paints a monochrome glyph on its zellij tab so you can tell at a glance what's happening:
+
+| Glyph | State      | Meaning                                                                              |
+|-------|------------|--------------------------------------------------------------------------------------|
+| ⏸️    | `idle`     | Turn ended, agent waiting for input or a queued message                              |
+| ▶️    | `busy`     | Agent is actively working — generating, running tools, thinking                       |
+| ❓︎    | `awaiting` | Agent is blocked on a user response (permission prompt, `AskUserQuestion`, plan mode) |
+
+The `awaiting` glyph is driven by Claude Code's `Notification` hook, which fires whenever Claude prompts the user. Kiro sessions have no equivalent event today and stay two-state.
 
 ### How wake-up works
 
-`radio send` reads the recipient's session file. If `STATE=idle`, it resolves the recipient's tab/pane id via `zellij action list-tabs --json` / `list-panes --json --tab` and writes `radio check\n` straight into that pane with `zellij action write-chars --pane-id` — no focus switch, so the sender's tab stays put. On the recipient's next turn end, the `Stop` hook (`radio ready && radio check`) surfaces the new message. If `STATE=busy`, the message is queued silently — no failed wake attempt, no interrupting the recipient mid-turn.
+`radio send` reads the recipient's session file. If `STATE=idle`, it resolves the recipient's tab/pane id via `zellij action list-tabs --json` / `list-panes --json --tab` and writes `radio check\n` straight into that pane with `zellij action write-chars --pane-id` — no focus switch, so the sender's tab stays put. On the recipient's next turn end, the `Stop` hook (`radio ready && radio check`) surfaces the new message. If `STATE=busy` or `STATE=awaiting`, the message is queued silently — no failed wake attempt, no risk of stray keystrokes answering a permission prompt, no interrupting the recipient mid-turn. The queued message is picked up on the recipient's next manual `radio check` or next flip back to `idle`.
 
 ### The hooks that make it work
 
 `task-init claude-*` writes these into your project's `.claude/settings.json` automatically:
 
-| Hook              | Command                       | Why                                            |
-|-------------------|-------------------------------|------------------------------------------------|
-| `SessionStart`    | `radio register`              | Claims the role's session file for this tab    |
-| `UserPromptSubmit`| `radio busy`                  | Marks the session busy while a turn is running |
-| `Stop`            | `radio ready && radio check`  | Marks idle and surfaces any queued messages    |
+| Hook              | Command                       | Why                                                          |
+|-------------------|-------------------------------|--------------------------------------------------------------|
+| `SessionStart`    | `radio register`              | Claims the role's session file for this tab                  |
+| `UserPromptSubmit`| `radio busy`                  | Marks the session busy while a turn is running               |
+| `Notification`    | `radio awaiting`              | Marks the session awaiting input on a permission/Ask prompt  |
+| `Stop`            | `radio ready && radio check`  | Marks idle and surfaces any queued messages                  |
+| `SessionEnd`      | `radio unregister`            | Cleans up the session file on real exit (intra-session events filtered) |
 
-For the kiro loadouts the same logic lives in `.kiro/hooks/` and runs off Kiro's equivalent triggers.
+For the kiro loadouts the same logic lives in `.kiro/hooks/` and runs off Kiro's equivalent triggers. Kiro has no `Notification` analogue today, so kiro sessions don't paint the `❓︎` glyph.
 
 ### Idle workers don't auto-act
 

--- a/claude-gh/bin/radio
+++ b/claude-gh/bin/radio
@@ -351,9 +351,35 @@ cmd_unregister() {
   _log "unregister role=$TASK_FORCE_ROLE"
 }
 
-cmd_ready()    { _silent_exit_if_no_role; _update_state idle; }
-cmd_busy()     { _silent_exit_if_no_role; _update_state busy; }
-cmd_awaiting() { _silent_exit_if_no_role; _update_state awaiting; }
+cmd_ready() { _silent_exit_if_no_role; _update_state idle; }
+cmd_busy()  { _silent_exit_if_no_role; _update_state busy; }
+
+# `radio awaiting` is wired to Claude Code's Notification hook, which fires for
+# both blocking prompts (permission gates, AskUserQuestion, ExitPlanMode) AND
+# idle-wait pings ("Claude is waiting for your input"). An unfiltered hook
+# would clobber STATE=idle with STATE=awaiting on every turn end, making the
+# ⏸️ glyph effectively unreachable in practice (#106 review). Read the JSON
+# payload piped on stdin and skip the state flip when the `message` field
+# indicates idle-wait, mirroring the cmd_unregister pattern (#107). Manual
+# CLI invocations (no piped payload) proceed unconditionally so the
+# subcommand remains usable from a shell.
+cmd_awaiting() {
+  _silent_exit_if_no_role
+  if [[ ! -t 0 ]]; then
+    local payload msg
+    payload=$(cat 2>/dev/null || true)
+    if [[ -n "$payload" ]] && command -v jq >/dev/null 2>&1; then
+      msg=$(printf '%s' "$payload" | jq -r '.message // empty' 2>/dev/null || true)
+      case "$msg" in
+        *waiting*your*input*|*waiting*for*input*|*idle*)
+          _log "awaiting: skipping (message=$msg — idle-wait, not blocking) role=$TASK_FORCE_ROLE"
+          return 0
+          ;;
+      esac
+    fi
+  fi
+  _update_state awaiting
+}
 
 cmd_send() {
   local to="" intent="" pr="" issue="" repo="" body=""

--- a/claude-gh/bin/radio
+++ b/claude-gh/bin/radio
@@ -19,6 +19,7 @@ Usage:
   radio register --role ROLE --tab TAB [--repo PATH] --agent claude|kiro [--loadout NAME]
   radio ready                            mark this role idle (and process pending)
   radio busy                             mark this role busy
+  radio awaiting                         mark this role awaiting user input
   radio unregister                       remove this role's session file
   radio orphans                          list session files with stale (>1h) heartbeat
 
@@ -103,6 +104,7 @@ _strip_tab_prefix() {
   local s="$1"
   s="${s#⏸️ }"
   s="${s#▶️ }"
+  s="${s#❓︎ }"
   printf '%s' "$s"
 }
 
@@ -233,9 +235,10 @@ _rename_tab() {
   fi
 
   case "$new_state" in
-    idle) prefix="⏸️ " ;;
-    busy) prefix="▶️ " ;;
-    *)    return 0 ;;
+    idle)     prefix="⏸️ " ;;
+    busy)     prefix="▶️ " ;;
+    awaiting) prefix="❓︎ " ;;
+    *)        return 0 ;;
   esac
   new_name="${prefix}${bare}"
 
@@ -348,8 +351,9 @@ cmd_unregister() {
   _log "unregister role=$TASK_FORCE_ROLE"
 }
 
-cmd_ready() { _silent_exit_if_no_role; _update_state idle; }
-cmd_busy()  { _silent_exit_if_no_role; _update_state busy; }
+cmd_ready()    { _silent_exit_if_no_role; _update_state idle; }
+cmd_busy()     { _silent_exit_if_no_role; _update_state busy; }
+cmd_awaiting() { _silent_exit_if_no_role; _update_state awaiting; }
 
 cmd_send() {
   local to="" intent="" pr="" issue="" repo="" body=""
@@ -413,7 +417,9 @@ cmd_send() {
   rstate=$(_session_field "$rs" STATE || true)
   rtab=$(_session_field "$rs" TAB || true)
   if [[ "$rstate" != "idle" ]]; then
-    _log "send: $to is busy (state=$rstate) — queued (id=$id)"
+    local reason="busy"
+    [[ "$rstate" == "awaiting" ]] && reason="awaiting input"
+    _log "send: $to is $reason (state=$rstate) — queued (id=$id)"
     return 0
   fi
   if [[ -z "$rtab" ]]; then
@@ -543,6 +549,7 @@ case "$sub" in
   register)    [[ -z "${TASK_FORCE_ROLE:-}" ]] && exit 0; cmd_register "$@" ;;
   ready)       cmd_ready ;;
   busy)        cmd_busy ;;
+  awaiting)    cmd_awaiting ;;
   unregister)  cmd_unregister ;;
   orphans)     cmd_orphans ;;
   -h|--help)   usage 0 ;;

--- a/claude-gh/bin/task-init
+++ b/claude-gh/bin/task-init
@@ -273,6 +273,7 @@ _radio_install_hooks() {
     .hooks //= {}
     | .hooks.SessionStart     = add_radio(.hooks.SessionStart;     $sess)
     | .hooks.UserPromptSubmit = add_radio(.hooks.UserPromptSubmit; $ups)
+    | .hooks.PreToolUse       = add_radio(.hooks.PreToolUse;       $ups)
     | .hooks.Notification     = add_radio(.hooks.Notification;     $notif)
     | .hooks.Stop             = add_radio(.hooks.Stop;             $stop)
     | .hooks.SessionEnd       = add_radio(.hooks.SessionEnd;       $endcmd)

--- a/claude-gh/bin/task-init
+++ b/claude-gh/bin/task-init
@@ -248,6 +248,7 @@ _radio_install_hooks() {
 
   local register_cmd="radio register --role \$TASK_FORCE_ROLE --tab \$ZELLIJ_TAB --repo \$(git rev-parse --show-toplevel 2>/dev/null) --agent claude --loadout $loadout"
   local busy_cmd="radio busy"
+  local awaiting_cmd="radio awaiting"
   local stop_cmd="radio ready && radio check"
   local end_cmd="radio unregister"
 
@@ -261,6 +262,7 @@ _radio_install_hooks() {
   jq \
     --arg sess "$register_cmd" \
     --arg ups  "$busy_cmd" \
+    --arg notif "$awaiting_cmd" \
     --arg stop "$stop_cmd" \
     --arg endcmd  "$end_cmd" \
     '
@@ -271,6 +273,7 @@ _radio_install_hooks() {
     .hooks //= {}
     | .hooks.SessionStart     = add_radio(.hooks.SessionStart;     $sess)
     | .hooks.UserPromptSubmit = add_radio(.hooks.UserPromptSubmit; $ups)
+    | .hooks.Notification     = add_radio(.hooks.Notification;     $notif)
     | .hooks.Stop             = add_radio(.hooks.Stop;             $stop)
     | .hooks.SessionEnd       = add_radio(.hooks.SessionEnd;       $endcmd)
     | .permissions //= {}

--- a/claude-jira/bin/radio
+++ b/claude-jira/bin/radio
@@ -351,9 +351,35 @@ cmd_unregister() {
   _log "unregister role=$TASK_FORCE_ROLE"
 }
 
-cmd_ready()    { _silent_exit_if_no_role; _update_state idle; }
-cmd_busy()     { _silent_exit_if_no_role; _update_state busy; }
-cmd_awaiting() { _silent_exit_if_no_role; _update_state awaiting; }
+cmd_ready() { _silent_exit_if_no_role; _update_state idle; }
+cmd_busy()  { _silent_exit_if_no_role; _update_state busy; }
+
+# `radio awaiting` is wired to Claude Code's Notification hook, which fires for
+# both blocking prompts (permission gates, AskUserQuestion, ExitPlanMode) AND
+# idle-wait pings ("Claude is waiting for your input"). An unfiltered hook
+# would clobber STATE=idle with STATE=awaiting on every turn end, making the
+# ⏸️ glyph effectively unreachable in practice (#106 review). Read the JSON
+# payload piped on stdin and skip the state flip when the `message` field
+# indicates idle-wait, mirroring the cmd_unregister pattern (#107). Manual
+# CLI invocations (no piped payload) proceed unconditionally so the
+# subcommand remains usable from a shell.
+cmd_awaiting() {
+  _silent_exit_if_no_role
+  if [[ ! -t 0 ]]; then
+    local payload msg
+    payload=$(cat 2>/dev/null || true)
+    if [[ -n "$payload" ]] && command -v jq >/dev/null 2>&1; then
+      msg=$(printf '%s' "$payload" | jq -r '.message // empty' 2>/dev/null || true)
+      case "$msg" in
+        *waiting*your*input*|*waiting*for*input*|*idle*)
+          _log "awaiting: skipping (message=$msg — idle-wait, not blocking) role=$TASK_FORCE_ROLE"
+          return 0
+          ;;
+      esac
+    fi
+  fi
+  _update_state awaiting
+}
 
 cmd_send() {
   local to="" intent="" pr="" issue="" repo="" body=""

--- a/claude-jira/bin/radio
+++ b/claude-jira/bin/radio
@@ -19,6 +19,7 @@ Usage:
   radio register --role ROLE --tab TAB [--repo PATH] --agent claude|kiro [--loadout NAME]
   radio ready                            mark this role idle (and process pending)
   radio busy                             mark this role busy
+  radio awaiting                         mark this role awaiting user input
   radio unregister                       remove this role's session file
   radio orphans                          list session files with stale (>1h) heartbeat
 
@@ -103,6 +104,7 @@ _strip_tab_prefix() {
   local s="$1"
   s="${s#⏸️ }"
   s="${s#▶️ }"
+  s="${s#❓︎ }"
   printf '%s' "$s"
 }
 
@@ -233,9 +235,10 @@ _rename_tab() {
   fi
 
   case "$new_state" in
-    idle) prefix="⏸️ " ;;
-    busy) prefix="▶️ " ;;
-    *)    return 0 ;;
+    idle)     prefix="⏸️ " ;;
+    busy)     prefix="▶️ " ;;
+    awaiting) prefix="❓︎ " ;;
+    *)        return 0 ;;
   esac
   new_name="${prefix}${bare}"
 
@@ -348,8 +351,9 @@ cmd_unregister() {
   _log "unregister role=$TASK_FORCE_ROLE"
 }
 
-cmd_ready() { _silent_exit_if_no_role; _update_state idle; }
-cmd_busy()  { _silent_exit_if_no_role; _update_state busy; }
+cmd_ready()    { _silent_exit_if_no_role; _update_state idle; }
+cmd_busy()     { _silent_exit_if_no_role; _update_state busy; }
+cmd_awaiting() { _silent_exit_if_no_role; _update_state awaiting; }
 
 cmd_send() {
   local to="" intent="" pr="" issue="" repo="" body=""
@@ -413,7 +417,9 @@ cmd_send() {
   rstate=$(_session_field "$rs" STATE || true)
   rtab=$(_session_field "$rs" TAB || true)
   if [[ "$rstate" != "idle" ]]; then
-    _log "send: $to is busy (state=$rstate) — queued (id=$id)"
+    local reason="busy"
+    [[ "$rstate" == "awaiting" ]] && reason="awaiting input"
+    _log "send: $to is $reason (state=$rstate) — queued (id=$id)"
     return 0
   fi
   if [[ -z "$rtab" ]]; then
@@ -543,6 +549,7 @@ case "$sub" in
   register)    [[ -z "${TASK_FORCE_ROLE:-}" ]] && exit 0; cmd_register "$@" ;;
   ready)       cmd_ready ;;
   busy)        cmd_busy ;;
+  awaiting)    cmd_awaiting ;;
   unregister)  cmd_unregister ;;
   orphans)     cmd_orphans ;;
   -h|--help)   usage 0 ;;

--- a/claude-jira/bin/task-init
+++ b/claude-jira/bin/task-init
@@ -217,6 +217,7 @@ _radio_install_hooks() {
 
   local register_cmd="radio register --role \$TASK_FORCE_ROLE --tab \$ZELLIJ_TAB --repo \$(git rev-parse --show-toplevel 2>/dev/null) --agent claude --loadout $loadout"
   local busy_cmd="radio busy"
+  local awaiting_cmd="radio awaiting"
   local stop_cmd="radio ready && radio check"
   local end_cmd="radio unregister"
 
@@ -233,6 +234,7 @@ _radio_install_hooks() {
   jq \
     --arg sess "$register_cmd" \
     --arg ups  "$busy_cmd" \
+    --arg notif "$awaiting_cmd" \
     --arg stop "$stop_cmd" \
     --arg endcmd  "$end_cmd" \
     '
@@ -243,6 +245,7 @@ _radio_install_hooks() {
     .hooks //= {}
     | .hooks.SessionStart     = add_radio(.hooks.SessionStart;     $sess)
     | .hooks.UserPromptSubmit = add_radio(.hooks.UserPromptSubmit; $ups)
+    | .hooks.Notification     = add_radio(.hooks.Notification;     $notif)
     | .hooks.Stop             = add_radio(.hooks.Stop;             $stop)
     | .hooks.SessionEnd       = add_radio(.hooks.SessionEnd;       $endcmd)
     | .permissions //= {}

--- a/claude-jira/bin/task-init
+++ b/claude-jira/bin/task-init
@@ -245,6 +245,7 @@ _radio_install_hooks() {
     .hooks //= {}
     | .hooks.SessionStart     = add_radio(.hooks.SessionStart;     $sess)
     | .hooks.UserPromptSubmit = add_radio(.hooks.UserPromptSubmit; $ups)
+    | .hooks.PreToolUse       = add_radio(.hooks.PreToolUse;       $ups)
     | .hooks.Notification     = add_radio(.hooks.Notification;     $notif)
     | .hooks.Stop             = add_radio(.hooks.Stop;             $stop)
     | .hooks.SessionEnd       = add_radio(.hooks.SessionEnd;       $endcmd)

--- a/claude-local/bin/radio
+++ b/claude-local/bin/radio
@@ -351,9 +351,35 @@ cmd_unregister() {
   _log "unregister role=$TASK_FORCE_ROLE"
 }
 
-cmd_ready()    { _silent_exit_if_no_role; _update_state idle; }
-cmd_busy()     { _silent_exit_if_no_role; _update_state busy; }
-cmd_awaiting() { _silent_exit_if_no_role; _update_state awaiting; }
+cmd_ready() { _silent_exit_if_no_role; _update_state idle; }
+cmd_busy()  { _silent_exit_if_no_role; _update_state busy; }
+
+# `radio awaiting` is wired to Claude Code's Notification hook, which fires for
+# both blocking prompts (permission gates, AskUserQuestion, ExitPlanMode) AND
+# idle-wait pings ("Claude is waiting for your input"). An unfiltered hook
+# would clobber STATE=idle with STATE=awaiting on every turn end, making the
+# ⏸️ glyph effectively unreachable in practice (#106 review). Read the JSON
+# payload piped on stdin and skip the state flip when the `message` field
+# indicates idle-wait, mirroring the cmd_unregister pattern (#107). Manual
+# CLI invocations (no piped payload) proceed unconditionally so the
+# subcommand remains usable from a shell.
+cmd_awaiting() {
+  _silent_exit_if_no_role
+  if [[ ! -t 0 ]]; then
+    local payload msg
+    payload=$(cat 2>/dev/null || true)
+    if [[ -n "$payload" ]] && command -v jq >/dev/null 2>&1; then
+      msg=$(printf '%s' "$payload" | jq -r '.message // empty' 2>/dev/null || true)
+      case "$msg" in
+        *waiting*your*input*|*waiting*for*input*|*idle*)
+          _log "awaiting: skipping (message=$msg — idle-wait, not blocking) role=$TASK_FORCE_ROLE"
+          return 0
+          ;;
+      esac
+    fi
+  fi
+  _update_state awaiting
+}
 
 cmd_send() {
   local to="" intent="" pr="" issue="" repo="" body=""

--- a/claude-local/bin/radio
+++ b/claude-local/bin/radio
@@ -19,6 +19,7 @@ Usage:
   radio register --role ROLE --tab TAB [--repo PATH] --agent claude|kiro [--loadout NAME]
   radio ready                            mark this role idle (and process pending)
   radio busy                             mark this role busy
+  radio awaiting                         mark this role awaiting user input
   radio unregister                       remove this role's session file
   radio orphans                          list session files with stale (>1h) heartbeat
 
@@ -103,6 +104,7 @@ _strip_tab_prefix() {
   local s="$1"
   s="${s#⏸️ }"
   s="${s#▶️ }"
+  s="${s#❓︎ }"
   printf '%s' "$s"
 }
 
@@ -233,9 +235,10 @@ _rename_tab() {
   fi
 
   case "$new_state" in
-    idle) prefix="⏸️ " ;;
-    busy) prefix="▶️ " ;;
-    *)    return 0 ;;
+    idle)     prefix="⏸️ " ;;
+    busy)     prefix="▶️ " ;;
+    awaiting) prefix="❓︎ " ;;
+    *)        return 0 ;;
   esac
   new_name="${prefix}${bare}"
 
@@ -348,8 +351,9 @@ cmd_unregister() {
   _log "unregister role=$TASK_FORCE_ROLE"
 }
 
-cmd_ready() { _silent_exit_if_no_role; _update_state idle; }
-cmd_busy()  { _silent_exit_if_no_role; _update_state busy; }
+cmd_ready()    { _silent_exit_if_no_role; _update_state idle; }
+cmd_busy()     { _silent_exit_if_no_role; _update_state busy; }
+cmd_awaiting() { _silent_exit_if_no_role; _update_state awaiting; }
 
 cmd_send() {
   local to="" intent="" pr="" issue="" repo="" body=""
@@ -413,7 +417,9 @@ cmd_send() {
   rstate=$(_session_field "$rs" STATE || true)
   rtab=$(_session_field "$rs" TAB || true)
   if [[ "$rstate" != "idle" ]]; then
-    _log "send: $to is busy (state=$rstate) — queued (id=$id)"
+    local reason="busy"
+    [[ "$rstate" == "awaiting" ]] && reason="awaiting input"
+    _log "send: $to is $reason (state=$rstate) — queued (id=$id)"
     return 0
   fi
   if [[ -z "$rtab" ]]; then
@@ -543,6 +549,7 @@ case "$sub" in
   register)    [[ -z "${TASK_FORCE_ROLE:-}" ]] && exit 0; cmd_register "$@" ;;
   ready)       cmd_ready ;;
   busy)        cmd_busy ;;
+  awaiting)    cmd_awaiting ;;
   unregister)  cmd_unregister ;;
   orphans)     cmd_orphans ;;
   -h|--help)   usage 0 ;;

--- a/claude-local/bin/task-init
+++ b/claude-local/bin/task-init
@@ -242,6 +242,7 @@ _radio_install_hooks() {
 
   local register_cmd="radio register --role \$TASK_FORCE_ROLE --tab \$ZELLIJ_TAB --repo \$(git rev-parse --show-toplevel 2>/dev/null) --agent claude --loadout $loadout"
   local busy_cmd="radio busy"
+  local awaiting_cmd="radio awaiting"
   local stop_cmd="radio ready && radio check"
   local end_cmd="radio unregister"
 
@@ -252,6 +253,7 @@ _radio_install_hooks() {
   jq \
     --arg sess "$register_cmd" \
     --arg ups  "$busy_cmd" \
+    --arg notif "$awaiting_cmd" \
     --arg stop "$stop_cmd" \
     --arg endcmd  "$end_cmd" \
     '
@@ -262,6 +264,7 @@ _radio_install_hooks() {
     .hooks //= {}
     | .hooks.SessionStart     = add_radio(.hooks.SessionStart;     $sess)
     | .hooks.UserPromptSubmit = add_radio(.hooks.UserPromptSubmit; $ups)
+    | .hooks.Notification     = add_radio(.hooks.Notification;     $notif)
     | .hooks.Stop             = add_radio(.hooks.Stop;             $stop)
     | .hooks.SessionEnd       = add_radio(.hooks.SessionEnd;       $endcmd)
     | .permissions //= {}

--- a/claude-local/bin/task-init
+++ b/claude-local/bin/task-init
@@ -264,6 +264,7 @@ _radio_install_hooks() {
     .hooks //= {}
     | .hooks.SessionStart     = add_radio(.hooks.SessionStart;     $sess)
     | .hooks.UserPromptSubmit = add_radio(.hooks.UserPromptSubmit; $ups)
+    | .hooks.PreToolUse       = add_radio(.hooks.PreToolUse;       $ups)
     | .hooks.Notification     = add_radio(.hooks.Notification;     $notif)
     | .hooks.Stop             = add_radio(.hooks.Stop;             $stop)
     | .hooks.SessionEnd       = add_radio(.hooks.SessionEnd;       $endcmd)

--- a/claude-notion/bin/radio
+++ b/claude-notion/bin/radio
@@ -351,9 +351,35 @@ cmd_unregister() {
   _log "unregister role=$TASK_FORCE_ROLE"
 }
 
-cmd_ready()    { _silent_exit_if_no_role; _update_state idle; }
-cmd_busy()     { _silent_exit_if_no_role; _update_state busy; }
-cmd_awaiting() { _silent_exit_if_no_role; _update_state awaiting; }
+cmd_ready() { _silent_exit_if_no_role; _update_state idle; }
+cmd_busy()  { _silent_exit_if_no_role; _update_state busy; }
+
+# `radio awaiting` is wired to Claude Code's Notification hook, which fires for
+# both blocking prompts (permission gates, AskUserQuestion, ExitPlanMode) AND
+# idle-wait pings ("Claude is waiting for your input"). An unfiltered hook
+# would clobber STATE=idle with STATE=awaiting on every turn end, making the
+# ⏸️ glyph effectively unreachable in practice (#106 review). Read the JSON
+# payload piped on stdin and skip the state flip when the `message` field
+# indicates idle-wait, mirroring the cmd_unregister pattern (#107). Manual
+# CLI invocations (no piped payload) proceed unconditionally so the
+# subcommand remains usable from a shell.
+cmd_awaiting() {
+  _silent_exit_if_no_role
+  if [[ ! -t 0 ]]; then
+    local payload msg
+    payload=$(cat 2>/dev/null || true)
+    if [[ -n "$payload" ]] && command -v jq >/dev/null 2>&1; then
+      msg=$(printf '%s' "$payload" | jq -r '.message // empty' 2>/dev/null || true)
+      case "$msg" in
+        *waiting*your*input*|*waiting*for*input*|*idle*)
+          _log "awaiting: skipping (message=$msg — idle-wait, not blocking) role=$TASK_FORCE_ROLE"
+          return 0
+          ;;
+      esac
+    fi
+  fi
+  _update_state awaiting
+}
 
 cmd_send() {
   local to="" intent="" pr="" issue="" repo="" body=""

--- a/claude-notion/bin/radio
+++ b/claude-notion/bin/radio
@@ -19,6 +19,7 @@ Usage:
   radio register --role ROLE --tab TAB [--repo PATH] --agent claude|kiro [--loadout NAME]
   radio ready                            mark this role idle (and process pending)
   radio busy                             mark this role busy
+  radio awaiting                         mark this role awaiting user input
   radio unregister                       remove this role's session file
   radio orphans                          list session files with stale (>1h) heartbeat
 
@@ -103,6 +104,7 @@ _strip_tab_prefix() {
   local s="$1"
   s="${s#⏸️ }"
   s="${s#▶️ }"
+  s="${s#❓︎ }"
   printf '%s' "$s"
 }
 
@@ -233,9 +235,10 @@ _rename_tab() {
   fi
 
   case "$new_state" in
-    idle) prefix="⏸️ " ;;
-    busy) prefix="▶️ " ;;
-    *)    return 0 ;;
+    idle)     prefix="⏸️ " ;;
+    busy)     prefix="▶️ " ;;
+    awaiting) prefix="❓︎ " ;;
+    *)        return 0 ;;
   esac
   new_name="${prefix}${bare}"
 
@@ -348,8 +351,9 @@ cmd_unregister() {
   _log "unregister role=$TASK_FORCE_ROLE"
 }
 
-cmd_ready() { _silent_exit_if_no_role; _update_state idle; }
-cmd_busy()  { _silent_exit_if_no_role; _update_state busy; }
+cmd_ready()    { _silent_exit_if_no_role; _update_state idle; }
+cmd_busy()     { _silent_exit_if_no_role; _update_state busy; }
+cmd_awaiting() { _silent_exit_if_no_role; _update_state awaiting; }
 
 cmd_send() {
   local to="" intent="" pr="" issue="" repo="" body=""
@@ -413,7 +417,9 @@ cmd_send() {
   rstate=$(_session_field "$rs" STATE || true)
   rtab=$(_session_field "$rs" TAB || true)
   if [[ "$rstate" != "idle" ]]; then
-    _log "send: $to is busy (state=$rstate) — queued (id=$id)"
+    local reason="busy"
+    [[ "$rstate" == "awaiting" ]] && reason="awaiting input"
+    _log "send: $to is $reason (state=$rstate) — queued (id=$id)"
     return 0
   fi
   if [[ -z "$rtab" ]]; then
@@ -543,6 +549,7 @@ case "$sub" in
   register)    [[ -z "${TASK_FORCE_ROLE:-}" ]] && exit 0; cmd_register "$@" ;;
   ready)       cmd_ready ;;
   busy)        cmd_busy ;;
+  awaiting)    cmd_awaiting ;;
   unregister)  cmd_unregister ;;
   orphans)     cmd_orphans ;;
   -h|--help)   usage 0 ;;

--- a/claude-notion/bin/task-init
+++ b/claude-notion/bin/task-init
@@ -172,6 +172,7 @@ _radio_install_hooks() {
 
   local register_cmd="radio register --role \$TASK_FORCE_ROLE --tab \$ZELLIJ_TAB --repo \$(git rev-parse --show-toplevel 2>/dev/null) --agent claude --loadout $loadout"
   local busy_cmd="radio busy"
+  local awaiting_cmd="radio awaiting"
   local stop_cmd="radio ready && radio check"
   local end_cmd="radio unregister"
 
@@ -189,6 +190,7 @@ _radio_install_hooks() {
   jq \
     --arg sess "$register_cmd" \
     --arg ups  "$busy_cmd" \
+    --arg notif "$awaiting_cmd" \
     --arg stop "$stop_cmd" \
     --arg endcmd  "$end_cmd" \
     '
@@ -199,6 +201,7 @@ _radio_install_hooks() {
     .hooks //= {}
     | .hooks.SessionStart     = add_radio(.hooks.SessionStart;     $sess)
     | .hooks.UserPromptSubmit = add_radio(.hooks.UserPromptSubmit; $ups)
+    | .hooks.Notification     = add_radio(.hooks.Notification;     $notif)
     | .hooks.Stop             = add_radio(.hooks.Stop;             $stop)
     | .hooks.SessionEnd       = add_radio(.hooks.SessionEnd;       $endcmd)
     | .permissions //= {}

--- a/claude-notion/bin/task-init
+++ b/claude-notion/bin/task-init
@@ -201,6 +201,7 @@ _radio_install_hooks() {
     .hooks //= {}
     | .hooks.SessionStart     = add_radio(.hooks.SessionStart;     $sess)
     | .hooks.UserPromptSubmit = add_radio(.hooks.UserPromptSubmit; $ups)
+    | .hooks.PreToolUse       = add_radio(.hooks.PreToolUse;       $ups)
     | .hooks.Notification     = add_radio(.hooks.Notification;     $notif)
     | .hooks.Stop             = add_radio(.hooks.Stop;             $stop)
     | .hooks.SessionEnd       = add_radio(.hooks.SessionEnd;       $endcmd)

--- a/kiro-gh/bin/radio
+++ b/kiro-gh/bin/radio
@@ -351,9 +351,35 @@ cmd_unregister() {
   _log "unregister role=$TASK_FORCE_ROLE"
 }
 
-cmd_ready()    { _silent_exit_if_no_role; _update_state idle; }
-cmd_busy()     { _silent_exit_if_no_role; _update_state busy; }
-cmd_awaiting() { _silent_exit_if_no_role; _update_state awaiting; }
+cmd_ready() { _silent_exit_if_no_role; _update_state idle; }
+cmd_busy()  { _silent_exit_if_no_role; _update_state busy; }
+
+# `radio awaiting` is wired to Claude Code's Notification hook, which fires for
+# both blocking prompts (permission gates, AskUserQuestion, ExitPlanMode) AND
+# idle-wait pings ("Claude is waiting for your input"). An unfiltered hook
+# would clobber STATE=idle with STATE=awaiting on every turn end, making the
+# ⏸️ glyph effectively unreachable in practice (#106 review). Read the JSON
+# payload piped on stdin and skip the state flip when the `message` field
+# indicates idle-wait, mirroring the cmd_unregister pattern (#107). Manual
+# CLI invocations (no piped payload) proceed unconditionally so the
+# subcommand remains usable from a shell.
+cmd_awaiting() {
+  _silent_exit_if_no_role
+  if [[ ! -t 0 ]]; then
+    local payload msg
+    payload=$(cat 2>/dev/null || true)
+    if [[ -n "$payload" ]] && command -v jq >/dev/null 2>&1; then
+      msg=$(printf '%s' "$payload" | jq -r '.message // empty' 2>/dev/null || true)
+      case "$msg" in
+        *waiting*your*input*|*waiting*for*input*|*idle*)
+          _log "awaiting: skipping (message=$msg — idle-wait, not blocking) role=$TASK_FORCE_ROLE"
+          return 0
+          ;;
+      esac
+    fi
+  fi
+  _update_state awaiting
+}
 
 cmd_send() {
   local to="" intent="" pr="" issue="" repo="" body=""

--- a/kiro-gh/bin/radio
+++ b/kiro-gh/bin/radio
@@ -19,6 +19,7 @@ Usage:
   radio register --role ROLE --tab TAB [--repo PATH] --agent claude|kiro [--loadout NAME]
   radio ready                            mark this role idle (and process pending)
   radio busy                             mark this role busy
+  radio awaiting                         mark this role awaiting user input
   radio unregister                       remove this role's session file
   radio orphans                          list session files with stale (>1h) heartbeat
 
@@ -103,6 +104,7 @@ _strip_tab_prefix() {
   local s="$1"
   s="${s#⏸️ }"
   s="${s#▶️ }"
+  s="${s#❓︎ }"
   printf '%s' "$s"
 }
 
@@ -233,9 +235,10 @@ _rename_tab() {
   fi
 
   case "$new_state" in
-    idle) prefix="⏸️ " ;;
-    busy) prefix="▶️ " ;;
-    *)    return 0 ;;
+    idle)     prefix="⏸️ " ;;
+    busy)     prefix="▶️ " ;;
+    awaiting) prefix="❓︎ " ;;
+    *)        return 0 ;;
   esac
   new_name="${prefix}${bare}"
 
@@ -348,8 +351,9 @@ cmd_unregister() {
   _log "unregister role=$TASK_FORCE_ROLE"
 }
 
-cmd_ready() { _silent_exit_if_no_role; _update_state idle; }
-cmd_busy()  { _silent_exit_if_no_role; _update_state busy; }
+cmd_ready()    { _silent_exit_if_no_role; _update_state idle; }
+cmd_busy()     { _silent_exit_if_no_role; _update_state busy; }
+cmd_awaiting() { _silent_exit_if_no_role; _update_state awaiting; }
 
 cmd_send() {
   local to="" intent="" pr="" issue="" repo="" body=""
@@ -413,7 +417,9 @@ cmd_send() {
   rstate=$(_session_field "$rs" STATE || true)
   rtab=$(_session_field "$rs" TAB || true)
   if [[ "$rstate" != "idle" ]]; then
-    _log "send: $to is busy (state=$rstate) — queued (id=$id)"
+    local reason="busy"
+    [[ "$rstate" == "awaiting" ]] && reason="awaiting input"
+    _log "send: $to is $reason (state=$rstate) — queued (id=$id)"
     return 0
   fi
   if [[ -z "$rtab" ]]; then
@@ -543,6 +549,7 @@ case "$sub" in
   register)    [[ -z "${TASK_FORCE_ROLE:-}" ]] && exit 0; cmd_register "$@" ;;
   ready)       cmd_ready ;;
   busy)        cmd_busy ;;
+  awaiting)    cmd_awaiting ;;
   unregister)  cmd_unregister ;;
   orphans)     cmd_orphans ;;
   -h|--help)   usage 0 ;;

--- a/kiro-local/bin/radio
+++ b/kiro-local/bin/radio
@@ -351,9 +351,35 @@ cmd_unregister() {
   _log "unregister role=$TASK_FORCE_ROLE"
 }
 
-cmd_ready()    { _silent_exit_if_no_role; _update_state idle; }
-cmd_busy()     { _silent_exit_if_no_role; _update_state busy; }
-cmd_awaiting() { _silent_exit_if_no_role; _update_state awaiting; }
+cmd_ready() { _silent_exit_if_no_role; _update_state idle; }
+cmd_busy()  { _silent_exit_if_no_role; _update_state busy; }
+
+# `radio awaiting` is wired to Claude Code's Notification hook, which fires for
+# both blocking prompts (permission gates, AskUserQuestion, ExitPlanMode) AND
+# idle-wait pings ("Claude is waiting for your input"). An unfiltered hook
+# would clobber STATE=idle with STATE=awaiting on every turn end, making the
+# ⏸️ glyph effectively unreachable in practice (#106 review). Read the JSON
+# payload piped on stdin and skip the state flip when the `message` field
+# indicates idle-wait, mirroring the cmd_unregister pattern (#107). Manual
+# CLI invocations (no piped payload) proceed unconditionally so the
+# subcommand remains usable from a shell.
+cmd_awaiting() {
+  _silent_exit_if_no_role
+  if [[ ! -t 0 ]]; then
+    local payload msg
+    payload=$(cat 2>/dev/null || true)
+    if [[ -n "$payload" ]] && command -v jq >/dev/null 2>&1; then
+      msg=$(printf '%s' "$payload" | jq -r '.message // empty' 2>/dev/null || true)
+      case "$msg" in
+        *waiting*your*input*|*waiting*for*input*|*idle*)
+          _log "awaiting: skipping (message=$msg — idle-wait, not blocking) role=$TASK_FORCE_ROLE"
+          return 0
+          ;;
+      esac
+    fi
+  fi
+  _update_state awaiting
+}
 
 cmd_send() {
   local to="" intent="" pr="" issue="" repo="" body=""

--- a/kiro-local/bin/radio
+++ b/kiro-local/bin/radio
@@ -19,6 +19,7 @@ Usage:
   radio register --role ROLE --tab TAB [--repo PATH] --agent claude|kiro [--loadout NAME]
   radio ready                            mark this role idle (and process pending)
   radio busy                             mark this role busy
+  radio awaiting                         mark this role awaiting user input
   radio unregister                       remove this role's session file
   radio orphans                          list session files with stale (>1h) heartbeat
 
@@ -103,6 +104,7 @@ _strip_tab_prefix() {
   local s="$1"
   s="${s#⏸️ }"
   s="${s#▶️ }"
+  s="${s#❓︎ }"
   printf '%s' "$s"
 }
 
@@ -233,9 +235,10 @@ _rename_tab() {
   fi
 
   case "$new_state" in
-    idle) prefix="⏸️ " ;;
-    busy) prefix="▶️ " ;;
-    *)    return 0 ;;
+    idle)     prefix="⏸️ " ;;
+    busy)     prefix="▶️ " ;;
+    awaiting) prefix="❓︎ " ;;
+    *)        return 0 ;;
   esac
   new_name="${prefix}${bare}"
 
@@ -348,8 +351,9 @@ cmd_unregister() {
   _log "unregister role=$TASK_FORCE_ROLE"
 }
 
-cmd_ready() { _silent_exit_if_no_role; _update_state idle; }
-cmd_busy()  { _silent_exit_if_no_role; _update_state busy; }
+cmd_ready()    { _silent_exit_if_no_role; _update_state idle; }
+cmd_busy()     { _silent_exit_if_no_role; _update_state busy; }
+cmd_awaiting() { _silent_exit_if_no_role; _update_state awaiting; }
 
 cmd_send() {
   local to="" intent="" pr="" issue="" repo="" body=""
@@ -413,7 +417,9 @@ cmd_send() {
   rstate=$(_session_field "$rs" STATE || true)
   rtab=$(_session_field "$rs" TAB || true)
   if [[ "$rstate" != "idle" ]]; then
-    _log "send: $to is busy (state=$rstate) — queued (id=$id)"
+    local reason="busy"
+    [[ "$rstate" == "awaiting" ]] && reason="awaiting input"
+    _log "send: $to is $reason (state=$rstate) — queued (id=$id)"
     return 0
   fi
   if [[ -z "$rtab" ]]; then
@@ -543,6 +549,7 @@ case "$sub" in
   register)    [[ -z "${TASK_FORCE_ROLE:-}" ]] && exit 0; cmd_register "$@" ;;
   ready)       cmd_ready ;;
   busy)        cmd_busy ;;
+  awaiting)    cmd_awaiting ;;
   unregister)  cmd_unregister ;;
   orphans)     cmd_orphans ;;
   -h|--help)   usage 0 ;;

--- a/kiro-notion/bin/radio
+++ b/kiro-notion/bin/radio
@@ -351,9 +351,35 @@ cmd_unregister() {
   _log "unregister role=$TASK_FORCE_ROLE"
 }
 
-cmd_ready()    { _silent_exit_if_no_role; _update_state idle; }
-cmd_busy()     { _silent_exit_if_no_role; _update_state busy; }
-cmd_awaiting() { _silent_exit_if_no_role; _update_state awaiting; }
+cmd_ready() { _silent_exit_if_no_role; _update_state idle; }
+cmd_busy()  { _silent_exit_if_no_role; _update_state busy; }
+
+# `radio awaiting` is wired to Claude Code's Notification hook, which fires for
+# both blocking prompts (permission gates, AskUserQuestion, ExitPlanMode) AND
+# idle-wait pings ("Claude is waiting for your input"). An unfiltered hook
+# would clobber STATE=idle with STATE=awaiting on every turn end, making the
+# ⏸️ glyph effectively unreachable in practice (#106 review). Read the JSON
+# payload piped on stdin and skip the state flip when the `message` field
+# indicates idle-wait, mirroring the cmd_unregister pattern (#107). Manual
+# CLI invocations (no piped payload) proceed unconditionally so the
+# subcommand remains usable from a shell.
+cmd_awaiting() {
+  _silent_exit_if_no_role
+  if [[ ! -t 0 ]]; then
+    local payload msg
+    payload=$(cat 2>/dev/null || true)
+    if [[ -n "$payload" ]] && command -v jq >/dev/null 2>&1; then
+      msg=$(printf '%s' "$payload" | jq -r '.message // empty' 2>/dev/null || true)
+      case "$msg" in
+        *waiting*your*input*|*waiting*for*input*|*idle*)
+          _log "awaiting: skipping (message=$msg — idle-wait, not blocking) role=$TASK_FORCE_ROLE"
+          return 0
+          ;;
+      esac
+    fi
+  fi
+  _update_state awaiting
+}
 
 cmd_send() {
   local to="" intent="" pr="" issue="" repo="" body=""

--- a/kiro-notion/bin/radio
+++ b/kiro-notion/bin/radio
@@ -19,6 +19,7 @@ Usage:
   radio register --role ROLE --tab TAB [--repo PATH] --agent claude|kiro [--loadout NAME]
   radio ready                            mark this role idle (and process pending)
   radio busy                             mark this role busy
+  radio awaiting                         mark this role awaiting user input
   radio unregister                       remove this role's session file
   radio orphans                          list session files with stale (>1h) heartbeat
 
@@ -103,6 +104,7 @@ _strip_tab_prefix() {
   local s="$1"
   s="${s#⏸️ }"
   s="${s#▶️ }"
+  s="${s#❓︎ }"
   printf '%s' "$s"
 }
 
@@ -233,9 +235,10 @@ _rename_tab() {
   fi
 
   case "$new_state" in
-    idle) prefix="⏸️ " ;;
-    busy) prefix="▶️ " ;;
-    *)    return 0 ;;
+    idle)     prefix="⏸️ " ;;
+    busy)     prefix="▶️ " ;;
+    awaiting) prefix="❓︎ " ;;
+    *)        return 0 ;;
   esac
   new_name="${prefix}${bare}"
 
@@ -348,8 +351,9 @@ cmd_unregister() {
   _log "unregister role=$TASK_FORCE_ROLE"
 }
 
-cmd_ready() { _silent_exit_if_no_role; _update_state idle; }
-cmd_busy()  { _silent_exit_if_no_role; _update_state busy; }
+cmd_ready()    { _silent_exit_if_no_role; _update_state idle; }
+cmd_busy()     { _silent_exit_if_no_role; _update_state busy; }
+cmd_awaiting() { _silent_exit_if_no_role; _update_state awaiting; }
 
 cmd_send() {
   local to="" intent="" pr="" issue="" repo="" body=""
@@ -413,7 +417,9 @@ cmd_send() {
   rstate=$(_session_field "$rs" STATE || true)
   rtab=$(_session_field "$rs" TAB || true)
   if [[ "$rstate" != "idle" ]]; then
-    _log "send: $to is busy (state=$rstate) — queued (id=$id)"
+    local reason="busy"
+    [[ "$rstate" == "awaiting" ]] && reason="awaiting input"
+    _log "send: $to is $reason (state=$rstate) — queued (id=$id)"
     return 0
   fi
   if [[ -z "$rtab" ]]; then
@@ -543,6 +549,7 @@ case "$sub" in
   register)    [[ -z "${TASK_FORCE_ROLE:-}" ]] && exit 0; cmd_register "$@" ;;
   ready)       cmd_ready ;;
   busy)        cmd_busy ;;
+  awaiting)    cmd_awaiting ;;
   unregister)  cmd_unregister ;;
   orphans)     cmd_orphans ;;
   -h|--help)   usage 0 ;;

--- a/tests/radio.bats
+++ b/tests/radio.bats
@@ -57,6 +57,13 @@ teardown() {
   assert_output "STATE=idle"
 }
 
+@test "awaiting toggles STATE to awaiting" {
+  "$RADIO" register --role pm --tab pm --agent claude
+  TASK_FORCE_ROLE=pm "$RADIO" awaiting
+  run grep "^STATE=" "$TASK_FORCE_HOME/radio/sessions/pm.info"
+  assert_output "STATE=awaiting"
+}
+
 @test "unregister removes the session file" {
   "$RADIO" register --role pm --tab pm --agent claude
   TASK_FORCE_ROLE=pm "$RADIO" unregister
@@ -101,6 +108,12 @@ teardown() {
 
 @test "unregister is a silent no-op when TASK_FORCE_ROLE is unset" {
   run env -u TASK_FORCE_ROLE "$RADIO" unregister
+  assert_success
+  [ -z "$output" ]
+}
+
+@test "awaiting is a silent no-op when TASK_FORCE_ROLE is unset" {
+  run env -u TASK_FORCE_ROLE "$RADIO" awaiting
   assert_success
   [ -z "$output" ]
 }

--- a/tests/radio_lifecycle.bats
+++ b/tests/radio_lifecycle.bats
@@ -134,6 +134,18 @@ teardown() {
   assert_output --partial "STATE=idle"
 }
 
+@test "awaiting re-seeds the session file from env vars if it was wiped (#106)" {
+  "$RADIO" register --role worker-foo --tab w-foo --agent claude
+  local sess="$TASK_FORCE_HOME/radio/sessions/worker-foo.info"
+  rm -f "$sess"
+
+  TASK_FORCE_ROLE=worker-foo ZELLIJ_TAB=w-foo run "$RADIO" awaiting
+  assert_success
+  assert [ -f "$sess" ]
+  run cat "$sess"
+  assert_output --partial "STATE=awaiting"
+}
+
 @test "re-seed is a no-op when \$ZELLIJ_TAB is unset (no identity to rebuild from)" {
   # Plain `claude` session with $TASK_FORCE_ROLE set but no $ZELLIJ_TAB
   # (e.g. user typed TASK_FORCE_ROLE=foo in a shell). Nothing to rebuild

--- a/tests/radio_lifecycle.bats
+++ b/tests/radio_lifecycle.bats
@@ -146,6 +146,84 @@ teardown() {
   assert_output --partial "STATE=awaiting"
 }
 
+# ----- Notification payload filter (#106 PR review) -------------------------
+# `radio awaiting` is wired to Claude Code's Notification hook, which fires
+# for both blocking prompts (permission gates, AskUserQuestion, ExitPlanMode)
+# AND idle-wait pings ("Claude is waiting for your input"). Without filtering,
+# every turn end would clobber STATE=idle → STATE=awaiting and the ⏸️ glyph
+# would never appear in practice. The filter reads the stdin payload and
+# skips the flip on idle-wait messages.
+
+@test "awaiting skips when stdin payload has message='Claude is waiting for your input' (idle-wait)" {
+  "$RADIO" register --role worker-foo --tab w-foo --agent claude
+  local sess="$TASK_FORCE_HOME/radio/sessions/worker-foo.info"
+  # Initial STATE=idle from register.
+  TASK_FORCE_ROLE=worker-foo run bash -c "echo '{\"message\":\"Claude is waiting for your input\"}' | '$RADIO' awaiting"
+  assert_success
+  # STATE must NOT have flipped to awaiting.
+  run grep "^STATE=" "$sess"
+  assert_output "STATE=idle"
+  run cat "$TASK_FORCE_HOME/radio/log"
+  assert_output --partial "awaiting: skipping"
+  assert_output --partial "idle-wait"
+}
+
+@test "awaiting skips when stdin payload has message='Claude is waiting for user input'" {
+  # Variant phrasing — also idle-wait, also skipped by the *waiting*for*input* arm.
+  "$RADIO" register --role worker-foo --tab w-foo --agent claude
+  local sess="$TASK_FORCE_HOME/radio/sessions/worker-foo.info"
+  TASK_FORCE_ROLE=worker-foo run bash -c "echo '{\"message\":\"Claude is waiting for user input\"}' | '$RADIO' awaiting"
+  assert_success
+  run grep "^STATE=" "$sess"
+  assert_output "STATE=idle"
+}
+
+@test "awaiting proceeds when stdin payload has a blocking-prompt message (permission gate)" {
+  "$RADIO" register --role worker-foo --tab w-foo --agent claude
+  local sess="$TASK_FORCE_HOME/radio/sessions/worker-foo.info"
+  TASK_FORCE_ROLE=worker-foo run bash -c "echo '{\"message\":\"Allow this Bash command?\"}' | '$RADIO' awaiting"
+  assert_success
+  run grep "^STATE=" "$sess"
+  assert_output "STATE=awaiting"
+}
+
+@test "awaiting proceeds when stdin payload has a blocking-prompt message (AskUserQuestion)" {
+  "$RADIO" register --role worker-foo --tab w-foo --agent claude
+  local sess="$TASK_FORCE_HOME/radio/sessions/worker-foo.info"
+  TASK_FORCE_ROLE=worker-foo run bash -c "echo '{\"message\":\"Claude needs your input\"}' | '$RADIO' awaiting"
+  assert_success
+  # "needs your input" doesn't match the *waiting* filter patterns — proceeds.
+  run grep "^STATE=" "$sess"
+  assert_output "STATE=awaiting"
+}
+
+@test "awaiting proceeds when stdin is empty (manual CLI invocation)" {
+  "$RADIO" register --role worker-foo --tab w-foo --agent claude
+  local sess="$TASK_FORCE_HOME/radio/sessions/worker-foo.info"
+  TASK_FORCE_ROLE=worker-foo run bash -c "'$RADIO' awaiting < /dev/null"
+  assert_success
+  run grep "^STATE=" "$sess"
+  assert_output "STATE=awaiting"
+}
+
+@test "awaiting proceeds when stdin payload is not valid JSON" {
+  "$RADIO" register --role worker-foo --tab w-foo --agent claude
+  local sess="$TASK_FORCE_HOME/radio/sessions/worker-foo.info"
+  TASK_FORCE_ROLE=worker-foo run bash -c "echo 'not json' | '$RADIO' awaiting"
+  assert_success
+  run grep "^STATE=" "$sess"
+  assert_output "STATE=awaiting"
+}
+
+@test "awaiting proceeds when payload JSON has no message field" {
+  "$RADIO" register --role worker-foo --tab w-foo --agent claude
+  local sess="$TASK_FORCE_HOME/radio/sessions/worker-foo.info"
+  TASK_FORCE_ROLE=worker-foo run bash -c "echo '{\"other_field\":\"value\"}' | '$RADIO' awaiting"
+  assert_success
+  run grep "^STATE=" "$sess"
+  assert_output "STATE=awaiting"
+}
+
 @test "re-seed is a no-op when \$ZELLIJ_TAB is unset (no identity to rebuild from)" {
   # Plain `claude` session with $TASK_FORCE_ROLE set but no $ZELLIJ_TAB
   # (e.g. user typed TASK_FORCE_ROLE=foo in a shell). Nothing to rebuild

--- a/tests/radio_tab_state.bats
+++ b/tests/radio_tab_state.bats
@@ -220,6 +220,42 @@ teardown() {
   assert_output "TAB=${PLAY}pm"
 }
 
+# ----- PreToolUse hook idempotency (#106 PR review) -------------------------
+# A `PreToolUse` hook is wired to `radio busy` so Claude resuming after a
+# permission "Allow" (no `UserPromptSubmit` fires there) repaints the tab
+# from ❓︎ back to ▶️ on the next tool call. Since PreToolUse fires before
+# every tool invocation, `radio busy` must be a no-op for tab paint when
+# state is already busy.
+
+@test "busy → busy is a no-op for STATE and paints the same play prefix" {
+  TASK_FORCE_ROLE=pm "$RADIO" register --role pm --tab pm --agent claude
+  TASK_FORCE_ROLE=pm "$RADIO" busy
+  : > "$STUB_CALLS_DIR/zellij.calls"
+  # Second busy — already busy, should be safe to call.
+  TASK_FORCE_ROLE=pm "$RADIO" busy
+  run grep "^STATE=" "$TASK_FORCE_HOME/radio/sessions/pm.info"
+  assert_output "STATE=busy"
+  # TAB= stays "<play> pm" — no stacking of glyphs.
+  run grep "^TAB=" "$TASK_FORCE_HOME/radio/sessions/pm.info"
+  assert_output "TAB=${PLAY}pm"
+  # The (single) rename-tab-by-id call targets the same name.
+  run bash -c "grep 'rename-tab-by-id' '$STUB_CALLS_DIR/zellij.calls' | tail -1"
+  assert_output "zellij action rename-tab-by-id 7 ${PLAY}pm"
+}
+
+@test "awaiting → busy via PreToolUse-style call flips STATE and paints ▶️" {
+  # Simulates the post-"Allow" resume: Notification fired (state=awaiting),
+  # then PreToolUse fires `radio busy` before the next tool call (#106
+  # review). Either tool-driven resume path is covered by this transition.
+  TASK_FORCE_ROLE=pm "$RADIO" register --role pm --tab pm --agent claude
+  TASK_FORCE_ROLE=pm "$RADIO" awaiting
+  TASK_FORCE_ROLE=pm "$RADIO" busy
+  run grep "^STATE=" "$TASK_FORCE_HOME/radio/sessions/pm.info"
+  assert_output "STATE=busy"
+  run grep "^TAB=" "$TASK_FORCE_HOME/radio/sessions/pm.info"
+  assert_output "TAB=${PLAY}pm"
+}
+
 @test "_rename_tab skips awaiting paint when \$ZELLIJ_TAB names a different tab" {
   TASK_FORCE_ROLE=pm "$RADIO" register --role pm --tab pm --agent claude
   : > "$STUB_CALLS_DIR/zellij.calls"

--- a/tests/radio_tab_state.bats
+++ b/tests/radio_tab_state.bats
@@ -18,6 +18,7 @@ load helpers/common
 # and we don't repeat the literal UTF-8 sequences across cases.
 PAUSE='⏸️ '
 PLAY='▶️ '
+WAIT='❓︎ '
 
 setup() {
   setup_task_force_home
@@ -172,4 +173,60 @@ teardown() {
   TASK_FORCE_ROLE=pm "$RADIO" register --role pm --tab pm --agent claude
   ZELLIJ_TAB=pm TASK_FORCE_ROLE=pm "$RADIO" busy
   assert_stub_called zellij "action rename-tab-by-id 7 ${PLAY}pm"
+}
+
+# ----- awaiting state (#106) ------------------------------------------------
+
+@test "awaiting writes STATE=awaiting and paints the question-mark prefix" {
+  TASK_FORCE_ROLE=pm "$RADIO" register --role pm --tab pm --agent claude
+  TASK_FORCE_ROLE=pm "$RADIO" awaiting
+  run grep "^STATE=" "$TASK_FORCE_HOME/radio/sessions/pm.info"
+  assert_output "STATE=awaiting"
+  assert_stub_called zellij "action rename-tab-by-id 7 ${WAIT}pm"
+  run grep "^TAB=" "$TASK_FORCE_HOME/radio/sessions/pm.info"
+  assert_output "TAB=${WAIT}pm"
+}
+
+@test "busy → awaiting → busy round-trip strips and repaints cleanly" {
+  TASK_FORCE_ROLE=pm "$RADIO" register --role pm --tab pm --agent claude
+  TASK_FORCE_ROLE=pm "$RADIO" busy
+  TASK_FORCE_ROLE=pm "$RADIO" awaiting
+  TASK_FORCE_ROLE=pm "$RADIO" busy
+
+  # Final TAB= should be exactly "<play> pm", not "<play><question> pm" etc.
+  run grep "^TAB=" "$TASK_FORCE_HOME/radio/sessions/pm.info"
+  assert_output "TAB=${PLAY}pm"
+
+  # And the most recent rename-tab-by-id call should target the same name.
+  run bash -c "grep 'rename-tab-by-id' '$STUB_CALLS_DIR/zellij.calls' | tail -1"
+  assert_output "zellij action rename-tab-by-id 7 ${PLAY}pm"
+}
+
+@test "awaiting → idle via cmd_ready paints the pause prefix" {
+  TASK_FORCE_ROLE=pm "$RADIO" register --role pm --tab pm --agent claude
+  TASK_FORCE_ROLE=pm "$RADIO" awaiting
+  TASK_FORCE_ROLE=pm "$RADIO" ready
+  run grep "^TAB=" "$TASK_FORCE_HOME/radio/sessions/pm.info"
+  assert_output "TAB=${PAUSE}pm"
+  run grep "^STATE=" "$TASK_FORCE_HOME/radio/sessions/pm.info"
+  assert_output "STATE=idle"
+}
+
+@test "awaiting → busy via cmd_busy paints the play prefix" {
+  TASK_FORCE_ROLE=pm "$RADIO" register --role pm --tab pm --agent claude
+  TASK_FORCE_ROLE=pm "$RADIO" awaiting
+  TASK_FORCE_ROLE=pm "$RADIO" busy
+  run grep "^TAB=" "$TASK_FORCE_HOME/radio/sessions/pm.info"
+  assert_output "TAB=${PLAY}pm"
+}
+
+@test "_rename_tab skips awaiting paint when \$ZELLIJ_TAB names a different tab" {
+  TASK_FORCE_ROLE=pm "$RADIO" register --role pm --tab pm --agent claude
+  : > "$STUB_CALLS_DIR/zellij.calls"
+  ZELLIJ_TAB=worker-foo TASK_FORCE_ROLE=pm "$RADIO" awaiting
+  run stub_calls zellij
+  refute_output --partial "rename-tab-by-id"
+  # State update still went through.
+  run grep "^STATE=" "$TASK_FORCE_HOME/radio/sessions/pm.info"
+  assert_output "STATE=awaiting"
 }

--- a/tests/radio_zellij.bats
+++ b/tests/radio_zellij.bats
@@ -72,6 +72,27 @@ teardown() {
 
 # ----- recipient's tab no longer exists in zellij --------------------------
 
+@test "send to awaiting recipient does not call zellij wake actions and logs awaiting input" {
+  # The awaiting state must be no-wake for the same reason busy is — writing
+  # `radio check\n` into a pane that's sitting at a permission prompt would
+  # answer the prompt with stray keystrokes (#106).
+  "$RADIO" register --role pm --tab pm --agent claude
+  TASK_FORCE_ROLE=pm "$RADIO" awaiting
+  TASK_FORCE_ROLE=worker-foo "$RADIO" send --to pm --intent ping --body "queue me"
+
+  run stub_calls zellij
+  refute_output --partial "write-chars"
+  refute_output --partial "go-to-tab-name"
+
+  # The message is still queued.
+  run bash -c "ls '$TASK_FORCE_HOME/radio/mailbox/pm/inbox/'*.md | wc -l"
+  assert_output --partial "1"
+
+  # And the log line distinguishes the awaiting case from the busy case.
+  run cat "$TASK_FORCE_HOME/radio/log"
+  assert_output --partial "awaiting input"
+}
+
 @test "send queues silently when recipient's tab has no writable panes (#102)" {
   # Register pm so TAB_ID=7 is captured, then wipe the panes fixture so the
   # `list-panes --json --tab` lookup returns []. The session file's TAB_ID=


### PR DESCRIPTION
Closes #106.

## Summary
- Adds a third radio state, `awaiting`, painted with a monochrome `❓︎` glyph (U+2753 + U+FE0E text-presentation selector). At-a-glance, users can now tell whether a worker is actively working (`▶️`) or blocked on a permission prompt / `AskUserQuestion` / plan approval (`❓︎`).
- Wired via Claude Code's `Notification` hook (`radio awaiting`); the existing `STATE != idle` send gate already covers awaiting correctly, so messages to an awaiting recipient queue silently — no stray keystrokes into a pending permission prompt.
- Kiro loadouts kept two-state (Kiro has no `Notification` analogue today).
- Drift-checked across all 7 `*/bin/radio` copies.

## Files changed
- 7 radio bodies (sync'd via `# region:body`): `_strip_tab_prefix` arm, `_rename_tab` switch case, `cmd_awaiting`, dispatch, `usage()`, distinct `cmd_send` log line for awaiting vs. busy.
- 4 claude-* `task-init` scripts: merge `Notification → radio awaiting` hook into target projects.
- 1 host `.claude/settings.json`: same Notification hook block.
- 4 bats files: state-machine paint, round-trip / no-stack regression guard, send-queues-without-write-chars + log-line distinction, silent no-op + STATE toggle, re-seed parity.
- `README.md`: new "Tab states" table + Notification hook documented.

## Test plan
- [x] `tools/check-drift.sh` exits 0 (7 radio bodies byte-identical).
- [x] Full `bats tests/` suite: 636/636 pass.
- [x] `shellcheck -x` (matching CI invocation): clean.
- [ ] Manual smoke (post-merge): trigger a permission prompt / `AskUserQuestion` in a worker; verify tab repaints to `❓︎ <slug>`. Verify `radio send` to that worker queues and logs `awaiting input` without `write-chars`. Verify `▶️` resumes after approval and `⏸️` on `Stop`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)