### PR TITLE
Re-attempt awaiting-state radio trigger: wire PermissionRequest + PreToolUse(AskUserQuestion,ExitPlanMode) → radio awaiting (#119)

### DIFF
--- a/claude-gh/bin/radio
+++ b/claude-gh/bin/radio
@@ -19,6 +19,7 @@ Usage:
   radio register --role ROLE --tab TAB [--repo PATH] --agent claude|kiro [--loadout NAME]
   radio ready                            mark this role idle (and process pending)
   radio busy                             mark this role busy
+  radio awaiting                         mark this role awaiting user input
   radio unregister                       remove this role's session file
   radio orphans                          list session files with stale (>1h) heartbeat
 
@@ -103,6 +104,7 @@ _strip_tab_prefix() {
   local s="$1"
   s="${s#⏸️ }"
   s="${s#▶️ }"
+  s="${s#❓︎ }"
   printf '%s' "$s"
 }
 
@@ -235,6 +237,7 @@ _rename_tab() {
   case "$new_state" in
     idle) prefix="⏸️ " ;;
     busy) prefix="▶️ " ;;
+    awaiting) prefix="❓︎ " ;;
     *)    return 0 ;;
   esac
   new_name="${prefix}${bare}"
@@ -372,6 +375,7 @@ cmd_unregister() {
 
 cmd_ready() { _silent_exit_if_no_role; _update_state idle; }
 cmd_busy()  { _silent_exit_if_no_role; _update_state busy; }
+cmd_awaiting() { _silent_exit_if_no_role; _update_state awaiting; }
 
 cmd_send() {
   local to="" intent="" pr="" issue="" repo="" body=""
@@ -565,6 +569,7 @@ case "$sub" in
   register)    [[ -z "${TASK_FORCE_ROLE:-}" ]] && exit 0; cmd_register "$@" ;;
   ready)       cmd_ready ;;
   busy)        cmd_busy ;;
+  awaiting)    cmd_awaiting ;;
   unregister)  cmd_unregister ;;
   orphans)     cmd_orphans ;;
   -h|--help)   usage 0 ;;

--- a/claude-gh/bin/task-init
+++ b/claude-gh/bin/task-init
@@ -250,6 +250,7 @@ _radio_install_hooks() {
   local busy_cmd="radio busy"
   local stop_cmd="radio ready && radio check"
   local end_cmd="radio unregister"
+  local awaiting_cmd="radio awaiting"
 
   mkdir -p "$(dirname "$settings_file")"
   [[ -f "$settings_file" ]] || printf '%s\n' '{}' >"$settings_file"
@@ -263,16 +264,25 @@ _radio_install_hooks() {
     --arg ups  "$busy_cmd" \
     --arg stop "$stop_cmd" \
     --arg endcmd  "$end_cmd" \
+    --arg awaiting "$awaiting_cmd" \
     '
     def add_radio(arr; cmd):
       if (arr // []) | any((.hooks // []) | any((.command // "") | startswith("radio "))) then arr
       else (arr // []) + [{hooks: [{type: "command", command: cmd}]}]
       end;
+    def add_radio_matcher(arr; mtch; cmd):
+      if (arr // []) | any(((.matcher // "") == mtch) and ((.hooks // []) | any((.command // "") | startswith("radio ")))) then arr
+      else (arr // []) + [{matcher: mtch, hooks: [{type: "command", command: cmd}]}]
+      end;
     .hooks //= {}
-    | .hooks.SessionStart     = add_radio(.hooks.SessionStart;     $sess)
-    | .hooks.UserPromptSubmit = add_radio(.hooks.UserPromptSubmit; $ups)
-    | .hooks.Stop             = add_radio(.hooks.Stop;             $stop)
-    | .hooks.SessionEnd       = add_radio(.hooks.SessionEnd;       $endcmd)
+    | .hooks.SessionStart      = add_radio(.hooks.SessionStart;     $sess)
+    | .hooks.UserPromptSubmit  = add_radio(.hooks.UserPromptSubmit; $ups)
+    | .hooks.Stop              = add_radio(.hooks.Stop;             $stop)
+    | .hooks.SessionEnd        = add_radio(.hooks.SessionEnd;       $endcmd)
+    | .hooks.PermissionRequest = add_radio(.hooks.PermissionRequest; $awaiting)
+    | .hooks.PreToolUse        = add_radio_matcher(.hooks.PreToolUse; "AskUserQuestion"; $awaiting)
+    | .hooks.PreToolUse        = add_radio_matcher(.hooks.PreToolUse; "ExitPlanMode";    $awaiting)
+    | .hooks.PostToolUse       = add_radio(.hooks.PostToolUse;       $ups)
     | .permissions //= {}
     | .permissions.allow //= []
     | .permissions.allow = (

--- a/claude-jira/bin/radio
+++ b/claude-jira/bin/radio
@@ -19,6 +19,7 @@ Usage:
   radio register --role ROLE --tab TAB [--repo PATH] --agent claude|kiro [--loadout NAME]
   radio ready                            mark this role idle (and process pending)
   radio busy                             mark this role busy
+  radio awaiting                         mark this role awaiting user input
   radio unregister                       remove this role's session file
   radio orphans                          list session files with stale (>1h) heartbeat
 
@@ -103,6 +104,7 @@ _strip_tab_prefix() {
   local s="$1"
   s="${s#⏸️ }"
   s="${s#▶️ }"
+  s="${s#❓︎ }"
   printf '%s' "$s"
 }
 
@@ -235,6 +237,7 @@ _rename_tab() {
   case "$new_state" in
     idle) prefix="⏸️ " ;;
     busy) prefix="▶️ " ;;
+    awaiting) prefix="❓︎ " ;;
     *)    return 0 ;;
   esac
   new_name="${prefix}${bare}"
@@ -372,6 +375,7 @@ cmd_unregister() {
 
 cmd_ready() { _silent_exit_if_no_role; _update_state idle; }
 cmd_busy()  { _silent_exit_if_no_role; _update_state busy; }
+cmd_awaiting() { _silent_exit_if_no_role; _update_state awaiting; }
 
 cmd_send() {
   local to="" intent="" pr="" issue="" repo="" body=""
@@ -565,6 +569,7 @@ case "$sub" in
   register)    [[ -z "${TASK_FORCE_ROLE:-}" ]] && exit 0; cmd_register "$@" ;;
   ready)       cmd_ready ;;
   busy)        cmd_busy ;;
+  awaiting)    cmd_awaiting ;;
   unregister)  cmd_unregister ;;
   orphans)     cmd_orphans ;;
   -h|--help)   usage 0 ;;

