### PR TITLE
Fix #117: preserve TAB_ID across re-register; persist TAB_ID in $INFO_FILE

### DIFF
--- a/claude-gh/bin/radio
+++ b/claude-gh/bin/radio
@@ -293,11 +293,33 @@ cmd_register() {
   local tab_id=""
   if [[ -n "${ZELLIJ:-}" ]] && command -v zellij >/dev/null 2>&1; then
     tab_id=$(_zellij_tab_id_by_name "$tab" || true)
-    [[ -z "$tab_id" ]] && _log "register: could not resolve tab_id for tab=$tab (zellij list-tabs returned no match)"
   fi
 
   local f
   f=$(_session_file "$role")
+
+  # Re-register protection (#117): `SessionStart` fires again on `/compact`,
+  # `/clear`, `/resume`, or a fresh `claude` in the same tab — each time
+  # passing the original $ZELLIJ_TAB (the bare slug captured at pane creation).
+  # By then `_rename_tab` has painted the visible name to "⏸️ <slug>" or
+  # "▶️ <slug>", so a literal-name lookup misses and `tab_id` is empty. If we
+  # blindly rewrote the session file we'd clobber a valid TAB_ID with "",
+  # killing all subsequent _rename_tab repaints and cmd_send wake-ups for the
+  # rest of the worker's life — and finally leaking the tab when task-done
+  # reads the now-empty TAB_ID (#117). Preserve the existing TAB_ID instead.
+  if [[ -z "$tab_id" ]]; then
+    local existing_tab_id=""
+    if [[ -f "$f" ]]; then
+      existing_tab_id=$(_session_field "$f" TAB_ID || true)
+    fi
+    if [[ -n "$existing_tab_id" ]]; then
+      tab_id="$existing_tab_id"
+      _log "register: zellij list-tabs miss for tab=$tab — preserving existing TAB_ID=$tab_id role=$role"
+    else
+      _log "register: could not resolve tab_id for tab=$tab (zellij list-tabs returned no match)"
+    fi
+  fi
+
   printf 'ROLE=%s\nTAB=%s\nTAB_ID=%s\nREPO=%s\nSTATE=idle\nLAST_HEARTBEAT=%s\nAGENT=%s\nLOADOUT=%s\n' \
     "$role" "$tab" "$tab_id" "$repo" "$(_now)" "$agent" "$loadout" \
     | _atomic_write "$f"

--- a/claude-gh/bin/task-done
+++ b/claude-gh/bin/task-done
@@ -104,8 +104,18 @@ fi
 # focused at call time — same focused-tab bug class as #102/#103 in a
 # different binary; if the user switches focus mid-cleanup, the wrong tab
 # (e.g., PM's) gets closed and an active session can be destroyed (#107).
+#
+# Preferred source: $INFO_FILE, which task-work writes at tab creation and
+# nobody else touches. Independent of the radio session file's mid-life
+# state, so an in-session SessionStart re-register that clobbered the
+# session file's TAB_ID= (#117) can't break cleanup. Fall back to the
+# radio session file for workers whose task-work pre-dates the $INFO_FILE
+# TAB_ID write.
 _WORKER_TAB_ID=""
-if [[ -n "${ZELLIJ:-}" && -n "${TASK_FORCE_ROLE:-}" ]]; then
+if [[ -n "${ZELLIJ:-}" && -f "$INFO_FILE" ]]; then
+  _WORKER_TAB_ID=$(awk -F= '/^TAB_ID=/ { print $2; exit }' "$INFO_FILE")
+fi
+if [[ -z "$_WORKER_TAB_ID" && -n "${ZELLIJ:-}" && -n "${TASK_FORCE_ROLE:-}" ]]; then
   _SESSION_FILE="${TASK_FORCE_HOME:-$HOME/.task-force}/radio/sessions/${TASK_FORCE_ROLE}.info"
   if [[ -f "$_SESSION_FILE" ]]; then
     _WORKER_TAB_ID=$(awk -F= '/^TAB_ID=/ { print $2; exit }' "$_SESSION_FILE")

--- a/claude-gh/bin/task-work
+++ b/claude-gh/bin/task-work
@@ -238,6 +238,11 @@ fi
 # owned by task-work / task-done and is never written by radio, so it stays
 # authoritative regardless of any SessionStart/SessionEnd re-register churn
 # inside the worker.
+#
+# Race-safe: aw_zellij_tab_id_by_name strips ⏸/▶/❓ paint prefixes off the
+# zellij-side .name before matching against $SLUG, so a `radio busy` paint
+# that fires between aw_launch_tab returning and this lookup (worker's
+# SessionStart → first prompt) can't make the match miss (#117 review).
 INFO_TAB_ID=$(aw_zellij_tab_id_by_name "$SLUG" || true)
 if [[ -n "$INFO_TAB_ID" ]]; then
   printf 'TAB_ID=%s\n' "$INFO_TAB_ID" >> "$INFO_FILE"

--- a/claude-gh/bin/task-work
+++ b/claude-gh/bin/task-work
@@ -230,3 +230,16 @@ else
   echo "Started worker in $WORKTREE_DIR (branch: $BRANCH, base: $BASE_BRANCH)"
 fi
 # endregion:worktree-creation-post-info
+
+# region:info-tab-id
+# Persist the zellij tab_id of the worker's tab into $INFO_FILE so task-done
+# can scope `zellij action close-tab-by-id` to *this* worker even if the
+# radio session file's TAB_ID gets clobbered mid-life (#117). $INFO_FILE is
+# owned by task-work / task-done and is never written by radio, so it stays
+# authoritative regardless of any SessionStart/SessionEnd re-register churn
+# inside the worker.
+INFO_TAB_ID=$(aw_zellij_tab_id_by_name "$SLUG" || true)
+if [[ -n "$INFO_TAB_ID" ]]; then
+  printf 'TAB_ID=%s\n' "$INFO_TAB_ID" >> "$INFO_FILE"
+fi
+# endregion:info-tab-id

--- a/claude-jira/bin/radio
+++ b/claude-jira/bin/radio
@@ -293,11 +293,33 @@ cmd_register() {
   local tab_id=""
   if [[ -n "${ZELLIJ:-}" ]] && command -v zellij >/dev/null 2>&1; then
     tab_id=$(_zellij_tab_id_by_name "$tab" || true)
-    [[ -z "$tab_id" ]] && _log "register: could not resolve tab_id for tab=$tab (zellij list-tabs returned no match)"
   fi
 
   local f
   f=$(_session_file "$role")
+
+  # Re-register protection (#117): `SessionStart` fires again on `/compact`,
+  # `/clear`, `/resume`, or a fresh `claude` in the same tab — each time
+  # passing the original $ZELLIJ_TAB (the bare slug captured at pane creation).
+  # By then `_rename_tab` has painted the visible name to "⏸️ <slug>" or
+  # "▶️ <slug>", so a literal-name lookup misses and `tab_id` is empty. If we
+  # blindly rewrote the session file we'd clobber a valid TAB_ID with "",
+  # killing all subsequent _rename_tab repaints and cmd_send wake-ups for the
+  # rest of the worker's life — and finally leaking the tab when task-done
+  # reads the now-empty TAB_ID (#117). Preserve the existing TAB_ID instead.
+  if [[ -z "$tab_id" ]]; then
+    local existing_tab_id=""
+    if [[ -f "$f" ]]; then
+      existing_tab_id=$(_session_field "$f" TAB_ID || true)
+    fi
+    if [[ -n "$existing_tab_id" ]]; then
+      tab_id="$existing_tab_id"
+      _log "register: zellij list-tabs miss for tab=$tab — preserving existing TAB_ID=$tab_id role=$role"
+    else
+      _log "register: could not resolve tab_id for tab=$tab (zellij list-tabs returned no match)"
+    fi
+  fi
+
   printf 'ROLE=%s\nTAB=%s\nTAB_ID=%s\nREPO=%s\nSTATE=idle\nLAST_HEARTBEAT=%s\nAGENT=%s\nLOADOUT=%s\n' \
     "$role" "$tab" "$tab_id" "$repo" "$(_now)" "$agent" "$loadout" \
     | _atomic_write "$f"

--- a/claude-jira/bin/task-done
+++ b/claude-jira/bin/task-done
@@ -110,8 +110,18 @@ fi
 # focused at call time — same focused-tab bug class as #102/#103 in a
 # different binary; if the user switches focus mid-cleanup, the wrong tab
 # (e.g., PM's) gets closed and an active session can be destroyed (#107).
+#
+# Preferred source: $INFO_FILE, which task-work writes at tab creation and
+# nobody else touches. Independent of the radio session file's mid-life
+# state, so an in-session SessionStart re-register that clobbered the
+# session file's TAB_ID= (#117) can't break cleanup. Fall back to the
+# radio session file for workers whose task-work pre-dates the $INFO_FILE
+# TAB_ID write.
 _WORKER_TAB_ID=""
-if [[ -n "${ZELLIJ:-}" && -n "${TASK_FORCE_ROLE:-}" ]]; then
+if [[ -n "${ZELLIJ:-}" && -f "$INFO_FILE" ]]; then
+  _WORKER_TAB_ID=$(awk -F= '/^TAB_ID=/ { print $2; exit }' "$INFO_FILE")
+fi
+if [[ -z "$_WORKER_TAB_ID" && -n "${ZELLIJ:-}" && -n "${TASK_FORCE_ROLE:-}" ]]; then
   _SESSION_FILE="${TASK_FORCE_HOME:-$HOME/.task-force}/radio/sessions/${TASK_FORCE_ROLE}.info"
   if [[ -f "$_SESSION_FILE" ]]; then
     _WORKER_TAB_ID=$(awk -F= '/^TAB_ID=/ { print $2; exit }' "$_SESSION_FILE")

--- a/claude-jira/bin/task-work
+++ b/claude-jira/bin/task-work
@@ -166,3 +166,16 @@ echo "Opening zellij tab '$SLUG'..."
 aw_launch_tab "$SLUG" "$WORKTREE_DIR" "${RADIO_ENV_PREFIX}$(build_claude_cmd)"
 
 echo "Worker started in $WORKTREE_DIR (branch: $BRANCH, base: $BASE_BRANCH)"
+
+# region:info-tab-id
+# Persist the zellij tab_id of the worker's tab into $INFO_FILE so task-done
+# can scope `zellij action close-tab-by-id` to *this* worker even if the
+# radio session file's TAB_ID gets clobbered mid-life (#117). $INFO_FILE is
+# owned by task-work / task-done and is never written by radio, so it stays
+# authoritative regardless of any SessionStart/SessionEnd re-register churn
+# inside the worker.
+INFO_TAB_ID=$(aw_zellij_tab_id_by_name "$SLUG" || true)
+if [[ -n "$INFO_TAB_ID" ]]; then
+  printf 'TAB_ID=%s\n' "$INFO_TAB_ID" >> "$INFO_FILE"
+fi
+# endregion:info-tab-id

--- a/claude-jira/bin/task-work
+++ b/claude-jira/bin/task-work
@@ -174,6 +174,11 @@ echo "Worker started in $WORKTREE_DIR (branch: $BRANCH, base: $BASE_BRANCH)"
 # owned by task-work / task-done and is never written by radio, so it stays
 # authoritative regardless of any SessionStart/SessionEnd re-register churn
 # inside the worker.
+#
+# Race-safe: aw_zellij_tab_id_by_name strips ⏸/▶/❓ paint prefixes off the
+# zellij-side .name before matching against $SLUG, so a `radio busy` paint
+# that fires between aw_launch_tab returning and this lookup (worker's
+# SessionStart → first prompt) can't make the match miss (#117 review).
 INFO_TAB_ID=$(aw_zellij_tab_id_by_name "$SLUG" || true)
 if [[ -n "$INFO_TAB_ID" ]]; then
   printf 'TAB_ID=%s\n' "$INFO_TAB_ID" >> "$INFO_FILE"

--- a/claude-local/bin/radio
+++ b/claude-local/bin/radio
@@ -293,11 +293,33 @@ cmd_register() {
   local tab_id=""
   if [[ -n "${ZELLIJ:-}" ]] && command -v zellij >/dev/null 2>&1; then
     tab_id=$(_zellij_tab_id_by_name "$tab" || true)
-    [[ -z "$tab_id" ]] && _log "register: could not resolve tab_id for tab=$tab (zellij list-tabs returned no match)"
   fi
 
   local f
   f=$(_session_file "$role")
+
+  # Re-register protection (#117): `SessionStart` fires again on `/compact`,
+  # `/clear`, `/resume`, or a fresh `claude` in the same tab — each time
+  # passing the original $ZELLIJ_TAB (the bare slug captured at pane creation).
+  # By then `_rename_tab` has painted the visible name to "⏸️ <slug>" or
+  # "▶️ <slug>", so a literal-name lookup misses and `tab_id` is empty. If we
+  # blindly rewrote the session file we'd clobber a valid TAB_ID with "",
+  # killing all subsequent _rename_tab repaints and cmd_send wake-ups for the
+  # rest of the worker's life — and finally leaking the tab when task-done
+  # reads the now-empty TAB_ID (#117). Preserve the existing TAB_ID instead.
+  if [[ -z "$tab_id" ]]; then
+    local existing_tab_id=""
+    if [[ -f "$f" ]]; then
+      existing_tab_id=$(_session_field "$f" TAB_ID || true)
+    fi
+    if [[ -n "$existing_tab_id" ]]; then
+      tab_id="$existing_tab_id"
+      _log "register: zellij list-tabs miss for tab=$tab — preserving existing TAB_ID=$tab_id role=$role"
+    else
+      _log "register: could not resolve tab_id for tab=$tab (zellij list-tabs returned no match)"
+    fi
+  fi
+
   printf 'ROLE=%s\nTAB=%s\nTAB_ID=%s\nREPO=%s\nSTATE=idle\nLAST_HEARTBEAT=%s\nAGENT=%s\nLOADOUT=%s\n' \
     "$role" "$tab" "$tab_id" "$repo" "$(_now)" "$agent" "$loadout" \
     | _atomic_write "$f"

--- a/claude-local/bin/task-done
+++ b/claude-local/bin/task-done
@@ -106,8 +106,18 @@ fi
 # focused at call time — same focused-tab bug class as #102/#103 in a
 # different binary; if the user switches focus mid-cleanup, the wrong tab
 # (e.g., PM's) gets closed and an active session can be destroyed (#107).
+#
+# Preferred source: $INFO_FILE, which task-work writes at tab creation and
+# nobody else touches. Independent of the radio session file's mid-life
+# state, so an in-session SessionStart re-register that clobbered the
+# session file's TAB_ID= (#117) can't break cleanup. Fall back to the
+# radio session file for workers whose task-work pre-dates the $INFO_FILE
+# TAB_ID write.
 _WORKER_TAB_ID=""
-if [[ -n "${ZELLIJ:-}" && -n "${TASK_FORCE_ROLE:-}" ]]; then
+if [[ -n "${ZELLIJ:-}" && -f "$INFO_FILE" ]]; then
+  _WORKER_TAB_ID=$(awk -F= '/^TAB_ID=/ { print $2; exit }' "$INFO_FILE")
+fi
+if [[ -z "$_WORKER_TAB_ID" && -n "${ZELLIJ:-}" && -n "${TASK_FORCE_ROLE:-}" ]]; then
   _SESSION_FILE="${TASK_FORCE_HOME:-$HOME/.task-force}/radio/sessions/${TASK_FORCE_ROLE}.info"
   if [[ -f "$_SESSION_FILE" ]]; then
     _WORKER_TAB_ID=$(awk -F= '/^TAB_ID=/ { print $2; exit }' "$_SESSION_FILE")

--- a/claude-local/bin/task-work
+++ b/claude-local/bin/task-work
@@ -255,6 +255,11 @@ fi
 # owned by task-work / task-done and is never written by radio, so it stays
 # authoritative regardless of any SessionStart/SessionEnd re-register churn
 # inside the worker.
+#
+# Race-safe: aw_zellij_tab_id_by_name strips ⏸/▶/❓ paint prefixes off the
+# zellij-side .name before matching against $SLUG, so a `radio busy` paint
+# that fires between aw_launch_tab returning and this lookup (worker's
+# SessionStart → first prompt) can't make the match miss (#117 review).
 INFO_TAB_ID=$(aw_zellij_tab_id_by_name "$SLUG" || true)
 if [[ -n "$INFO_TAB_ID" ]]; then
   printf 'TAB_ID=%s\n' "$INFO_TAB_ID" >> "$INFO_FILE"

--- a/claude-local/bin/task-work
+++ b/claude-local/bin/task-work
@@ -247,3 +247,16 @@ else
   echo "Started worker in $WORKTREE_DIR (branch: $BRANCH, base: $BASE_BRANCH)"
 fi
 # endregion:worktree-creation-post-info
+
+# region:info-tab-id
+# Persist the zellij tab_id of the worker's tab into $INFO_FILE so task-done
+# can scope `zellij action close-tab-by-id` to *this* worker even if the
+# radio session file's TAB_ID gets clobbered mid-life (#117). $INFO_FILE is
+# owned by task-work / task-done and is never written by radio, so it stays
+# authoritative regardless of any SessionStart/SessionEnd re-register churn
+# inside the worker.
+INFO_TAB_ID=$(aw_zellij_tab_id_by_name "$SLUG" || true)
+if [[ -n "$INFO_TAB_ID" ]]; then
+  printf 'TAB_ID=%s\n' "$INFO_TAB_ID" >> "$INFO_FILE"
+fi
+# endregion:info-tab-id

--- a/claude-notion/bin/radio
+++ b/claude-notion/bin/radio
@@ -293,11 +293,33 @@ cmd_register() {
   local tab_id=""
   if [[ -n "${ZELLIJ:-}" ]] && command -v zellij >/dev/null 2>&1; then
     tab_id=$(_zellij_tab_id_by_name "$tab" || true)
-    [[ -z "$tab_id" ]] && _log "register: could not resolve tab_id for tab=$tab (zellij list-tabs returned no match)"
   fi
 
   local f
   f=$(_session_file "$role")
+
+  # Re-register protection (#117): `SessionStart` fires again on `/compact`,
+  # `/clear`, `/resume`, or a fresh `claude` in the same tab — each time
+  # passing the original $ZELLIJ_TAB (the bare slug captured at pane creation).
+  # By then `_rename_tab` has painted the visible name to "⏸️ <slug>" or
+  # "▶️ <slug>", so a literal-name lookup misses and `tab_id` is empty. If we
+  # blindly rewrote the session file we'd clobber a valid TAB_ID with "",
+  # killing all subsequent _rename_tab repaints and cmd_send wake-ups for the
+  # rest of the worker's life — and finally leaking the tab when task-done
+  # reads the now-empty TAB_ID (#117). Preserve the existing TAB_ID instead.
+  if [[ -z "$tab_id" ]]; then
+    local existing_tab_id=""
+    if [[ -f "$f" ]]; then
+      existing_tab_id=$(_session_field "$f" TAB_ID || true)
+    fi
+    if [[ -n "$existing_tab_id" ]]; then
+      tab_id="$existing_tab_id"
+      _log "register: zellij list-tabs miss for tab=$tab — preserving existing TAB_ID=$tab_id role=$role"
+    else
+      _log "register: could not resolve tab_id for tab=$tab (zellij list-tabs returned no match)"
+    fi
+  fi
+
   printf 'ROLE=%s\nTAB=%s\nTAB_ID=%s\nREPO=%s\nSTATE=idle\nLAST_HEARTBEAT=%s\nAGENT=%s\nLOADOUT=%s\n' \
     "$role" "$tab" "$tab_id" "$repo" "$(_now)" "$agent" "$loadout" \
     | _atomic_write "$f"

--- a/claude-notion/bin/task-done
+++ b/claude-notion/bin/task-done
@@ -104,8 +104,18 @@ fi
 # focused at call time — same focused-tab bug class as #102/#103 in a
 # different binary; if the user switches focus mid-cleanup, the wrong tab
 # (e.g., PM's) gets closed and an active session can be destroyed (#107).
+#
+# Preferred source: $INFO_FILE, which task-work writes at tab creation and
+# nobody else touches. Independent of the radio session file's mid-life
+# state, so an in-session SessionStart re-register that clobbered the
+# session file's TAB_ID= (#117) can't break cleanup. Fall back to the
+# radio session file for workers whose task-work pre-dates the $INFO_FILE
+# TAB_ID write.
 _WORKER_TAB_ID=""
-if [[ -n "${ZELLIJ:-}" && -n "${TASK_FORCE_ROLE:-}" ]]; then
+if [[ -n "${ZELLIJ:-}" && -f "$INFO_FILE" ]]; then
+  _WORKER_TAB_ID=$(awk -F= '/^TAB_ID=/ { print $2; exit }' "$INFO_FILE")
+fi
+if [[ -z "$_WORKER_TAB_ID" && -n "${ZELLIJ:-}" && -n "${TASK_FORCE_ROLE:-}" ]]; then
   _SESSION_FILE="${TASK_FORCE_HOME:-$HOME/.task-force}/radio/sessions/${TASK_FORCE_ROLE}.info"
   if [[ -f "$_SESSION_FILE" ]]; then
     _WORKER_TAB_ID=$(awk -F= '/^TAB_ID=/ { print $2; exit }' "$_SESSION_FILE")

--- a/claude-notion/bin/task-work
+++ b/claude-notion/bin/task-work
@@ -227,3 +227,16 @@ else
   echo "Started worker in $WORKTREE_DIR (branch: $BRANCH, base: $BASE_BRANCH)"
 fi
 # endregion:worktree-creation-post-info
+
+# region:info-tab-id
+# Persist the zellij tab_id of the worker's tab into $INFO_FILE so task-done
+# can scope `zellij action close-tab-by-id` to *this* worker even if the
+# radio session file's TAB_ID gets clobbered mid-life (#117). $INFO_FILE is
+# owned by task-work / task-done and is never written by radio, so it stays
+# authoritative regardless of any SessionStart/SessionEnd re-register churn
+# inside the worker.
+INFO_TAB_ID=$(aw_zellij_tab_id_by_name "$SLUG" || true)
+if [[ -n "$INFO_TAB_ID" ]]; then
+  printf 'TAB_ID=%s\n' "$INFO_TAB_ID" >> "$INFO_FILE"
+fi
+# endregion:info-tab-id

--- a/claude-notion/bin/task-work
+++ b/claude-notion/bin/task-work
@@ -235,6 +235,11 @@ fi
 # owned by task-work / task-done and is never written by radio, so it stays
 # authoritative regardless of any SessionStart/SessionEnd re-register churn
 # inside the worker.
+#
+# Race-safe: aw_zellij_tab_id_by_name strips ⏸/▶/❓ paint prefixes off the
+# zellij-side .name before matching against $SLUG, so a `radio busy` paint
+# that fires between aw_launch_tab returning and this lookup (worker's
+# SessionStart → first prompt) can't make the match miss (#117 review).
 INFO_TAB_ID=$(aw_zellij_tab_id_by_name "$SLUG" || true)
 if [[ -n "$INFO_TAB_ID" ]]; then
   printf 'TAB_ID=%s\n' "$INFO_TAB_ID" >> "$INFO_FILE"

--- a/kiro-gh/bin/radio
+++ b/kiro-gh/bin/radio
@@ -293,11 +293,33 @@ cmd_register() {
   local tab_id=""
   if [[ -n "${ZELLIJ:-}" ]] && command -v zellij >/dev/null 2>&1; then
     tab_id=$(_zellij_tab_id_by_name "$tab" || true)
-    [[ -z "$tab_id" ]] && _log "register: could not resolve tab_id for tab=$tab (zellij list-tabs returned no match)"
   fi
 
   local f
   f=$(_session_file "$role")
+
+  # Re-register protection (#117): `SessionStart` fires again on `/compact`,
+  # `/clear`, `/resume`, or a fresh `claude` in the same tab — each time
+  # passing the original $ZELLIJ_TAB (the bare slug captured at pane creation).
+  # By then `_rename_tab` has painted the visible name to "⏸️ <slug>" or
+  # "▶️ <slug>", so a literal-name lookup misses and `tab_id` is empty. If we
+  # blindly rewrote the session file we'd clobber a valid TAB_ID with "",
+  # killing all subsequent _rename_tab repaints and cmd_send wake-ups for the
+  # rest of the worker's life — and finally leaking the tab when task-done
+  # reads the now-empty TAB_ID (#117). Preserve the existing TAB_ID instead.
+  if [[ -z "$tab_id" ]]; then
+    local existing_tab_id=""
+    if [[ -f "$f" ]]; then
+      existing_tab_id=$(_session_field "$f" TAB_ID || true)
+    fi
+    if [[ -n "$existing_tab_id" ]]; then
+      tab_id="$existing_tab_id"
+      _log "register: zellij list-tabs miss for tab=$tab — preserving existing TAB_ID=$tab_id role=$role"
+    else
+      _log "register: could not resolve tab_id for tab=$tab (zellij list-tabs returned no match)"
+    fi
+  fi
+
   printf 'ROLE=%s\nTAB=%s\nTAB_ID=%s\nREPO=%s\nSTATE=idle\nLAST_HEARTBEAT=%s\nAGENT=%s\nLOADOUT=%s\n' \
     "$role" "$tab" "$tab_id" "$repo" "$(_now)" "$agent" "$loadout" \
     | _atomic_write "$f"

--- a/kiro-gh/bin/task-done
+++ b/kiro-gh/bin/task-done
@@ -104,8 +104,18 @@ fi
 # focused at call time — same focused-tab bug class as #102/#103 in a
 # different binary; if the user switches focus mid-cleanup, the wrong tab
 # (e.g., PM's) gets closed and an active session can be destroyed (#107).
+#
+# Preferred source: $INFO_FILE, which task-work writes at tab creation and
+# nobody else touches. Independent of the radio session file's mid-life
+# state, so an in-session SessionStart re-register that clobbered the
+# session file's TAB_ID= (#117) can't break cleanup. Fall back to the
+# radio session file for workers whose task-work pre-dates the $INFO_FILE
+# TAB_ID write.
 _WORKER_TAB_ID=""
-if [[ -n "${ZELLIJ:-}" && -n "${TASK_FORCE_ROLE:-}" ]]; then
+if [[ -n "${ZELLIJ:-}" && -f "$INFO_FILE" ]]; then
+  _WORKER_TAB_ID=$(awk -F= '/^TAB_ID=/ { print $2; exit }' "$INFO_FILE")
+fi
+if [[ -z "$_WORKER_TAB_ID" && -n "${ZELLIJ:-}" && -n "${TASK_FORCE_ROLE:-}" ]]; then
   _SESSION_FILE="${TASK_FORCE_HOME:-$HOME/.task-force}/radio/sessions/${TASK_FORCE_ROLE}.info"
   if [[ -f "$_SESSION_FILE" ]]; then
     _WORKER_TAB_ID=$(awk -F= '/^TAB_ID=/ { print $2; exit }' "$_SESSION_FILE")

--- a/kiro-gh/bin/task-work
+++ b/kiro-gh/bin/task-work
@@ -236,6 +236,11 @@ fi
 # owned by task-work / task-done and is never written by radio, so it stays
 # authoritative regardless of any SessionStart/SessionEnd re-register churn
 # inside the worker.
+#
+# Race-safe: aw_zellij_tab_id_by_name strips ⏸/▶/❓ paint prefixes off the
+# zellij-side .name before matching against $SLUG, so a `radio busy` paint
+# that fires between aw_launch_tab returning and this lookup (worker's
+# SessionStart → first prompt) can't make the match miss (#117 review).
 INFO_TAB_ID=$(aw_zellij_tab_id_by_name "$SLUG" || true)
 if [[ -n "$INFO_TAB_ID" ]]; then
   printf 'TAB_ID=%s\n' "$INFO_TAB_ID" >> "$INFO_FILE"

--- a/kiro-gh/bin/task-work
+++ b/kiro-gh/bin/task-work
@@ -228,3 +228,16 @@ else
   echo "Started $desc in $WORKTREE_DIR (branch: $BRANCH, base: $BASE_BRANCH)"
 fi
 # endregion:worktree-creation-post-info
+
+# region:info-tab-id
+# Persist the zellij tab_id of the worker's tab into $INFO_FILE so task-done
+# can scope `zellij action close-tab-by-id` to *this* worker even if the
+# radio session file's TAB_ID gets clobbered mid-life (#117). $INFO_FILE is
+# owned by task-work / task-done and is never written by radio, so it stays
+# authoritative regardless of any SessionStart/SessionEnd re-register churn
+# inside the worker.
+INFO_TAB_ID=$(aw_zellij_tab_id_by_name "$SLUG" || true)
+if [[ -n "$INFO_TAB_ID" ]]; then
+  printf 'TAB_ID=%s\n' "$INFO_TAB_ID" >> "$INFO_FILE"
+fi
+# endregion:info-tab-id

--- a/kiro-local/bin/radio
+++ b/kiro-local/bin/radio
@@ -293,11 +293,33 @@ cmd_register() {
   local tab_id=""
   if [[ -n "${ZELLIJ:-}" ]] && command -v zellij >/dev/null 2>&1; then
     tab_id=$(_zellij_tab_id_by_name "$tab" || true)
-    [[ -z "$tab_id" ]] && _log "register: could not resolve tab_id for tab=$tab (zellij list-tabs returned no match)"
   fi
 
   local f
   f=$(_session_file "$role")
+
+  # Re-register protection (#117): `SessionStart` fires again on `/compact`,
+  # `/clear`, `/resume`, or a fresh `claude` in the same tab — each time
+  # passing the original $ZELLIJ_TAB (the bare slug captured at pane creation).
+  # By then `_rename_tab` has painted the visible name to "⏸️ <slug>" or
+  # "▶️ <slug>", so a literal-name lookup misses and `tab_id` is empty. If we
+  # blindly rewrote the session file we'd clobber a valid TAB_ID with "",
+  # killing all subsequent _rename_tab repaints and cmd_send wake-ups for the
+  # rest of the worker's life — and finally leaking the tab when task-done
+  # reads the now-empty TAB_ID (#117). Preserve the existing TAB_ID instead.
+  if [[ -z "$tab_id" ]]; then
+    local existing_tab_id=""
+    if [[ -f "$f" ]]; then
+      existing_tab_id=$(_session_field "$f" TAB_ID || true)
+    fi
+    if [[ -n "$existing_tab_id" ]]; then
+      tab_id="$existing_tab_id"
+      _log "register: zellij list-tabs miss for tab=$tab — preserving existing TAB_ID=$tab_id role=$role"
+    else
+      _log "register: could not resolve tab_id for tab=$tab (zellij list-tabs returned no match)"
+    fi
+  fi
+
   printf 'ROLE=%s\nTAB=%s\nTAB_ID=%s\nREPO=%s\nSTATE=idle\nLAST_HEARTBEAT=%s\nAGENT=%s\nLOADOUT=%s\n' \
     "$role" "$tab" "$tab_id" "$repo" "$(_now)" "$agent" "$loadout" \
     | _atomic_write "$f"

--- a/kiro-local/bin/task-done
+++ b/kiro-local/bin/task-done
@@ -106,8 +106,18 @@ fi
 # focused at call time — same focused-tab bug class as #102/#103 in a
 # different binary; if the user switches focus mid-cleanup, the wrong tab
 # (e.g., PM's) gets closed and an active session can be destroyed (#107).
+#
+# Preferred source: $INFO_FILE, which task-work writes at tab creation and
+# nobody else touches. Independent of the radio session file's mid-life
+# state, so an in-session SessionStart re-register that clobbered the
+# session file's TAB_ID= (#117) can't break cleanup. Fall back to the
+# radio session file for workers whose task-work pre-dates the $INFO_FILE
+# TAB_ID write.
 _WORKER_TAB_ID=""
-if [[ -n "${ZELLIJ:-}" && -n "${TASK_FORCE_ROLE:-}" ]]; then
+if [[ -n "${ZELLIJ:-}" && -f "$INFO_FILE" ]]; then
+  _WORKER_TAB_ID=$(awk -F= '/^TAB_ID=/ { print $2; exit }' "$INFO_FILE")
+fi
+if [[ -z "$_WORKER_TAB_ID" && -n "${ZELLIJ:-}" && -n "${TASK_FORCE_ROLE:-}" ]]; then
   _SESSION_FILE="${TASK_FORCE_HOME:-$HOME/.task-force}/radio/sessions/${TASK_FORCE_ROLE}.info"
   if [[ -f "$_SESSION_FILE" ]]; then
     _WORKER_TAB_ID=$(awk -F= '/^TAB_ID=/ { print $2; exit }' "$_SESSION_FILE")

--- a/kiro-local/bin/task-work
+++ b/kiro-local/bin/task-work
@@ -249,3 +249,16 @@ else
   echo "Started $desc in $WORKTREE_DIR (branch: $BRANCH, base: $BASE_BRANCH)"
 fi
 # endregion:worktree-creation-post-info
+
+# region:info-tab-id
+# Persist the zellij tab_id of the worker's tab into $INFO_FILE so task-done
+# can scope `zellij action close-tab-by-id` to *this* worker even if the
+# radio session file's TAB_ID gets clobbered mid-life (#117). $INFO_FILE is
+# owned by task-work / task-done and is never written by radio, so it stays
+# authoritative regardless of any SessionStart/SessionEnd re-register churn
+# inside the worker.
+INFO_TAB_ID=$(aw_zellij_tab_id_by_name "$SLUG" || true)
+if [[ -n "$INFO_TAB_ID" ]]; then
+  printf 'TAB_ID=%s\n' "$INFO_TAB_ID" >> "$INFO_FILE"
+fi
+# endregion:info-tab-id

--- a/kiro-local/bin/task-work
+++ b/kiro-local/bin/task-work
@@ -257,6 +257,11 @@ fi
 # owned by task-work / task-done and is never written by radio, so it stays
 # authoritative regardless of any SessionStart/SessionEnd re-register churn
 # inside the worker.
+#
+# Race-safe: aw_zellij_tab_id_by_name strips ⏸/▶/❓ paint prefixes off the
+# zellij-side .name before matching against $SLUG, so a `radio busy` paint
+# that fires between aw_launch_tab returning and this lookup (worker's
+# SessionStart → first prompt) can't make the match miss (#117 review).
 INFO_TAB_ID=$(aw_zellij_tab_id_by_name "$SLUG" || true)
 if [[ -n "$INFO_TAB_ID" ]]; then
   printf 'TAB_ID=%s\n' "$INFO_TAB_ID" >> "$INFO_FILE"

--- a/kiro-notion/bin/radio
+++ b/kiro-notion/bin/radio
@@ -293,11 +293,33 @@ cmd_register() {
   local tab_id=""
   if [[ -n "${ZELLIJ:-}" ]] && command -v zellij >/dev/null 2>&1; then
     tab_id=$(_zellij_tab_id_by_name "$tab" || true)
-    [[ -z "$tab_id" ]] && _log "register: could not resolve tab_id for tab=$tab (zellij list-tabs returned no match)"
   fi
 
   local f
   f=$(_session_file "$role")
+
+  # Re-register protection (#117): `SessionStart` fires again on `/compact`,
+  # `/clear`, `/resume`, or a fresh `claude` in the same tab — each time
+  # passing the original $ZELLIJ_TAB (the bare slug captured at pane creation).
+  # By then `_rename_tab` has painted the visible name to "⏸️ <slug>" or
+  # "▶️ <slug>", so a literal-name lookup misses and `tab_id` is empty. If we
+  # blindly rewrote the session file we'd clobber a valid TAB_ID with "",
+  # killing all subsequent _rename_tab repaints and cmd_send wake-ups for the
+  # rest of the worker's life — and finally leaking the tab when task-done
+  # reads the now-empty TAB_ID (#117). Preserve the existing TAB_ID instead.
+  if [[ -z "$tab_id" ]]; then
+    local existing_tab_id=""
+    if [[ -f "$f" ]]; then
+      existing_tab_id=$(_session_field "$f" TAB_ID || true)
+    fi
+    if [[ -n "$existing_tab_id" ]]; then
+      tab_id="$existing_tab_id"
+      _log "register: zellij list-tabs miss for tab=$tab — preserving existing TAB_ID=$tab_id role=$role"
+    else
+      _log "register: could not resolve tab_id for tab=$tab (zellij list-tabs returned no match)"
+    fi
+  fi
+
   printf 'ROLE=%s\nTAB=%s\nTAB_ID=%s\nREPO=%s\nSTATE=idle\nLAST_HEARTBEAT=%s\nAGENT=%s\nLOADOUT=%s\n' \
     "$role" "$tab" "$tab_id" "$repo" "$(_now)" "$agent" "$loadout" \
     | _atomic_write "$f"

--- a/kiro-notion/bin/task-done
+++ b/kiro-notion/bin/task-done
@@ -104,8 +104,18 @@ fi
 # focused at call time — same focused-tab bug class as #102/#103 in a
 # different binary; if the user switches focus mid-cleanup, the wrong tab
 # (e.g., PM's) gets closed and an active session can be destroyed (#107).
+#
+# Preferred source: $INFO_FILE, which task-work writes at tab creation and
+# nobody else touches. Independent of the radio session file's mid-life
+# state, so an in-session SessionStart re-register that clobbered the
+# session file's TAB_ID= (#117) can't break cleanup. Fall back to the
+# radio session file for workers whose task-work pre-dates the $INFO_FILE
+# TAB_ID write.
 _WORKER_TAB_ID=""
-if [[ -n "${ZELLIJ:-}" && -n "${TASK_FORCE_ROLE:-}" ]]; then
+if [[ -n "${ZELLIJ:-}" && -f "$INFO_FILE" ]]; then
+  _WORKER_TAB_ID=$(awk -F= '/^TAB_ID=/ { print $2; exit }' "$INFO_FILE")
+fi
+if [[ -z "$_WORKER_TAB_ID" && -n "${ZELLIJ:-}" && -n "${TASK_FORCE_ROLE:-}" ]]; then
   _SESSION_FILE="${TASK_FORCE_HOME:-$HOME/.task-force}/radio/sessions/${TASK_FORCE_ROLE}.info"
   if [[ -f "$_SESSION_FILE" ]]; then
     _WORKER_TAB_ID=$(awk -F= '/^TAB_ID=/ { print $2; exit }' "$_SESSION_FILE")

--- a/kiro-notion/bin/task-work
+++ b/kiro-notion/bin/task-work
@@ -238,6 +238,11 @@ fi
 # owned by task-work / task-done and is never written by radio, so it stays
 # authoritative regardless of any SessionStart/SessionEnd re-register churn
 # inside the worker.
+#
+# Race-safe: aw_zellij_tab_id_by_name strips ⏸/▶/❓ paint prefixes off the
+# zellij-side .name before matching against $SLUG, so a `radio busy` paint
+# that fires between aw_launch_tab returning and this lookup (worker's
+# SessionStart → first prompt) can't make the match miss (#117 review).
 INFO_TAB_ID=$(aw_zellij_tab_id_by_name "$SLUG" || true)
 if [[ -n "$INFO_TAB_ID" ]]; then
   printf 'TAB_ID=%s\n' "$INFO_TAB_ID" >> "$INFO_FILE"

--- a/kiro-notion/bin/task-work
+++ b/kiro-notion/bin/task-work
@@ -230,3 +230,16 @@ else
   echo "Started $desc in $WORKTREE_DIR (branch: $BRANCH, base: $BASE_BRANCH)"
 fi
 # endregion:worktree-creation-post-info
+
+# region:info-tab-id
+# Persist the zellij tab_id of the worker's tab into $INFO_FILE so task-done
+# can scope `zellij action close-tab-by-id` to *this* worker even if the
+# radio session file's TAB_ID gets clobbered mid-life (#117). $INFO_FILE is
+# owned by task-work / task-done and is never written by radio, so it stays
+# authoritative regardless of any SessionStart/SessionEnd re-register churn
+# inside the worker.
+INFO_TAB_ID=$(aw_zellij_tab_id_by_name "$SLUG" || true)
+if [[ -n "$INFO_TAB_ID" ]]; then
+  printf 'TAB_ID=%s\n' "$INFO_TAB_ID" >> "$INFO_FILE"
+fi
+# endregion:info-tab-id

--- a/lib/zellij-tab.sh
+++ b/lib/zellij-tab.sh
@@ -20,6 +20,23 @@
 # zellij-native path for "new tab running this command" and preserves the
 # session UI.
 
+# Resolve a freshly-created tab's stable zellij tab_id by its name. Used by
+# task-work right after aw_launch_tab to persist TAB_ID into $INFO_FILE so
+# task-done has an authoritative source independent of the radio session
+# file's mid-life state (#117). Empty stdout means "could not resolve" —
+# zellij not running, jq absent, or the tab isn't visible yet — caller
+# must treat that as a soft skip (task-done falls back to the radio
+# session file in that case).
+aw_zellij_tab_id_by_name() {
+  local target="$1"
+  [[ -n "$target" ]] || return 0
+  command -v zellij >/dev/null 2>&1 || return 0
+  command -v jq >/dev/null 2>&1 || return 0
+  zellij action list-tabs --json 2>/dev/null \
+    | jq -r --arg n "$target" \
+        '[.[] | select(.name == $n) | .tab_id] | .[0] // empty' 2>/dev/null
+}
+
 # Launch a new zellij tab. See file header for semantics.
 aw_launch_tab() {
   local slug="$1"

--- a/lib/zellij-tab.sh
+++ b/lib/zellij-tab.sh
@@ -27,6 +27,14 @@
 # zellij not running, jq absent, or the tab isn't visible yet — caller
 # must treat that as a soft skip (task-done falls back to the radio
 # session file in that case).
+#
+# Race-safe against in-flight `radio busy` / `radio ready` paints (#117
+# review): the worker's SessionStart → first-prompt → radio busy chain can
+# repaint the tab name to "▶️ <slug>" between aw_launch_tab returning and
+# this lookup running. The jq filter strips known paint prefixes from
+# .name before comparing against $n (which is always the bare slug, since
+# task-work passes $SLUG), so the match still hits regardless of paint
+# state. Keep this prefix list in sync with `_rename_tab` in `radio`.
 aw_zellij_tab_id_by_name() {
   local target="$1"
   [[ -n "$target" ]] || return 0
@@ -34,7 +42,13 @@ aw_zellij_tab_id_by_name() {
   command -v jq >/dev/null 2>&1 || return 0
   zellij action list-tabs --json 2>/dev/null \
     | jq -r --arg n "$target" \
-        '[.[] | select(.name == $n) | .tab_id] | .[0] // empty' 2>/dev/null
+        '[.[]
+          | select((.name
+                    | sub("^⏸️ "; "")
+                    | sub("^▶️ "; "")
+                    | sub("^❓ "; "")) == $n)
+          | .tab_id]
+         | .[0] // empty' 2>/dev/null
 }
 
 # Launch a new zellij tab. See file header for semantics.

--- a/tests/claude_gh_task_work.bats
+++ b/tests/claude_gh_task_work.bats
@@ -424,6 +424,27 @@ _setup_stale_local_base() {
   assert_failure
 }
 
+@test ".info records TAB_ID even when the tab is already paint-prefixed at lookup time (#117 review)" {
+  # Race scenario: between aw_launch_tab returning and task-work's tab_id
+  # lookup, the worker's SessionStart → first prompt → `radio busy` chain
+  # repaints the tab name to "▶️ my-feature". A literal-name jq match would
+  # miss; aw_zellij_tab_id_by_name's prefix-stripping filter must still hit.
+  export STUB_ZELLIJ_TABS_JSON='[{"name":"▶️ my-feature","tab_id":12}]'
+  run "$CLAUDE_GH_TASK_WORK" my-feature
+  assert_success
+  source "$WORKTREE_BASE/.my-feature.info"
+  assert_equal "${TAB_ID:-}" "12"
+}
+
+@test ".info records TAB_ID when the tab is idle-painted (⏸️ <slug>) at lookup time (#117 review)" {
+  # Symmetric to the busy-paint case — idle paint must also be stripped.
+  export STUB_ZELLIJ_TABS_JSON='[{"name":"⏸️ my-feature","tab_id":12}]'
+  run "$CLAUDE_GH_TASK_WORK" my-feature
+  assert_success
+  source "$WORKTREE_BASE/.my-feature.info"
+  assert_equal "${TAB_ID:-}" "12"
+}
+
 # ---------------------------------------------------------------------------
 # Zellij interactions
 # ---------------------------------------------------------------------------

--- a/tests/claude_gh_task_work.bats
+++ b/tests/claude_gh_task_work.bats
@@ -402,6 +402,28 @@ _setup_stale_local_base() {
   assert_equal "${GH_URL:-}" ""
 }
 
+@test ".info records TAB_ID resolved from zellij list-tabs (#117)" {
+  # The zellij stub returns whatever STUB_ZELLIJ_TABS_JSON advertises for
+  # `action list-tabs --json`. task-work, post-launch, looks up the tab by
+  # name and appends TAB_ID= to $INFO_FILE so task-done has an authoritative
+  # source independent of the radio session file's mid-life state.
+  export STUB_ZELLIJ_TABS_JSON='[{"name":"my-feature","tab_id":12}]'
+  run "$CLAUDE_GH_TASK_WORK" my-feature
+  assert_success
+  source "$WORKTREE_BASE/.my-feature.info"
+  assert_equal "${TAB_ID:-}" "12"
+}
+
+@test ".info has no TAB_ID line when zellij list-tabs misses (graceful no-op)" {
+  # No STUB_ZELLIJ_TABS_JSON → stub returns empty → aw_zellij_tab_id_by_name
+  # returns empty → no TAB_ID= line is appended. task-done's fallback (radio
+  # session file) covers this case.
+  run "$CLAUDE_GH_TASK_WORK" my-feature
+  assert_success
+  run grep "^TAB_ID=" "$WORKTREE_BASE/.my-feature.info"
+  assert_failure
+}
+
 # ---------------------------------------------------------------------------
 # Zellij interactions
 # ---------------------------------------------------------------------------

--- a/tests/radio_lifecycle.bats
+++ b/tests/radio_lifecycle.bats
@@ -203,3 +203,77 @@ teardown() {
   # Same tab id as the original register call — re-seed re-resolved by name.
   assert_output --partial "TAB_ID=7"
 }
+
+# ----- re-register preserves TAB_ID on zellij lookup miss (#117) ------------
+#
+# The #117 failure mode: a worker's $ZELLIJ_TAB env var sticks to the bare
+# slug captured at pane creation, but the visible tab name has since been
+# painted to "⏸️ <slug>" / "▶️ <slug>" by _rename_tab. When SessionStart
+# fires a second time (because of /compact, /clear, /resume, or a fresh
+# `claude` in the same tab), the hook re-runs `radio register --tab $ZELLIJ_TAB`
+# with the bare slug and the literal-name lookup in zellij misses. Pre-fix,
+# we'd blindly rewrite TAB_ID= to empty — killing _rename_tab and cmd_send
+# for the rest of the worker's life, and finally leaking the tab when
+# task-done read the now-empty TAB_ID.
+
+@test "register: re-register preserves existing TAB_ID when zellij list-tabs misses (#117)" {
+  setup_stubs
+  seed_zellij_tabs worker-foo
+  export ZELLIJ=fake
+
+  # First register: finds tab_id=7 by name and persists it.
+  "$RADIO" register --role worker-foo --tab worker-foo --agent claude
+  local sess="$TASK_FORCE_HOME/radio/sessions/worker-foo.info"
+  run grep "^TAB_ID=" "$sess"
+  assert_output --partial "TAB_ID=7"
+
+  # Now simulate the second SessionStart: the visible tab has been painted
+  # to "▶️ worker-foo", so the bare-name lookup misses. Re-seed the stub
+  # fixture so only the prefixed entry is advertised.
+  export STUB_ZELLIJ_TABS_JSON='[{"name":"▶️ worker-foo","tab_id":7}]'
+  export STUB_ZELLIJ_PANES_JSON='[{"id":700,"is_plugin":false,"is_focused":true,"tab_id":7}]'
+
+  "$RADIO" register --role worker-foo --tab worker-foo --agent claude
+  # TAB_ID must still be 7 — preserved, not clobbered to empty.
+  run grep "^TAB_ID=" "$sess"
+  assert_output "TAB_ID=7"
+  run cat "$TASK_FORCE_HOME/radio/log"
+  assert_output --partial "preserving existing TAB_ID=7"
+  refute_output --partial "could not resolve tab_id for tab=worker-foo"
+}
+
+@test "register: first-time lookup miss with no existing file still logs the resolve-failure (#117)" {
+  # Layer 1 must not change first-time behavior: a brand-new register for a
+  # role with no prior session file, when zellij can't resolve the tab,
+  # should still write TAB_ID= empty and log the "could not resolve" line.
+  setup_stubs
+  export ZELLIJ=fake
+  # No stub fixture → list-tabs returns empty.
+
+  "$RADIO" register --role worker-new --tab worker-new --agent claude
+  local sess="$TASK_FORCE_HOME/radio/sessions/worker-new.info"
+  run grep "^TAB_ID=" "$sess"
+  assert_output "TAB_ID="
+  run cat "$TASK_FORCE_HOME/radio/log"
+  assert_output --partial "could not resolve tab_id for tab=worker-new"
+  refute_output --partial "preserving existing TAB_ID"
+}
+
+@test "register: re-register with empty existing TAB_ID falls through to the resolve-failure path" {
+  # Edge case: prior session file exists but TAB_ID= is empty (e.g. zellij
+  # wasn't running at the original register). A subsequent re-register that
+  # also misses should NOT log "preserving" (nothing useful to preserve) —
+  # it should log the original "could not resolve" line, same as a first
+  # register would.
+  setup_stubs
+  export ZELLIJ=fake
+  # First register: no fixture → TAB_ID= empty in file.
+  "$RADIO" register --role worker-empty --tab worker-empty --agent claude
+
+  # Second register: still no fixture.
+  "$RADIO" register --role worker-empty --tab worker-empty --agent claude
+
+  run cat "$TASK_FORCE_HOME/radio/log"
+  assert_output --partial "could not resolve tab_id for tab=worker-empty"
+  refute_output --partial "preserving existing TAB_ID"
+}

--- a/tests/task_done_close_tab.bats
+++ b/tests/task_done_close_tab.bats
@@ -52,6 +52,16 @@ write_session_file() {
     > "$TASK_FORCE_HOME/radio/sessions/$ROLE.info"
 }
 
+# Append TAB_ID= to the worktree's $INFO_FILE. setup_worktree pre-seeds the
+# file with BASE_BRANCH/SLUG/NOTION_URL; the Layer 2 task-work change appends
+# TAB_ID= after the tab is opened, so the file ends up with TAB_ID as the
+# last line (which is what task-done's awk parser picks up by exit-on-first-
+# match).
+write_info_tab_id() {
+  local tab_id="$1"
+  printf 'TAB_ID=%s\n' "$tab_id" >> "$WORKTREE_BASE/.$SLUG.info"
+}
+
 # Returns the set of close-tab-flavored calls made against the zellij stub,
 # one per line.
 zellij_close_calls() {
@@ -158,4 +168,55 @@ zellij_close_calls() {
   assert_output --partial "Skipping zellij close-tab"
   run zellij_close_calls
   assert_output ""
+}
+
+# ---------------------------------------------------------------------------
+# Layer 2: $INFO_FILE is the authoritative TAB_ID source (#117)
+#
+# task-work now writes TAB_ID= into $INFO_FILE at tab-creation time, where
+# the radio binary never touches it. task-done reads from $INFO_FILE first
+# and only falls back to the radio session file. This protects close-tab
+# from any mid-session SessionStart re-register that clobbered the radio
+# session file's TAB_ID — the #117 regression scenario.
+# ---------------------------------------------------------------------------
+
+@test "close-tab prefers \$INFO_FILE TAB_ID over the radio session file (#117)" {
+  export ZELLIJ=fake-session
+  export TASK_FORCE_ROLE="$ROLE"
+  # Simulate the #117 mid-life clobber: radio session file's TAB_ID was
+  # wiped to empty by a re-register, but $INFO_FILE still has the right id.
+  write_info_tab_id 12
+  write_session_file ""
+
+  run "$CLAUDE_GH_TASK_DONE" --remove-worktree --force
+  assert_success
+  assert_stub_called zellij "action close-tab-by-id 12"
+  run zellij_close_calls
+  refute_output --partial "action close-tab"$'\n'
+}
+
+@test "close-tab falls back to radio session file when \$INFO_FILE has no TAB_ID (pre-fix worker)" {
+  # Worker started before the Layer 2 task-work change → $INFO_FILE doesn't
+  # carry TAB_ID. task-done should still recover the id via the radio
+  # session file (Layer 2 fallback).
+  export ZELLIJ=fake-session
+  export TASK_FORCE_ROLE="$ROLE"
+  # Do NOT call write_info_tab_id — $INFO_FILE has BASE_BRANCH/SLUG only.
+  write_session_file 7
+
+  run "$CLAUDE_GH_TASK_DONE" --remove-worktree --force
+  assert_success
+  assert_stub_called zellij "action close-tab-by-id 7"
+}
+
+@test "close-tab uses \$INFO_FILE TAB_ID even when the radio session file is missing entirely (#117)" {
+  # Defense in depth: \$INFO_FILE alone is enough to close the right tab.
+  export ZELLIJ=fake-session
+  export TASK_FORCE_ROLE="$ROLE"
+  write_info_tab_id 12
+  # No write_session_file call → no radio session file on disk.
+
+  run "$CLAUDE_GH_TASK_DONE" --remove-worktree --force
+  assert_success
+  assert_stub_called zellij "action close-tab-by-id 12"
 }

--- a/tools/check-drift.sh
+++ b/tools/check-drift.sh
@@ -24,6 +24,7 @@ GROUPS_DEFAULT=(
   "task-work-claude|worktree-creation-post-info|claude-gh/bin/task-work claude-local/bin/task-work claude-notion/bin/task-work"
   "task-work-kiro|worktree-creation-post-info|kiro-gh/bin/task-work kiro-local/bin/task-work kiro-notion/bin/task-work"
   "task-work|radio-env-injection|claude-gh/bin/task-work claude-jira/bin/task-work claude-local/bin/task-work claude-notion/bin/task-work kiro-gh/bin/task-work kiro-local/bin/task-work kiro-notion/bin/task-work"
+  "task-work|info-tab-id|claude-gh/bin/task-work claude-jira/bin/task-work claude-local/bin/task-work claude-notion/bin/task-work kiro-gh/bin/task-work kiro-local/bin/task-work kiro-notion/bin/task-work"
   "radio|body|claude-gh/bin/radio claude-jira/bin/radio claude-local/bin/radio claude-notion/bin/radio kiro-gh/bin/radio kiro-local/bin/radio kiro-notion/bin/radio"
   "task-pm-claude|body|claude-gh/bin/task-pm claude-jira/bin/task-pm claude-local/bin/task-pm claude-notion/bin/task-pm"
   "task-pm-kiro|body|kiro-gh/bin/task-pm kiro-local/bin/task-pm kiro-notion/bin/task-pm"


### PR DESCRIPTION
Fixes #117.

## Summary

`task-done --remove-worktree` was leaving worker zellij tabs orphaned whenever the worker's Claude session had re-initialized at least once (`/compact`, `/clear`, `/resume`, or a fresh `claude` in the same tab). Live log evidence in #117 traced the regression to `cmd_register` blindly rewriting `TAB_ID=` to empty when the post-paint tab name no longer matched the bare slug `$ZELLIJ_TAB` passes in.

Two layers:

- **Layer 1** — `cmd_register` (`radio`): on a zellij `list-tabs` miss, preserve an existing non-empty `TAB_ID=` from the session file instead of clobbering it. The "could not resolve" log line stays for the first-register-no-match case; a distinct "preserving existing TAB_ID=N" line covers the re-register path. Stops the cascade that breaks `_rename_tab` repaints and `cmd_send` wake-ups for the rest of the worker's life.
- **Layer 2** — `task-work` + `task-done`: persist the worker's `TAB_ID=` into `$INFO_FILE` after `aw_launch_tab` (via a new `aw_zellij_tab_id_by_name` helper in `lib/zellij-tab.sh`). `task-done` reads `$INFO_FILE` first, falls back to the radio session file for pre-fix workers. `$INFO_FILE` is owned by `task-work`/`task-done` and is never touched by radio, so close-tab survives any future mid-life radio-session-file accident.

Synced across all 7 `radio` copies, all 7 `task-work` copies, and all 7 `task-done` copies; drift check manifest extended with the new `task-work|info-tab-id` group.

## Test plan

- [x] `tests/radio_lifecycle.bats` — three new tests cover Layer 1: re-register preserves TAB_ID on lookup miss; first-time miss still logs "could not resolve"; re-register with empty existing TAB_ID falls through (no "preserving" log).
- [x] `tests/task_done_close_tab.bats` — three new tests cover Layer 2: prefer `$INFO_FILE`; fall back to session file when `$INFO_FILE` has no TAB_ID; close still works when the session file is missing.
- [x] `tests/claude_gh_task_work.bats` — two new tests cover the `$INFO_FILE` TAB_ID write (with and without a zellij fixture).
- [x] `tools/check-drift.sh` — 17/17 groups green (new `info-tab-id` group across all 7 task-work loadouts).
- [x] Full bats suite — 636/636 passing.
- [x] All four existing `#107` close-tab scenarios still pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)