--- a/claude-jira/bin/task-init
+++ b/claude-jira/bin/task-init
@@ -219,6 +219,7 @@ _radio_install_hooks() {
   local busy_cmd="radio busy"
   local stop_cmd="radio ready && radio check"
   local end_cmd="radio unregister"
+  local awaiting_cmd="radio awaiting"
 
   mkdir -p "$(dirname "$settings_file")"
   [[ -f "$settings_file" ]] || printf '%s\n' '{}' >"$settings_file"
@@ -235,16 +236,25 @@ _radio_install_hooks() {
     --arg ups  "$busy_cmd" \
     --arg stop "$stop_cmd" \
     --arg endcmd  "$end_cmd" \
+    --arg awaiting "$awaiting_cmd" \
     '
     def add_radio(arr; cmd):
       if (arr // []) | any((.hooks // []) | any((.command // "") | startswith("radio "))) then arr
       else (arr // []) + [{hooks: [{type: "command", command: cmd}]}]
       end;
+    def add_radio_matcher(arr; mtch; cmd):
+      if (arr // []) | any(((.matcher // "") == mtch) and ((.hooks // []) | any((.command // "") | startswith("radio ")))) then arr
+      else (arr // []) + [{matcher: mtch, hooks: [{type: "command", command: cmd}]}]
+      end;
     .hooks //= {}
-    | .hooks.SessionStart     = add_radio(.hooks.SessionStart;     $sess)
-    | .hooks.UserPromptSubmit = add_radio(.hooks.UserPromptSubmit; $ups)
-    | .hooks.Stop             = add_radio(.hooks.Stop;             $stop)
-    | .hooks.SessionEnd       = add_radio(.hooks.SessionEnd;       $endcmd)
+    | .hooks.SessionStart      = add_radio(.hooks.SessionStart;     $sess)
+    | .hooks.UserPromptSubmit  = add_radio(.hooks.UserPromptSubmit; $ups)
+    | .hooks.Stop              = add_radio(.hooks.Stop;             $stop)
+    | .hooks.SessionEnd        = add_radio(.hooks.SessionEnd;       $endcmd)
+    | .hooks.PermissionRequest = add_radio(.hooks.PermissionRequest; $awaiting)
+    | .hooks.PreToolUse        = add_radio_matcher(.hooks.PreToolUse; "AskUserQuestion"; $awaiting)
+    | .hooks.PreToolUse        = add_radio_matcher(.hooks.PreToolUse; "ExitPlanMode";    $awaiting)
+    | .hooks.PostToolUse       = add_radio(.hooks.PostToolUse;       $ups)
     | .permissions //= {}
     | .permissions.allow //= []
     | .permissions.allow = (

--- a/claude-local/bin/radio
+++ b/claude-local/bin/radio
@@ -19,6 +19,7 @@ Usage:
   radio register --role ROLE --tab TAB [--repo PATH] --agent claude|kiro [--loadout NAME]
   radio ready                            mark this role idle (and process pending)
   radio busy                             mark this role busy
+  radio awaiting                         mark this role awaiting user input
   radio unregister                       remove this role's session file
   radio orphans                          list session files with stale (>1h) heartbeat
 
@@ -103,6 +104,7 @@ _strip_tab_prefix() {
   local s="$1"
   s="${s#⏸️ }"
   s="${s#▶️ }"
+  s="${s#❓︎ }"
   printf '%s' "$s"
 }
 
@@ -235,6 +237,7 @@ _rename_tab() {
   case "$new_state" in
     idle) prefix="⏸️ " ;;
     busy) prefix="▶️ " ;;
+    awaiting) prefix="❓︎ " ;;
     *)    return 0 ;;
   esac
   new_name="${prefix}${bare}"
@@ -372,6 +375,7 @@ cmd_unregister() {
 
 cmd_ready() { _silent_exit_if_no_role; _update_state idle; }
 cmd_busy()  { _silent_exit_if_no_role; _update_state busy; }
+cmd_awaiting() { _silent_exit_if_no_role; _update_state awaiting; }
 
 cmd_send() {
   local to="" intent="" pr="" issue="" repo="" body=""
@@ -565,6 +569,7 @@ case "$sub" in
   register)    [[ -z "${TASK_FORCE_ROLE:-}" ]] && exit 0; cmd_register "$@" ;;
   ready)       cmd_ready ;;
   busy)        cmd_busy ;;
+  awaiting)    cmd_awaiting ;;
   unregister)  cmd_unregister ;;
   orphans)     cmd_orphans ;;
   -h|--help)   usage 0 ;;

--- a/claude-local/bin/task-init
+++ b/claude-local/bin/task-init
@@ -244,6 +244,7 @@ _radio_install_hooks() {
   local busy_cmd="radio busy"
   local stop_cmd="radio ready && radio check"
   local end_cmd="radio unregister"
+  local awaiting_cmd="radio awaiting"
 
   mkdir -p "$(dirname "$settings_file")"
   [[ -f "$settings_file" ]] || printf '%s\n' '{}' >"$settings_file"
@@ -254,16 +255,25 @@ _radio_install_hooks() {
     --arg ups  "$busy_cmd" \
     --arg stop "$stop_cmd" \
     --arg endcmd  "$end_cmd" \
+    --arg awaiting "$awaiting_cmd" \
     '
     def add_radio(arr; cmd):
       if (arr // []) | any((.hooks // []) | any((.command // "") | startswith("radio "))) then arr
       else (arr // []) + [{hooks: [{type: "command", command: cmd}]}]
       end;
+    def add_radio_matcher(arr; mtch; cmd):
+      if (arr // []) | any(((.matcher // "") == mtch) and ((.hooks // []) | any((.command // "") | startswith("radio ")))) then arr
+      else (arr // []) + [{matcher: mtch, hooks: [{type: "command", command: cmd}]}]
+      end;
     .hooks //= {}
-    | .hooks.SessionStart     = add_radio(.hooks.SessionStart;     $sess)
-    | .hooks.UserPromptSubmit = add_radio(.hooks.UserPromptSubmit; $ups)
-    | .hooks.Stop             = add_radio(.hooks.Stop;             $stop)
-    | .hooks.SessionEnd       = add_radio(.hooks.SessionEnd;       $endcmd)
+    | .hooks.SessionStart      = add_radio(.hooks.SessionStart;     $sess)
+    | .hooks.UserPromptSubmit  = add_radio(.hooks.UserPromptSubmit; $ups)
+    | .hooks.Stop              = add_radio(.hooks.Stop;             $stop)
+    | .hooks.SessionEnd        = add_radio(.hooks.SessionEnd;       $endcmd)
+    | .hooks.PermissionRequest = add_radio(.hooks.PermissionRequest; $awaiting)
+    | .hooks.PreToolUse        = add_radio_matcher(.hooks.PreToolUse; "AskUserQuestion"; $awaiting)
+    | .hooks.PreToolUse        = add_radio_matcher(.hooks.PreToolUse; "ExitPlanMode";    $awaiting)
+    | .hooks.PostToolUse       = add_radio(.hooks.PostToolUse;       $ups)
     | .permissions //= {}
     | .permissions.allow //= []
     | .permissions.allow = (

--- a/claude-notion/bin/radio
+++ b/claude-notion/bin/radio
@@ -19,6 +19,7 @@ Usage:
   radio register --role ROLE --tab TAB [--repo PATH] --agent claude|kiro [--loadout NAME]
   radio ready                            mark this role idle (and process pending)
   radio busy                             mark this role busy
+  radio awaiting                         mark this role awaiting user input
   radio unregister                       remove this role's session file
   radio orphans                          list session files with stale (>1h) heartbeat
 
@@ -103,6 +104,7 @@ _strip_tab_prefix() {
   local s="$1"
   s="${s#⏸️ }"
   s="${s#▶️ }"
+  s="${s#❓︎ }"
   printf '%s' "$s"
 }
 
@@ -235,6 +237,7 @@ _rename_tab() {
   case "$new_state" in
     idle) prefix="⏸️ " ;;
     busy) prefix="▶️ " ;;
+    awaiting) prefix="❓︎ " ;;
     *)    return 0 ;;
   esac
   new_name="${prefix}${bare}"
@@ -372,6 +375,7 @@ cmd_unregister() {
 
 cmd_ready() { _silent_exit_if_no_role; _update_state idle; }
 cmd_busy()  { _silent_exit_if_no_role; _update_state busy; }
+cmd_awaiting() { _silent_exit_if_no_role; _update_state awaiting; }
 
 cmd_send() {
   local to="" intent="" pr="" issue="" repo="" body=""
@@ -565,6 +569,7 @@ case "$sub" in
   register)    [[ -z "${TASK_FORCE_ROLE:-}" ]] && exit 0; cmd_register "$@" ;;
   ready)       cmd_ready ;;
   busy)        cmd_busy ;;
+  awaiting)    cmd_awaiting ;;
   unregister)  cmd_unregister ;;
   orphans)     cmd_orphans ;;
   -h|--help)   usage 0 ;;

--- a/claude-notion/bin/task-init
+++ b/claude-notion/bin/task-init
@@ -174,6 +174,7 @@ _radio_install_hooks() {
   local busy_cmd="radio busy"
   local stop_cmd="radio ready && radio check"
   local end_cmd="radio unregister"
+  local awaiting_cmd="radio awaiting"
 
   mkdir -p "$(dirname "$settings_file")"
   [[ -f "$settings_file" ]] || printf '%s\n' '{}' >"$settings_file"
@@ -191,16 +192,25 @@ _radio_install_hooks() {
     --arg ups  "$busy_cmd" \
     --arg stop "$stop_cmd" \
     --arg endcmd  "$end_cmd" \
+    --arg awaiting "$awaiting_cmd" \
     '
     def add_radio(arr; cmd):
       if (arr // []) | any((.hooks // []) | any((.command // "") | startswith("radio "))) then arr
       else (arr // []) + [{hooks: [{type: "command", command: cmd}]}]
       end;
+    def add_radio_matcher(arr; mtch; cmd):
+      if (arr // []) | any(((.matcher // "") == mtch) and ((.hooks // []) | any((.command // "") | startswith("radio ")))) then arr
+      else (arr // []) + [{matcher: mtch, hooks: [{type: "command", command: cmd}]}]
+      end;
     .hooks //= {}
-    | .hooks.SessionStart     = add_radio(.hooks.SessionStart;     $sess)
-    | .hooks.UserPromptSubmit = add_radio(.hooks.UserPromptSubmit; $ups)
-    | .hooks.Stop             = add_radio(.hooks.Stop;             $stop)
-    | .hooks.SessionEnd       = add_radio(.hooks.SessionEnd;       $endcmd)
+    | .hooks.SessionStart      = add_radio(.hooks.SessionStart;     $sess)
+    | .hooks.UserPromptSubmit  = add_radio(.hooks.UserPromptSubmit; $ups)
+    | .hooks.Stop              = add_radio(.hooks.Stop;             $stop)
+    | .hooks.SessionEnd        = add_radio(.hooks.SessionEnd;       $endcmd)
+    | .hooks.PermissionRequest = add_radio(.hooks.PermissionRequest; $awaiting)
+    | .hooks.PreToolUse        = add_radio_matcher(.hooks.PreToolUse; "AskUserQuestion"; $awaiting)
+    | .hooks.PreToolUse        = add_radio_matcher(.hooks.PreToolUse; "ExitPlanMode";    $awaiting)
+    | .hooks.PostToolUse       = add_radio(.hooks.PostToolUse;       $ups)
     | .permissions //= {}
     | .permissions.allow //= []
     | .permissions.allow = (

--- a/kiro-gh/bin/radio
+++ b/kiro-gh/bin/radio
@@ -19,6 +19,7 @@ Usage:
   radio register --role ROLE --tab TAB [--repo PATH] --agent claude|kiro [--loadout NAME]
   radio ready                            mark this role idle (and process pending)
   radio busy                             mark this role busy
+  radio awaiting                         mark this role awaiting user input
   radio unregister                       remove this role's session file
   radio orphans                          list session files with stale (>1h) heartbeat
 
@@ -103,6 +104,7 @@ _strip_tab_prefix() {
   local s="$1"
   s="${s#⏸️ }"
   s="${s#▶️ }"
+  s="${s#❓︎ }"
   printf '%s' "$s"
 }
 
@@ -235,6 +237,7 @@ _rename_tab() {
   case "$new_state" in
     idle) prefix="⏸️ " ;;
     busy) prefix="▶️ " ;;
+    awaiting) prefix="❓︎ " ;;
     *)    return 0 ;;
   esac
   new_name="${prefix}${bare}"
@@ -372,6 +375,7 @@ cmd_unregister() {
 
 cmd_ready() { _silent_exit_if_no_role; _update_state idle; }
 cmd_busy()  { _silent_exit_if_no_role; _update_state busy; }
+cmd_awaiting() { _silent_exit_if_no_role; _update_state awaiting; }
 
 cmd_send() {
   local to="" intent="" pr="" issue="" repo="" body=""
@@ -565,6 +569,7 @@ case "$sub" in
   register)    [[ -z "${TASK_FORCE_ROLE:-}" ]] && exit 0; cmd_register "$@" ;;
   ready)       cmd_ready ;;
   busy)        cmd_busy ;;
+  awaiting)    cmd_awaiting ;;
   unregister)  cmd_unregister ;;
   orphans)     cmd_orphans ;;
   -h|--help)   usage 0 ;;

--- a/kiro-local/bin/radio
+++ b/kiro-local/bin/radio
@@ -19,6 +19,7 @@ Usage:
   radio register --role ROLE --tab TAB [--repo PATH] --agent claude|kiro [--loadout NAME]
   radio ready                            mark this role idle (and process pending)
   radio busy                             mark this role busy
+  radio awaiting                         mark this role awaiting user input
   radio unregister                       remove this role's session file
   radio orphans                          list session files with stale (>1h) heartbeat
 
@@ -103,6 +104,7 @@ _strip_tab_prefix() {
   local s="$1"
   s="${s#⏸️ }"
   s="${s#▶️ }"
+  s="${s#❓︎ }"
   printf '%s' "$s"
 }
 
@@ -235,6 +237,7 @@ _rename_tab() {
   case "$new_state" in
     idle) prefix="⏸️ " ;;
     busy) prefix="▶️ " ;;
+    awaiting) prefix="❓︎ " ;;
     *)    return 0 ;;
   esac
   new_name="${prefix}${bare}"
@@ -372,6 +375,7 @@ cmd_unregister() {
 
 cmd_ready() { _silent_exit_if_no_role; _update_state idle; }
 cmd_busy()  { _silent_exit_if_no_role; _update_state busy; }
+cmd_awaiting() { _silent_exit_if_no_role; _update_state awaiting; }
 
 cmd_send() {
   local to="" intent="" pr="" issue="" repo="" body=""
@@ -565,6 +569,7 @@ case "$sub" in
   register)    [[ -z "${TASK_FORCE_ROLE:-}" ]] && exit 0; cmd_register "$@" ;;
   ready)       cmd_ready ;;
   busy)        cmd_busy ;;
+  awaiting)    cmd_awaiting ;;
   unregister)  cmd_unregister ;;
   orphans)     cmd_orphans ;;
   -h|--help)   usage 0 ;;

--- a/kiro-notion/bin/radio
+++ b/kiro-notion/bin/radio
@@ -19,6 +19,7 @@ Usage:
   radio register --role ROLE --tab TAB [--repo PATH] --agent claude|kiro [--loadout NAME]
   radio ready                            mark this role idle (and process pending)
   radio busy                             mark this role busy
+  radio awaiting                         mark this role awaiting user input
   radio unregister                       remove this role's session file
   radio orphans                          list session files with stale (>1h) heartbeat
 
@@ -103,6 +104,7 @@ _strip_tab_prefix() {
   local s="$1"
   s="${s#⏸️ }"
   s="${s#▶️ }"
+  s="${s#❓︎ }"
   printf '%s' "$s"
 }
 
@@ -235,6 +237,7 @@ _rename_tab() {
   case "$new_state" in
     idle) prefix="⏸️ " ;;
     busy) prefix="▶️ " ;;
+    awaiting) prefix="❓︎ " ;;
     *)    return 0 ;;
   esac
   new_name="${prefix}${bare}"
@@ -372,6 +375,7 @@ cmd_unregister() {
 
 cmd_ready() { _silent_exit_if_no_role; _update_state idle; }
 cmd_busy()  { _silent_exit_if_no_role; _update_state busy; }
+cmd_awaiting() { _silent_exit_if_no_role; _update_state awaiting; }
 
 cmd_send() {
   local to="" intent="" pr="" issue="" repo="" body=""
@@ -565,6 +569,7 @@ case "$sub" in
   register)    [[ -z "${TASK_FORCE_ROLE:-}" ]] && exit 0; cmd_register "$@" ;;
   ready)       cmd_ready ;;
   busy)        cmd_busy ;;
+  awaiting)    cmd_awaiting ;;
   unregister)  cmd_unregister ;;
   orphans)     cmd_orphans ;;
   -h|--help)   usage 0 ;;

--- a/tests/claude_gh_task_init.bats
+++ b/tests/claude_gh_task_init.bats
@@ -404,23 +404,42 @@ EOF
   assert_success
   run "$CLAUDE_GH_TASK_INIT" --force
   assert_success
-  for event in SessionStart UserPromptSubmit Stop SessionEnd; do
+  for event in SessionStart UserPromptSubmit Stop SessionEnd PermissionRequest PostToolUse; do
     run jq -r ".hooks.$event | length" "$TARGET_DIR/.claude/settings.json"
     assert_output "1"
   done
+  # PreToolUse has TWO matcher entries (AskUserQuestion + ExitPlanMode) and
+  # `add_radio_matcher` is per-matcher idempotent — re-run must keep both
+  # without doubling them up (#119).
+  run jq -r '.hooks.PreToolUse | length' "$TARGET_DIR/.claude/settings.json"
+  assert_output "2"
 }
 
-# Pins the contract reverted in #114: Notification hook is intentionally NOT
-# wired up. Claude Code's Notification hook only fires on idle-wait, not on
-# permission / AskUserQuestion / ExitPlanMode prompts, so an awaiting tab state
-# driven by it was non-functional. Re-introducing this hook needs a real trigger
-# mechanism first — see follow-up to #106.
-@test "Notification hook is NOT installed by task-init (#114)" {
+# Positive coverage for the awaiting-state triggers introduced in #119. The
+# previous pin (negative coverage from #114) asserted PreToolUse / Notification
+# absence; #119 wires PermissionRequest + PreToolUse(AskUserQuestion,ExitPlanMode)
+# → `radio awaiting` and PostToolUse → `radio busy` (reverse edge). Notification
+# stays asserted-absent so the broken #112 trigger can't sneak back in.
+@test "radio awaiting hooks installed: PermissionRequest, PreToolUse, PostToolUse (#119)" {
   run "$CLAUDE_GH_TASK_INIT"
   assert_success
+
+  # PermissionRequest → radio awaiting
+  run jq -r '.hooks.PermissionRequest[0].hooks[0].command' "$TARGET_DIR/.claude/settings.json"
+  assert_output "radio awaiting"
+
+  # PreToolUse matchers AskUserQuestion + ExitPlanMode → radio awaiting
+  run jq -r '[.hooks.PreToolUse[] | select(.matcher == "AskUserQuestion") | .hooks[0].command] | .[0]' "$TARGET_DIR/.claude/settings.json"
+  assert_output "radio awaiting"
+  run jq -r '[.hooks.PreToolUse[] | select(.matcher == "ExitPlanMode") | .hooks[0].command] | .[0]' "$TARGET_DIR/.claude/settings.json"
+  assert_output "radio awaiting"
+
+  # PostToolUse reverse-edge → radio busy
+  run jq -r '.hooks.PostToolUse[0].hooks[0].command' "$TARGET_DIR/.claude/settings.json"
+  assert_output "radio busy"
+
+  # Notification still absent (the broken #114 trigger must not return).
   run jq -r '.hooks.Notification // "absent"' "$TARGET_DIR/.claude/settings.json"
-  assert_output "absent"
-  run jq -r '.hooks.PreToolUse // "absent"' "$TARGET_DIR/.claude/settings.json"
   assert_output "absent"
 }
 

--- a/tests/radio.bats
+++ b/tests/radio.bats
@@ -57,6 +57,13 @@ teardown() {
   assert_output "STATE=idle"
 }
 
+@test "awaiting toggles STATE to awaiting (#119)" {
+  "$RADIO" register --role pm --tab pm --agent claude
+  TASK_FORCE_ROLE=pm "$RADIO" awaiting
+  run grep "^STATE=" "$TASK_FORCE_HOME/radio/sessions/pm.info"
+  assert_output "STATE=awaiting"
+}
+
 @test "unregister removes the session file" {
   "$RADIO" register --role pm --tab pm --agent claude
   TASK_FORCE_ROLE=pm "$RADIO" unregister
@@ -89,6 +96,12 @@ teardown() {
 
 @test "ready is a silent no-op when TASK_FORCE_ROLE is unset" {
   run env -u TASK_FORCE_ROLE "$RADIO" ready
+  assert_success
+  [ -z "$output" ]
+}
+
+@test "awaiting is a silent no-op when TASK_FORCE_ROLE is unset (#119)" {
+  run env -u TASK_FORCE_ROLE "$RADIO" awaiting
   assert_success
   [ -z "$output" ]
 }
@@ -169,6 +182,20 @@ teardown() {
   assert_output --partial "1"
   run cat "$TASK_FORCE_HOME/radio/log"
   assert_output --partial "no session for pm"
+}
+
+@test "send queues silently when recipient is awaiting (send-gate covers non-idle) (#119)" {
+  # Pins the spec's send-gate contract: STATE != idle blocks wake-ups. `awaiting`
+  # is not `idle`, so it composes for free with the existing gate — no logic
+  # changes at radio:437 needed.
+  export ZELLIJ=fake-session
+  "$RADIO" register --role pm --tab pm --agent claude
+  TASK_FORCE_ROLE=pm "$RADIO" awaiting
+  TASK_FORCE_ROLE=worker-foo "$RADIO" send --to pm --intent review-requested --body "PR up"
+  run bash -c "ls '$TASK_FORCE_HOME/radio/mailbox/pm/inbox/'*.md 2>/dev/null | wc -l | tr -d ' '"
+  assert_output "1"
+  run cat "$TASK_FORCE_HOME/radio/log"
+  assert_output --partial "is busy (state=awaiting)"
 }
 
 @test "check lists unread messages and prints (no unread messages) when empty" {

--- a/tests/radio_tab_state.bats
+++ b/tests/radio_tab_state.bats
@@ -18,6 +18,7 @@ load helpers/common
 # and we don't repeat the literal UTF-8 sequences across cases.
 PAUSE='⏸️ '
 PLAY='▶️ '
+AWAIT='❓︎ '
 
 setup() {
   setup_task_force_home
@@ -115,6 +116,14 @@ teardown() {
   assert_output "TAB=${PAUSE}pm"
 }
 
+@test "awaiting flips tab to the awaiting prefix and updates TAB= (#119)" {
+  TASK_FORCE_ROLE=pm "$RADIO" register --role pm --tab pm --agent claude
+  TASK_FORCE_ROLE=pm "$RADIO" awaiting
+  assert_stub_called zellij "action rename-tab-by-id 7 ${AWAIT}pm"
+  run grep "^TAB=" "$TASK_FORCE_HOME/radio/sessions/pm.info"
+  assert_output "TAB=${AWAIT}pm"
+}
+
 # ----- no prefix stacking ---------------------------------------------------
 
 @test "consecutive idle→busy→idle flips do not stack emoji prefixes" {
@@ -131,6 +140,19 @@ teardown() {
   # And the most recent rename-tab-by-id call should target the same name.
   run bash -c "grep 'rename-tab-by-id' '$STUB_CALLS_DIR/zellij.calls' | tail -1"
   assert_output "zellij action rename-tab-by-id 7 ${PAUSE}pm"
+}
+
+@test "busy → awaiting → busy flips do not stack emoji prefixes (#119)" {
+  # Exercises _strip_tab_prefix's new ❓︎ strip — without it, the second `busy`
+  # flip would rename to "▶️ ❓︎ pm".
+  TASK_FORCE_ROLE=pm "$RADIO" register --role pm --tab pm --agent claude
+  TASK_FORCE_ROLE=pm "$RADIO" busy
+  TASK_FORCE_ROLE=pm "$RADIO" awaiting
+  TASK_FORCE_ROLE=pm "$RADIO" busy
+  run grep "^TAB=" "$TASK_FORCE_HOME/radio/sessions/pm.info"
+  assert_output "TAB=${PLAY}pm"
+  run bash -c "grep 'rename-tab-by-id' '$STUB_CALLS_DIR/zellij.calls' | tail -1"
+  assert_output "zellij action rename-tab-by-id 7 ${PLAY}pm"
 }
 
 # ----- TAB= sync keeps wake-up working --------------------------------------


### PR DESCRIPTION
## Summary

Closes #119. Re-introduces the `awaiting` tab state (`❓︎ <slug>`) that PR #112 added and PR #115 reverted. The original wiring used Claude Code's `Notification` hook, which empirically only fires on idle-wait. #116's investigation produced live-captured payloads + GO verdicts for the real triggers, plus a reverse edge via `PostToolUse`.

### What changed

- **All 7 `radio` scripts** (drift-constrained `# region:body`): added `cmd_awaiting`, the `awaiting)` case in `_rename_tab` and dispatch, the `❓︎ ` glyph strip in `_strip_tab_prefix`, and the `radio awaiting` usage line.
- **All 4 `claude-*/bin/task-init`** `_radio_install_hooks`: new `add_radio_matcher` jq helper (per-matcher idempotent) and three new hook installs — `PermissionRequest` + `PreToolUse{AskUserQuestion,ExitPlanMode}` → `radio awaiting`, plus `PostToolUse` → `radio busy` (reverse edge).
- **Tests**:
  - `tests/claude_gh_task_init.bats`: flipped the #114 pin from negative coverage (Notification/PreToolUse absent) to positive coverage of the three new hooks; retained `Notification == absent` so the broken #112 trigger can't return; extended the idempotency loop.
  - `tests/radio.bats`: STATE transition, silent no-op when role unset, and send-gate non-idle coverage for `awaiting`.
  - `tests/radio_tab_state.bats`: `AWAIT='❓︎ '` constant, awaiting paint + no-stacking on busy→awaiting→busy.

### Out of scope (carried from #116)

- **Send-gate at `claude-gh/bin/radio:437` is UNCHANGED** — `STATE != idle` already covers `awaiting`, queueing wake-ups correctly.
- **Kiro task-init** — no `PermissionRequest` / `PreToolUse` equivalent on its hook surface.

### Why no `PreToolUse` catch-all → `radio busy`?

Claude Code fires *all* matching `PreToolUse` entries in unspecified order, so a catch-all `radio busy` would race against the just-set `radio awaiting` for `AskUserQuestion` / `ExitPlanMode` tool calls. The `PostToolUse` reverse-edge alone is unambiguous: it fires after the user resolves the prompt and the tool resumes.

## Test plan

- [x] `bats tests/claude_gh_task_init.bats` — flipped #119 pin green; idempotency loop now covers all 6 events + PreToolUse=2.
- [x] `bats tests/radio.bats` — new awaiting cases (#119) green; existing cases stay green.
- [x] `bats tests/radio_tab_state.bats` — awaiting paint + no-stacking cases green.
- [x] `./tools/check-drift.sh` — exit 0, all 7 radio body regions byte-identical.
- [x] Full `./run_tests.sh` — 643 tests, exit 0.
- [ ] Manual end-to-end (paint on permission prompt, AskUserQuestion, ExitPlanMode; clear on reverse edge) — to be run before merge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)