### PR TITLE
radio: opt-in auto-submit on wake-up for --auto workers (CR not LF) (#128)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,10 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 
 ## [Unreleased]
 
+### Added
+
+- **Opt-in auto-submit on radio wake-up for `--auto` workers.** `radio send`'s zellij `write-chars` wake-up has always written `radio check\n` (LF) into the recipient's pane, leaving it sitting in the input box until the user pressed Enter. For workers launched via `task-work --auto` — already an explicit autonomy opt-in, and idle most of their life waiting on PM — that human gate is friction with no upside. `task-work --auto` now exports `TASK_FORCE_AUTO_SUBMIT=1`; `radio register` / `_ensure_session_file` persist that as `AUTO_SUBMIT=1` in the session file; `cmd_send` reads it and switches the wake-up byte to CR (`\r`), which Claude Code's raw-mode input binds to Enter. PM and default (non-`--auto`) workers leave the flag unset and keep the LF wake-up, so a `radio check` ping can never corrupt a partially-typed prompt. (#128)
+
 ## [0.2.2] — 2026-05-23
 
 Patch release. Extends the cross-tab targeting fix from `v0.2.1` (radio) to `task-done`, and hardens the radio session lifecycle so intra-session Claude events (`/clear`, `/compact`, resume) don't brick subsequent radio operations.

--- a/claude-gh/bin/radio
+++ b/claude-gh/bin/radio
@@ -166,10 +166,19 @@ _ensure_session_file() {
   local repo
   repo=$(git rev-parse --show-toplevel 2>/dev/null || echo "")
 
-  printf 'ROLE=%s\nTAB=%s\nTAB_ID=%s\nREPO=%s\nSTATE=idle\nLAST_HEARTBEAT=%s\nAGENT=%s\nLOADOUT=%s\n' \
-    "$TASK_FORCE_ROLE" "$ZELLIJ_TAB" "$tab_id" "$repo" "$(_now)" \
-    "${TASK_FORCE_AGENT:-claude}" "${TASK_FORCE_LOADOUT:-unknown}" \
-    | _atomic_write "$f"
+  {
+    printf 'ROLE=%s\nTAB=%s\nTAB_ID=%s\nREPO=%s\nSTATE=idle\nLAST_HEARTBEAT=%s\nAGENT=%s\nLOADOUT=%s\n' \
+      "$TASK_FORCE_ROLE" "$ZELLIJ_TAB" "$tab_id" "$repo" "$(_now)" \
+      "${TASK_FORCE_AGENT:-claude}" "${TASK_FORCE_LOADOUT:-unknown}"
+    # Preserve the --auto opt-in across self-heal so cmd_send keeps using CR
+    # for wake-up after an intra-session re-seed (#128). Use `if` rather than
+    # `&&` so the brace group exits 0 when the flag is absent — otherwise
+    # pipefail would surface a stray exit-1 through `| _atomic_write` and
+    # `set -e` would abort the re-seed.
+    if [[ "${TASK_FORCE_AUTO_SUBMIT:-}" == "1" ]]; then
+      printf 'AUTO_SUBMIT=1\n'
+    fi
+  } | _atomic_write "$f"
 
   mkdir -p "$(_inbox_dir "$TASK_FORCE_ROLE")" "$(_processed_dir "$TASK_FORCE_ROLE")"
   _log "ensure_session: re-seeded $TASK_FORCE_ROLE (file was missing) tab_id=$tab_id"
@@ -323,9 +332,20 @@ cmd_register() {
     fi
   fi
 
-  printf 'ROLE=%s\nTAB=%s\nTAB_ID=%s\nREPO=%s\nSTATE=idle\nLAST_HEARTBEAT=%s\nAGENT=%s\nLOADOUT=%s\n' \
-    "$role" "$tab" "$tab_id" "$repo" "$(_now)" "$agent" "$loadout" \
-    | _atomic_write "$f"
+  {
+    printf 'ROLE=%s\nTAB=%s\nTAB_ID=%s\nREPO=%s\nSTATE=idle\nLAST_HEARTBEAT=%s\nAGENT=%s\nLOADOUT=%s\n' \
+      "$role" "$tab" "$tab_id" "$repo" "$(_now)" "$agent" "$loadout"
+    # Persist the --auto opt-in (#128). task-work --auto exports
+    # TASK_FORCE_AUTO_SUBMIT=1 into the tab's env; cmd_send reads AUTO_SUBMIT
+    # off the recipient's session file and flips wake-up from LF (manual) to
+    # CR (auto-submit). task-pm and default workers never export this, so
+    # they keep the human-gated default. `if` rather than `&&` so the brace
+    # group exits 0 even when the flag is absent — pipefail + set -e would
+    # otherwise abort register on every non-auto worker.
+    if [[ "${TASK_FORCE_AUTO_SUBMIT:-}" == "1" ]]; then
+      printf 'AUTO_SUBMIT=1\n'
+    fi
+  } | _atomic_write "$f"
 
   mkdir -p "$(_inbox_dir "$role")" "$(_processed_dir "$role")"
   _log "register role=$role tab=$tab tab_id=$tab_id agent=$agent loadout=$loadout"
@@ -463,12 +483,24 @@ cmd_send() {
     _log "send: no writable pane on tab_id=$rtab_id for $to — queued (id=$id)"
     return 0
   fi
-  # Only ever write the literal string "radio check\n" — never the message body
-  # or any caller-supplied data. `zellij write-chars` injects directly into the
-  # recipient's TUI input buffer; writing anything else risks corrupting the
-  # agent's unsaved prompt or smuggling content into a TUI command. The
-  # recipient reads the actual message via `radio check` / `radio read`.
-  zellij action write-chars --pane-id "$rpane_id" "radio check"$'\n' >/dev/null 2>&1 || {
+  # Only ever write the literal string "radio check<term>" — never the message
+  # body or any caller-supplied data. `zellij write-chars` injects directly
+  # into the recipient's TUI input buffer; writing anything else risks
+  # corrupting the agent's unsaved prompt or smuggling content into a TUI
+  # command. The recipient reads the actual message via `radio check` /
+  # `radio read`.
+  #
+  # Recipients launched via `task-work --auto` opt in to CR (auto-submit) so
+  # PM pings process without a manual Enter (#128). Everyone else — PM,
+  # default workers, pre-#128 workers with no AUTO_SUBMIT field — gets LF,
+  # which lands "radio check" in the input box and waits for the user to
+  # press Enter. The human gate is what protects partially-typed prompts
+  # from being corrupted by an incoming wake-up.
+  local wake_term=$'\n'
+  if [[ "$(_session_field "$rs" AUTO_SUBMIT || true)" == "1" ]]; then
+    wake_term=$'\r'
+  fi
+  zellij action write-chars --pane-id "$rpane_id" "radio check${wake_term}" >/dev/null 2>&1 || {
     _log "send: write-chars failed for $to (pane=$rpane_id) — queued (id=$id)"; return 0; }
   _log "send: woke $to via tab_id=$rtab_id pane=$rpane_id (id=$id)"
 }

--- a/claude-gh/bin/task-work
+++ b/claude-gh/bin/task-work
@@ -214,6 +214,11 @@ printf 'BASE_BRANCH=%s\nSLUG=%s\nGH_URL=%s\n' "$BASE_BRANCH" "$SLUG" "$GH_URL" >
 # command exports those vars to that command's environment only.
 TASK_FORCE_ROLE_VALUE="worker-${REPO_NAME}-${SLUG}"
 RADIO_ENV_PREFIX="TASK_FORCE_ROLE=$(printf %q "$TASK_FORCE_ROLE_VALUE") ZELLIJ_TAB=$(printf %q "$SLUG") "
+# Opt --auto workers into radio's CR (auto-submit) wake-up so PM pings process
+# without a manual Enter (#128). PM and non-auto workers leave this unset, so
+# radio keeps using LF — preserves the human gate that protects a partially-
+# typed prompt from being corrupted by an incoming `radio check`.
+[[ -n "${AUTO_MODE:-}" ]] && RADIO_ENV_PREFIX+="TASK_FORCE_AUTO_SUBMIT=1 "
 # endregion:radio-env-injection
 
 # region:worktree-creation-post-info

--- a/claude-jira/bin/radio
+++ b/claude-jira/bin/radio
@@ -166,10 +166,19 @@ _ensure_session_file() {
   local repo
   repo=$(git rev-parse --show-toplevel 2>/dev/null || echo "")
 
-  printf 'ROLE=%s\nTAB=%s\nTAB_ID=%s\nREPO=%s\nSTATE=idle\nLAST_HEARTBEAT=%s\nAGENT=%s\nLOADOUT=%s\n' \
-    "$TASK_FORCE_ROLE" "$ZELLIJ_TAB" "$tab_id" "$repo" "$(_now)" \
-    "${TASK_FORCE_AGENT:-claude}" "${TASK_FORCE_LOADOUT:-unknown}" \
-    | _atomic_write "$f"
+  {
+    printf 'ROLE=%s\nTAB=%s\nTAB_ID=%s\nREPO=%s\nSTATE=idle\nLAST_HEARTBEAT=%s\nAGENT=%s\nLOADOUT=%s\n' \
+      "$TASK_FORCE_ROLE" "$ZELLIJ_TAB" "$tab_id" "$repo" "$(_now)" \
+      "${TASK_FORCE_AGENT:-claude}" "${TASK_FORCE_LOADOUT:-unknown}"
+    # Preserve the --auto opt-in across self-heal so cmd_send keeps using CR
+    # for wake-up after an intra-session re-seed (#128). Use `if` rather than
+    # `&&` so the brace group exits 0 when the flag is absent — otherwise
+    # pipefail would surface a stray exit-1 through `| _atomic_write` and
+    # `set -e` would abort the re-seed.
+    if [[ "${TASK_FORCE_AUTO_SUBMIT:-}" == "1" ]]; then
+      printf 'AUTO_SUBMIT=1\n'
+    fi
+  } | _atomic_write "$f"
 
   mkdir -p "$(_inbox_dir "$TASK_FORCE_ROLE")" "$(_processed_dir "$TASK_FORCE_ROLE")"
   _log "ensure_session: re-seeded $TASK_FORCE_ROLE (file was missing) tab_id=$tab_id"
@@ -323,9 +332,20 @@ cmd_register() {
     fi
   fi
 
-  printf 'ROLE=%s\nTAB=%s\nTAB_ID=%s\nREPO=%s\nSTATE=idle\nLAST_HEARTBEAT=%s\nAGENT=%s\nLOADOUT=%s\n' \
-    "$role" "$tab" "$tab_id" "$repo" "$(_now)" "$agent" "$loadout" \
-    | _atomic_write "$f"
+  {
+    printf 'ROLE=%s\nTAB=%s\nTAB_ID=%s\nREPO=%s\nSTATE=idle\nLAST_HEARTBEAT=%s\nAGENT=%s\nLOADOUT=%s\n' \
+      "$role" "$tab" "$tab_id" "$repo" "$(_now)" "$agent" "$loadout"
+    # Persist the --auto opt-in (#128). task-work --auto exports
+    # TASK_FORCE_AUTO_SUBMIT=1 into the tab's env; cmd_send reads AUTO_SUBMIT
+    # off the recipient's session file and flips wake-up from LF (manual) to
+    # CR (auto-submit). task-pm and default workers never export this, so
+    # they keep the human-gated default. `if` rather than `&&` so the brace
+    # group exits 0 even when the flag is absent — pipefail + set -e would
+    # otherwise abort register on every non-auto worker.
+    if [[ "${TASK_FORCE_AUTO_SUBMIT:-}" == "1" ]]; then
+      printf 'AUTO_SUBMIT=1\n'
+    fi
+  } | _atomic_write "$f"
 
   mkdir -p "$(_inbox_dir "$role")" "$(_processed_dir "$role")"
   _log "register role=$role tab=$tab tab_id=$tab_id agent=$agent loadout=$loadout"
@@ -463,12 +483,24 @@ cmd_send() {
     _log "send: no writable pane on tab_id=$rtab_id for $to — queued (id=$id)"
     return 0
   fi
-  # Only ever write the literal string "radio check\n" — never the message body
-  # or any caller-supplied data. `zellij write-chars` injects directly into the
-  # recipient's TUI input buffer; writing anything else risks corrupting the
-  # agent's unsaved prompt or smuggling content into a TUI command. The
-  # recipient reads the actual message via `radio check` / `radio read`.
-  zellij action write-chars --pane-id "$rpane_id" "radio check"$'\n' >/dev/null 2>&1 || {
+  # Only ever write the literal string "radio check<term>" — never the message
+  # body or any caller-supplied data. `zellij write-chars` injects directly
+  # into the recipient's TUI input buffer; writing anything else risks
+  # corrupting the agent's unsaved prompt or smuggling content into a TUI
+  # command. The recipient reads the actual message via `radio check` /
+  # `radio read`.
+  #
+  # Recipients launched via `task-work --auto` opt in to CR (auto-submit) so
+  # PM pings process without a manual Enter (#128). Everyone else — PM,
+  # default workers, pre-#128 workers with no AUTO_SUBMIT field — gets LF,
+  # which lands "radio check" in the input box and waits for the user to
+  # press Enter. The human gate is what protects partially-typed prompts
+  # from being corrupted by an incoming wake-up.
+  local wake_term=$'\n'
+  if [[ "$(_session_field "$rs" AUTO_SUBMIT || true)" == "1" ]]; then
+    wake_term=$'\r'
+  fi
+  zellij action write-chars --pane-id "$rpane_id" "radio check${wake_term}" >/dev/null 2>&1 || {
     _log "send: write-chars failed for $to (pane=$rpane_id) — queued (id=$id)"; return 0; }
   _log "send: woke $to via tab_id=$rtab_id pane=$rpane_id (id=$id)"
 }

--- a/claude-jira/bin/task-work
+++ b/claude-jira/bin/task-work
@@ -160,6 +160,11 @@ printf 'BASE_BRANCH=%s\nSLUG=%s\nJIRA_REF=%s\n' "$BASE_BRANCH" "$SLUG" "$JIRA_RE
 # command exports those vars to that command's environment only.
 TASK_FORCE_ROLE_VALUE="worker-${REPO_NAME}-${SLUG}"
 RADIO_ENV_PREFIX="TASK_FORCE_ROLE=$(printf %q "$TASK_FORCE_ROLE_VALUE") ZELLIJ_TAB=$(printf %q "$SLUG") "
+# Opt --auto workers into radio's CR (auto-submit) wake-up so PM pings process
+# without a manual Enter (#128). PM and non-auto workers leave this unset, so
+# radio keeps using LF — preserves the human gate that protects a partially-
+# typed prompt from being corrupted by an incoming `radio check`.
+[[ -n "${AUTO_MODE:-}" ]] && RADIO_ENV_PREFIX+="TASK_FORCE_AUTO_SUBMIT=1 "
 # endregion:radio-env-injection
 
 echo "Opening zellij tab '$SLUG'..."

--- a/claude-local/bin/radio
+++ b/claude-local/bin/radio
@@ -166,10 +166,19 @@ _ensure_session_file() {
   local repo
   repo=$(git rev-parse --show-toplevel 2>/dev/null || echo "")
 
-  printf 'ROLE=%s\nTAB=%s\nTAB_ID=%s\nREPO=%s\nSTATE=idle\nLAST_HEARTBEAT=%s\nAGENT=%s\nLOADOUT=%s\n' \
-    "$TASK_FORCE_ROLE" "$ZELLIJ_TAB" "$tab_id" "$repo" "$(_now)" \
-    "${TASK_FORCE_AGENT:-claude}" "${TASK_FORCE_LOADOUT:-unknown}" \
-    | _atomic_write "$f"
+  {
+    printf 'ROLE=%s\nTAB=%s\nTAB_ID=%s\nREPO=%s\nSTATE=idle\nLAST_HEARTBEAT=%s\nAGENT=%s\nLOADOUT=%s\n' \
+      "$TASK_FORCE_ROLE" "$ZELLIJ_TAB" "$tab_id" "$repo" "$(_now)" \
+      "${TASK_FORCE_AGENT:-claude}" "${TASK_FORCE_LOADOUT:-unknown}"
+    # Preserve the --auto opt-in across self-heal so cmd_send keeps using CR
+    # for wake-up after an intra-session re-seed (#128). Use `if` rather than
+    # `&&` so the brace group exits 0 when the flag is absent — otherwise
+    # pipefail would surface a stray exit-1 through `| _atomic_write` and
+    # `set -e` would abort the re-seed.
+    if [[ "${TASK_FORCE_AUTO_SUBMIT:-}" == "1" ]]; then
+      printf 'AUTO_SUBMIT=1\n'
+    fi
+  } | _atomic_write "$f"
 
   mkdir -p "$(_inbox_dir "$TASK_FORCE_ROLE")" "$(_processed_dir "$TASK_FORCE_ROLE")"
   _log "ensure_session: re-seeded $TASK_FORCE_ROLE (file was missing) tab_id=$tab_id"
@@ -323,9 +332,20 @@ cmd_register() {
     fi
   fi
 
-  printf 'ROLE=%s\nTAB=%s\nTAB_ID=%s\nREPO=%s\nSTATE=idle\nLAST_HEARTBEAT=%s\nAGENT=%s\nLOADOUT=%s\n' \
-    "$role" "$tab" "$tab_id" "$repo" "$(_now)" "$agent" "$loadout" \
-    | _atomic_write "$f"
+  {
+    printf 'ROLE=%s\nTAB=%s\nTAB_ID=%s\nREPO=%s\nSTATE=idle\nLAST_HEARTBEAT=%s\nAGENT=%s\nLOADOUT=%s\n' \
+      "$role" "$tab" "$tab_id" "$repo" "$(_now)" "$agent" "$loadout"
+    # Persist the --auto opt-in (#128). task-work --auto exports
+    # TASK_FORCE_AUTO_SUBMIT=1 into the tab's env; cmd_send reads AUTO_SUBMIT
+    # off the recipient's session file and flips wake-up from LF (manual) to
+    # CR (auto-submit). task-pm and default workers never export this, so
+    # they keep the human-gated default. `if` rather than `&&` so the brace
+    # group exits 0 even when the flag is absent — pipefail + set -e would
+    # otherwise abort register on every non-auto worker.
+    if [[ "${TASK_FORCE_AUTO_SUBMIT:-}" == "1" ]]; then
+      printf 'AUTO_SUBMIT=1\n'
+    fi
+  } | _atomic_write "$f"
 
   mkdir -p "$(_inbox_dir "$role")" "$(_processed_dir "$role")"
   _log "register role=$role tab=$tab tab_id=$tab_id agent=$agent loadout=$loadout"
@@ -463,12 +483,24 @@ cmd_send() {
     _log "send: no writable pane on tab_id=$rtab_id for $to — queued (id=$id)"
     return 0
   fi
-  # Only ever write the literal string "radio check\n" — never the message body
-  # or any caller-supplied data. `zellij write-chars` injects directly into the
-  # recipient's TUI input buffer; writing anything else risks corrupting the
-  # agent's unsaved prompt or smuggling content into a TUI command. The
-  # recipient reads the actual message via `radio check` / `radio read`.
-  zellij action write-chars --pane-id "$rpane_id" "radio check"$'\n' >/dev/null 2>&1 || {
+  # Only ever write the literal string "radio check<term>" — never the message
+  # body or any caller-supplied data. `zellij write-chars` injects directly
+  # into the recipient's TUI input buffer; writing anything else risks
+  # corrupting the agent's unsaved prompt or smuggling content into a TUI
+  # command. The recipient reads the actual message via `radio check` /
+  # `radio read`.
+  #
+  # Recipients launched via `task-work --auto` opt in to CR (auto-submit) so
+  # PM pings process without a manual Enter (#128). Everyone else — PM,
+  # default workers, pre-#128 workers with no AUTO_SUBMIT field — gets LF,
+  # which lands "radio check" in the input box and waits for the user to
+  # press Enter. The human gate is what protects partially-typed prompts
+  # from being corrupted by an incoming wake-up.
+  local wake_term=$'\n'
+  if [[ "$(_session_field "$rs" AUTO_SUBMIT || true)" == "1" ]]; then
+    wake_term=$'\r'
+  fi
+  zellij action write-chars --pane-id "$rpane_id" "radio check${wake_term}" >/dev/null 2>&1 || {
     _log "send: write-chars failed for $to (pane=$rpane_id) — queued (id=$id)"; return 0; }
   _log "send: woke $to via tab_id=$rtab_id pane=$rpane_id (id=$id)"
 }

--- a/claude-local/bin/task-work
+++ b/claude-local/bin/task-work
@@ -231,6 +231,11 @@ fi
 # command exports those vars to that command's environment only.
 TASK_FORCE_ROLE_VALUE="worker-${REPO_NAME}-${SLUG}"
 RADIO_ENV_PREFIX="TASK_FORCE_ROLE=$(printf %q "$TASK_FORCE_ROLE_VALUE") ZELLIJ_TAB=$(printf %q "$SLUG") "
+# Opt --auto workers into radio's CR (auto-submit) wake-up so PM pings process
+# without a manual Enter (#128). PM and non-auto workers leave this unset, so
+# radio keeps using LF — preserves the human gate that protects a partially-
+# typed prompt from being corrupted by an incoming `radio check`.
+[[ -n "${AUTO_MODE:-}" ]] && RADIO_ENV_PREFIX+="TASK_FORCE_AUTO_SUBMIT=1 "
 # endregion:radio-env-injection
 
 # region:worktree-creation-post-info

--- a/claude-notion/bin/radio
+++ b/claude-notion/bin/radio
@@ -166,10 +166,19 @@ _ensure_session_file() {
   local repo
   repo=$(git rev-parse --show-toplevel 2>/dev/null || echo "")
 
-  printf 'ROLE=%s\nTAB=%s\nTAB_ID=%s\nREPO=%s\nSTATE=idle\nLAST_HEARTBEAT=%s\nAGENT=%s\nLOADOUT=%s\n' \
-    "$TASK_FORCE_ROLE" "$ZELLIJ_TAB" "$tab_id" "$repo" "$(_now)" \
-    "${TASK_FORCE_AGENT:-claude}" "${TASK_FORCE_LOADOUT:-unknown}" \
-    | _atomic_write "$f"
+  {
+    printf 'ROLE=%s\nTAB=%s\nTAB_ID=%s\nREPO=%s\nSTATE=idle\nLAST_HEARTBEAT=%s\nAGENT=%s\nLOADOUT=%s\n' \
+      "$TASK_FORCE_ROLE" "$ZELLIJ_TAB" "$tab_id" "$repo" "$(_now)" \
+      "${TASK_FORCE_AGENT:-claude}" "${TASK_FORCE_LOADOUT:-unknown}"
+    # Preserve the --auto opt-in across self-heal so cmd_send keeps using CR
+    # for wake-up after an intra-session re-seed (#128). Use `if` rather than
+    # `&&` so the brace group exits 0 when the flag is absent — otherwise
+    # pipefail would surface a stray exit-1 through `| _atomic_write` and
+    # `set -e` would abort the re-seed.
+    if [[ "${TASK_FORCE_AUTO_SUBMIT:-}" == "1" ]]; then
+      printf 'AUTO_SUBMIT=1\n'
+    fi
+  } | _atomic_write "$f"
 
   mkdir -p "$(_inbox_dir "$TASK_FORCE_ROLE")" "$(_processed_dir "$TASK_FORCE_ROLE")"
   _log "ensure_session: re-seeded $TASK_FORCE_ROLE (file was missing) tab_id=$tab_id"
@@ -323,9 +332,20 @@ cmd_register() {
     fi
   fi
 
-  printf 'ROLE=%s\nTAB=%s\nTAB_ID=%s\nREPO=%s\nSTATE=idle\nLAST_HEARTBEAT=%s\nAGENT=%s\nLOADOUT=%s\n' \
-    "$role" "$tab" "$tab_id" "$repo" "$(_now)" "$agent" "$loadout" \
-    | _atomic_write "$f"
+  {
+    printf 'ROLE=%s\nTAB=%s\nTAB_ID=%s\nREPO=%s\nSTATE=idle\nLAST_HEARTBEAT=%s\nAGENT=%s\nLOADOUT=%s\n' \
+      "$role" "$tab" "$tab_id" "$repo" "$(_now)" "$agent" "$loadout"
+    # Persist the --auto opt-in (#128). task-work --auto exports
+    # TASK_FORCE_AUTO_SUBMIT=1 into the tab's env; cmd_send reads AUTO_SUBMIT
+    # off the recipient's session file and flips wake-up from LF (manual) to
+    # CR (auto-submit). task-pm and default workers never export this, so
+    # they keep the human-gated default. `if` rather than `&&` so the brace
+    # group exits 0 even when the flag is absent — pipefail + set -e would
+    # otherwise abort register on every non-auto worker.
+    if [[ "${TASK_FORCE_AUTO_SUBMIT:-}" == "1" ]]; then
+      printf 'AUTO_SUBMIT=1\n'
+    fi
+  } | _atomic_write "$f"
 
   mkdir -p "$(_inbox_dir "$role")" "$(_processed_dir "$role")"
   _log "register role=$role tab=$tab tab_id=$tab_id agent=$agent loadout=$loadout"
@@ -463,12 +483,24 @@ cmd_send() {
     _log "send: no writable pane on tab_id=$rtab_id for $to — queued (id=$id)"
     return 0
   fi
-  # Only ever write the literal string "radio check\n" — never the message body
-  # or any caller-supplied data. `zellij write-chars` injects directly into the
-  # recipient's TUI input buffer; writing anything else risks corrupting the
-  # agent's unsaved prompt or smuggling content into a TUI command. The
-  # recipient reads the actual message via `radio check` / `radio read`.
-  zellij action write-chars --pane-id "$rpane_id" "radio check"$'\n' >/dev/null 2>&1 || {
+  # Only ever write the literal string "radio check<term>" — never the message
+  # body or any caller-supplied data. `zellij write-chars` injects directly
+  # into the recipient's TUI input buffer; writing anything else risks
+  # corrupting the agent's unsaved prompt or smuggling content into a TUI
+  # command. The recipient reads the actual message via `radio check` /
+  # `radio read`.
+  #
+  # Recipients launched via `task-work --auto` opt in to CR (auto-submit) so
+  # PM pings process without a manual Enter (#128). Everyone else — PM,
+  # default workers, pre-#128 workers with no AUTO_SUBMIT field — gets LF,
+  # which lands "radio check" in the input box and waits for the user to
+  # press Enter. The human gate is what protects partially-typed prompts
+  # from being corrupted by an incoming wake-up.
+  local wake_term=$'\n'
+  if [[ "$(_session_field "$rs" AUTO_SUBMIT || true)" == "1" ]]; then
+    wake_term=$'\r'
+  fi
+  zellij action write-chars --pane-id "$rpane_id" "radio check${wake_term}" >/dev/null 2>&1 || {
     _log "send: write-chars failed for $to (pane=$rpane_id) — queued (id=$id)"; return 0; }
   _log "send: woke $to via tab_id=$rtab_id pane=$rpane_id (id=$id)"
 }

--- a/claude-notion/bin/task-work
+++ b/claude-notion/bin/task-work
@@ -211,6 +211,11 @@ printf 'BASE_BRANCH=%s\nSLUG=%s\nNOTION_URL=%s\n' "$BASE_BRANCH" "$SLUG" "$NOTIO
 # command exports those vars to that command's environment only.
 TASK_FORCE_ROLE_VALUE="worker-${REPO_NAME}-${SLUG}"
 RADIO_ENV_PREFIX="TASK_FORCE_ROLE=$(printf %q "$TASK_FORCE_ROLE_VALUE") ZELLIJ_TAB=$(printf %q "$SLUG") "
+# Opt --auto workers into radio's CR (auto-submit) wake-up so PM pings process
+# without a manual Enter (#128). PM and non-auto workers leave this unset, so
+# radio keeps using LF — preserves the human gate that protects a partially-
+# typed prompt from being corrupted by an incoming `radio check`.
+[[ -n "${AUTO_MODE:-}" ]] && RADIO_ENV_PREFIX+="TASK_FORCE_AUTO_SUBMIT=1 "
 # endregion:radio-env-injection
 
 # region:worktree-creation-post-info

--- a/kiro-gh/bin/radio
+++ b/kiro-gh/bin/radio
@@ -166,10 +166,19 @@ _ensure_session_file() {
   local repo
   repo=$(git rev-parse --show-toplevel 2>/dev/null || echo "")
 
-  printf 'ROLE=%s\nTAB=%s\nTAB_ID=%s\nREPO=%s\nSTATE=idle\nLAST_HEARTBEAT=%s\nAGENT=%s\nLOADOUT=%s\n' \
-    "$TASK_FORCE_ROLE" "$ZELLIJ_TAB" "$tab_id" "$repo" "$(_now)" \
-    "${TASK_FORCE_AGENT:-claude}" "${TASK_FORCE_LOADOUT:-unknown}" \
-    | _atomic_write "$f"
+  {
+    printf 'ROLE=%s\nTAB=%s\nTAB_ID=%s\nREPO=%s\nSTATE=idle\nLAST_HEARTBEAT=%s\nAGENT=%s\nLOADOUT=%s\n' \
+      "$TASK_FORCE_ROLE" "$ZELLIJ_TAB" "$tab_id" "$repo" "$(_now)" \
+      "${TASK_FORCE_AGENT:-claude}" "${TASK_FORCE_LOADOUT:-unknown}"
+    # Preserve the --auto opt-in across self-heal so cmd_send keeps using CR
+    # for wake-up after an intra-session re-seed (#128). Use `if` rather than
+    # `&&` so the brace group exits 0 when the flag is absent — otherwise
+    # pipefail would surface a stray exit-1 through `| _atomic_write` and
+    # `set -e` would abort the re-seed.
+    if [[ "${TASK_FORCE_AUTO_SUBMIT:-}" == "1" ]]; then
+      printf 'AUTO_SUBMIT=1\n'
+    fi
+  } | _atomic_write "$f"
 
   mkdir -p "$(_inbox_dir "$TASK_FORCE_ROLE")" "$(_processed_dir "$TASK_FORCE_ROLE")"
   _log "ensure_session: re-seeded $TASK_FORCE_ROLE (file was missing) tab_id=$tab_id"
@@ -323,9 +332,20 @@ cmd_register() {
     fi
   fi
 
-  printf 'ROLE=%s\nTAB=%s\nTAB_ID=%s\nREPO=%s\nSTATE=idle\nLAST_HEARTBEAT=%s\nAGENT=%s\nLOADOUT=%s\n' \
-    "$role" "$tab" "$tab_id" "$repo" "$(_now)" "$agent" "$loadout" \
-    | _atomic_write "$f"
+  {
+    printf 'ROLE=%s\nTAB=%s\nTAB_ID=%s\nREPO=%s\nSTATE=idle\nLAST_HEARTBEAT=%s\nAGENT=%s\nLOADOUT=%s\n' \
+      "$role" "$tab" "$tab_id" "$repo" "$(_now)" "$agent" "$loadout"
+    # Persist the --auto opt-in (#128). task-work --auto exports
+    # TASK_FORCE_AUTO_SUBMIT=1 into the tab's env; cmd_send reads AUTO_SUBMIT
+    # off the recipient's session file and flips wake-up from LF (manual) to
+    # CR (auto-submit). task-pm and default workers never export this, so
+    # they keep the human-gated default. `if` rather than `&&` so the brace
+    # group exits 0 even when the flag is absent — pipefail + set -e would
+    # otherwise abort register on every non-auto worker.
+    if [[ "${TASK_FORCE_AUTO_SUBMIT:-}" == "1" ]]; then
+      printf 'AUTO_SUBMIT=1\n'
+    fi
+  } | _atomic_write "$f"
 
   mkdir -p "$(_inbox_dir "$role")" "$(_processed_dir "$role")"
   _log "register role=$role tab=$tab tab_id=$tab_id agent=$agent loadout=$loadout"
@@ -463,12 +483,24 @@ cmd_send() {
     _log "send: no writable pane on tab_id=$rtab_id for $to — queued (id=$id)"
     return 0
   fi
-  # Only ever write the literal string "radio check\n" — never the message body
-  # or any caller-supplied data. `zellij write-chars` injects directly into the
-  # recipient's TUI input buffer; writing anything else risks corrupting the
-  # agent's unsaved prompt or smuggling content into a TUI command. The
-  # recipient reads the actual message via `radio check` / `radio read`.
-  zellij action write-chars --pane-id "$rpane_id" "radio check"$'\n' >/dev/null 2>&1 || {
+  # Only ever write the literal string "radio check<term>" — never the message
+  # body or any caller-supplied data. `zellij write-chars` injects directly
+  # into the recipient's TUI input buffer; writing anything else risks
+  # corrupting the agent's unsaved prompt or smuggling content into a TUI
+  # command. The recipient reads the actual message via `radio check` /
+  # `radio read`.
+  #
+  # Recipients launched via `task-work --auto` opt in to CR (auto-submit) so
+  # PM pings process without a manual Enter (#128). Everyone else — PM,
+  # default workers, pre-#128 workers with no AUTO_SUBMIT field — gets LF,
+  # which lands "radio check" in the input box and waits for the user to
+  # press Enter. The human gate is what protects partially-typed prompts
+  # from being corrupted by an incoming wake-up.
+  local wake_term=$'\n'
+  if [[ "$(_session_field "$rs" AUTO_SUBMIT || true)" == "1" ]]; then
+    wake_term=$'\r'
+  fi
+  zellij action write-chars --pane-id "$rpane_id" "radio check${wake_term}" >/dev/null 2>&1 || {
     _log "send: write-chars failed for $to (pane=$rpane_id) — queued (id=$id)"; return 0; }
   _log "send: woke $to via tab_id=$rtab_id pane=$rpane_id (id=$id)"
 }

--- a/kiro-gh/bin/task-work
+++ b/kiro-gh/bin/task-work
@@ -209,6 +209,11 @@ printf 'BASE_BRANCH=%s\nSLUG=%s\nGH_URL=%s\n' "$BASE_BRANCH" "$SLUG" "$GH_URL" >
 # command exports those vars to that command's environment only.
 TASK_FORCE_ROLE_VALUE="worker-${REPO_NAME}-${SLUG}"
 RADIO_ENV_PREFIX="TASK_FORCE_ROLE=$(printf %q "$TASK_FORCE_ROLE_VALUE") ZELLIJ_TAB=$(printf %q "$SLUG") "
+# Opt --auto workers into radio's CR (auto-submit) wake-up so PM pings process
+# without a manual Enter (#128). PM and non-auto workers leave this unset, so
+# radio keeps using LF — preserves the human gate that protects a partially-
+# typed prompt from being corrupted by an incoming `radio check`.
+[[ -n "${AUTO_MODE:-}" ]] && RADIO_ENV_PREFIX+="TASK_FORCE_AUTO_SUBMIT=1 "
 # endregion:radio-env-injection
 
 # region:worktree-creation-post-info

--- a/kiro-local/bin/radio
+++ b/kiro-local/bin/radio
@@ -166,10 +166,19 @@ _ensure_session_file() {
   local repo
   repo=$(git rev-parse --show-toplevel 2>/dev/null || echo "")
 
-  printf 'ROLE=%s\nTAB=%s\nTAB_ID=%s\nREPO=%s\nSTATE=idle\nLAST_HEARTBEAT=%s\nAGENT=%s\nLOADOUT=%s\n' \
-    "$TASK_FORCE_ROLE" "$ZELLIJ_TAB" "$tab_id" "$repo" "$(_now)" \
-    "${TASK_FORCE_AGENT:-claude}" "${TASK_FORCE_LOADOUT:-unknown}" \
-    | _atomic_write "$f"
+  {
+    printf 'ROLE=%s\nTAB=%s\nTAB_ID=%s\nREPO=%s\nSTATE=idle\nLAST_HEARTBEAT=%s\nAGENT=%s\nLOADOUT=%s\n' \
+      "$TASK_FORCE_ROLE" "$ZELLIJ_TAB" "$tab_id" "$repo" "$(_now)" \
+      "${TASK_FORCE_AGENT:-claude}" "${TASK_FORCE_LOADOUT:-unknown}"
+    # Preserve the --auto opt-in across self-heal so cmd_send keeps using CR
+    # for wake-up after an intra-session re-seed (#128). Use `if` rather than
+    # `&&` so the brace group exits 0 when the flag is absent — otherwise
+    # pipefail would surface a stray exit-1 through `| _atomic_write` and
+    # `set -e` would abort the re-seed.
+    if [[ "${TASK_FORCE_AUTO_SUBMIT:-}" == "1" ]]; then
+      printf 'AUTO_SUBMIT=1\n'
+    fi
+  } | _atomic_write "$f"
 
   mkdir -p "$(_inbox_dir "$TASK_FORCE_ROLE")" "$(_processed_dir "$TASK_FORCE_ROLE")"
   _log "ensure_session: re-seeded $TASK_FORCE_ROLE (file was missing) tab_id=$tab_id"
@@ -323,9 +332,20 @@ cmd_register() {
     fi
   fi
 
-  printf 'ROLE=%s\nTAB=%s\nTAB_ID=%s\nREPO=%s\nSTATE=idle\nLAST_HEARTBEAT=%s\nAGENT=%s\nLOADOUT=%s\n' \
-    "$role" "$tab" "$tab_id" "$repo" "$(_now)" "$agent" "$loadout" \
-    | _atomic_write "$f"
+  {
+    printf 'ROLE=%s\nTAB=%s\nTAB_ID=%s\nREPO=%s\nSTATE=idle\nLAST_HEARTBEAT=%s\nAGENT=%s\nLOADOUT=%s\n' \
+      "$role" "$tab" "$tab_id" "$repo" "$(_now)" "$agent" "$loadout"
+    # Persist the --auto opt-in (#128). task-work --auto exports
+    # TASK_FORCE_AUTO_SUBMIT=1 into the tab's env; cmd_send reads AUTO_SUBMIT
+    # off the recipient's session file and flips wake-up from LF (manual) to
+    # CR (auto-submit). task-pm and default workers never export this, so
+    # they keep the human-gated default. `if` rather than `&&` so the brace
+    # group exits 0 even when the flag is absent — pipefail + set -e would
+    # otherwise abort register on every non-auto worker.
+    if [[ "${TASK_FORCE_AUTO_SUBMIT:-}" == "1" ]]; then
+      printf 'AUTO_SUBMIT=1\n'
+    fi
+  } | _atomic_write "$f"
 
   mkdir -p "$(_inbox_dir "$role")" "$(_processed_dir "$role")"
   _log "register role=$role tab=$tab tab_id=$tab_id agent=$agent loadout=$loadout"
@@ -463,12 +483,24 @@ cmd_send() {
     _log "send: no writable pane on tab_id=$rtab_id for $to — queued (id=$id)"
     return 0
   fi
-  # Only ever write the literal string "radio check\n" — never the message body
-  # or any caller-supplied data. `zellij write-chars` injects directly into the
-  # recipient's TUI input buffer; writing anything else risks corrupting the
-  # agent's unsaved prompt or smuggling content into a TUI command. The
-  # recipient reads the actual message via `radio check` / `radio read`.
-  zellij action write-chars --pane-id "$rpane_id" "radio check"$'\n' >/dev/null 2>&1 || {
+  # Only ever write the literal string "radio check<term>" — never the message
+  # body or any caller-supplied data. `zellij write-chars` injects directly
+  # into the recipient's TUI input buffer; writing anything else risks
+  # corrupting the agent's unsaved prompt or smuggling content into a TUI
+  # command. The recipient reads the actual message via `radio check` /
+  # `radio read`.
+  #
+  # Recipients launched via `task-work --auto` opt in to CR (auto-submit) so
+  # PM pings process without a manual Enter (#128). Everyone else — PM,
+  # default workers, pre-#128 workers with no AUTO_SUBMIT field — gets LF,
+  # which lands "radio check" in the input box and waits for the user to
+  # press Enter. The human gate is what protects partially-typed prompts
+  # from being corrupted by an incoming wake-up.
+  local wake_term=$'\n'
+  if [[ "$(_session_field "$rs" AUTO_SUBMIT || true)" == "1" ]]; then
+    wake_term=$'\r'
+  fi
+  zellij action write-chars --pane-id "$rpane_id" "radio check${wake_term}" >/dev/null 2>&1 || {
     _log "send: write-chars failed for $to (pane=$rpane_id) — queued (id=$id)"; return 0; }
   _log "send: woke $to via tab_id=$rtab_id pane=$rpane_id (id=$id)"
 }

--- a/kiro-local/bin/task-work
+++ b/kiro-local/bin/task-work
@@ -230,6 +230,11 @@ fi
 # command exports those vars to that command's environment only.
 TASK_FORCE_ROLE_VALUE="worker-${REPO_NAME}-${SLUG}"
 RADIO_ENV_PREFIX="TASK_FORCE_ROLE=$(printf %q "$TASK_FORCE_ROLE_VALUE") ZELLIJ_TAB=$(printf %q "$SLUG") "
+# Opt --auto workers into radio's CR (auto-submit) wake-up so PM pings process
+# without a manual Enter (#128). PM and non-auto workers leave this unset, so
+# radio keeps using LF — preserves the human gate that protects a partially-
+# typed prompt from being corrupted by an incoming `radio check`.
+[[ -n "${AUTO_MODE:-}" ]] && RADIO_ENV_PREFIX+="TASK_FORCE_AUTO_SUBMIT=1 "
 # endregion:radio-env-injection
 
 # region:worktree-creation-post-info

--- a/kiro-notion/bin/radio
+++ b/kiro-notion/bin/radio
@@ -166,10 +166,19 @@ _ensure_session_file() {
   local repo
   repo=$(git rev-parse --show-toplevel 2>/dev/null || echo "")
 
-  printf 'ROLE=%s\nTAB=%s\nTAB_ID=%s\nREPO=%s\nSTATE=idle\nLAST_HEARTBEAT=%s\nAGENT=%s\nLOADOUT=%s\n' \
-    "$TASK_FORCE_ROLE" "$ZELLIJ_TAB" "$tab_id" "$repo" "$(_now)" \
-    "${TASK_FORCE_AGENT:-claude}" "${TASK_FORCE_LOADOUT:-unknown}" \
-    | _atomic_write "$f"
+  {
+    printf 'ROLE=%s\nTAB=%s\nTAB_ID=%s\nREPO=%s\nSTATE=idle\nLAST_HEARTBEAT=%s\nAGENT=%s\nLOADOUT=%s\n' \
+      "$TASK_FORCE_ROLE" "$ZELLIJ_TAB" "$tab_id" "$repo" "$(_now)" \
+      "${TASK_FORCE_AGENT:-claude}" "${TASK_FORCE_LOADOUT:-unknown}"
+    # Preserve the --auto opt-in across self-heal so cmd_send keeps using CR
+    # for wake-up after an intra-session re-seed (#128). Use `if` rather than
+    # `&&` so the brace group exits 0 when the flag is absent — otherwise
+    # pipefail would surface a stray exit-1 through `| _atomic_write` and
+    # `set -e` would abort the re-seed.
+    if [[ "${TASK_FORCE_AUTO_SUBMIT:-}" == "1" ]]; then
+      printf 'AUTO_SUBMIT=1\n'
+    fi
+  } | _atomic_write "$f"
 
   mkdir -p "$(_inbox_dir "$TASK_FORCE_ROLE")" "$(_processed_dir "$TASK_FORCE_ROLE")"
   _log "ensure_session: re-seeded $TASK_FORCE_ROLE (file was missing) tab_id=$tab_id"
@@ -323,9 +332,20 @@ cmd_register() {
     fi
   fi
 
-  printf 'ROLE=%s\nTAB=%s\nTAB_ID=%s\nREPO=%s\nSTATE=idle\nLAST_HEARTBEAT=%s\nAGENT=%s\nLOADOUT=%s\n' \
-    "$role" "$tab" "$tab_id" "$repo" "$(_now)" "$agent" "$loadout" \
-    | _atomic_write "$f"
+  {
+    printf 'ROLE=%s\nTAB=%s\nTAB_ID=%s\nREPO=%s\nSTATE=idle\nLAST_HEARTBEAT=%s\nAGENT=%s\nLOADOUT=%s\n' \
+      "$role" "$tab" "$tab_id" "$repo" "$(_now)" "$agent" "$loadout"
+    # Persist the --auto opt-in (#128). task-work --auto exports
+    # TASK_FORCE_AUTO_SUBMIT=1 into the tab's env; cmd_send reads AUTO_SUBMIT
+    # off the recipient's session file and flips wake-up from LF (manual) to
+    # CR (auto-submit). task-pm and default workers never export this, so
+    # they keep the human-gated default. `if` rather than `&&` so the brace
+    # group exits 0 even when the flag is absent — pipefail + set -e would
+    # otherwise abort register on every non-auto worker.
+    if [[ "${TASK_FORCE_AUTO_SUBMIT:-}" == "1" ]]; then
+      printf 'AUTO_SUBMIT=1\n'
+    fi
+  } | _atomic_write "$f"
 
   mkdir -p "$(_inbox_dir "$role")" "$(_processed_dir "$role")"
   _log "register role=$role tab=$tab tab_id=$tab_id agent=$agent loadout=$loadout"
@@ -463,12 +483,24 @@ cmd_send() {
     _log "send: no writable pane on tab_id=$rtab_id for $to — queued (id=$id)"
     return 0
   fi
-  # Only ever write the literal string "radio check\n" — never the message body
-  # or any caller-supplied data. `zellij write-chars` injects directly into the
-  # recipient's TUI input buffer; writing anything else risks corrupting the
-  # agent's unsaved prompt or smuggling content into a TUI command. The
-  # recipient reads the actual message via `radio check` / `radio read`.
-  zellij action write-chars --pane-id "$rpane_id" "radio check"$'\n' >/dev/null 2>&1 || {
+  # Only ever write the literal string "radio check<term>" — never the message
+  # body or any caller-supplied data. `zellij write-chars` injects directly
+  # into the recipient's TUI input buffer; writing anything else risks
+  # corrupting the agent's unsaved prompt or smuggling content into a TUI
+  # command. The recipient reads the actual message via `radio check` /
+  # `radio read`.
+  #
+  # Recipients launched via `task-work --auto` opt in to CR (auto-submit) so
+  # PM pings process without a manual Enter (#128). Everyone else — PM,
+  # default workers, pre-#128 workers with no AUTO_SUBMIT field — gets LF,
+  # which lands "radio check" in the input box and waits for the user to
+  # press Enter. The human gate is what protects partially-typed prompts
+  # from being corrupted by an incoming wake-up.
+  local wake_term=$'\n'
+  if [[ "$(_session_field "$rs" AUTO_SUBMIT || true)" == "1" ]]; then
+    wake_term=$'\r'
+  fi
+  zellij action write-chars --pane-id "$rpane_id" "radio check${wake_term}" >/dev/null 2>&1 || {
     _log "send: write-chars failed for $to (pane=$rpane_id) — queued (id=$id)"; return 0; }
   _log "send: woke $to via tab_id=$rtab_id pane=$rpane_id (id=$id)"
 }

--- a/kiro-notion/bin/task-work
+++ b/kiro-notion/bin/task-work
@@ -211,6 +211,11 @@ printf 'BASE_BRANCH=%s\nSLUG=%s\nNOTION_URL=%s\n' "$BASE_BRANCH" "$SLUG" "$NOTIO
 # command exports those vars to that command's environment only.
 TASK_FORCE_ROLE_VALUE="worker-${REPO_NAME}-${SLUG}"
 RADIO_ENV_PREFIX="TASK_FORCE_ROLE=$(printf %q "$TASK_FORCE_ROLE_VALUE") ZELLIJ_TAB=$(printf %q "$SLUG") "
+# Opt --auto workers into radio's CR (auto-submit) wake-up so PM pings process
+# without a manual Enter (#128). PM and non-auto workers leave this unset, so
+# radio keeps using LF — preserves the human gate that protects a partially-
+# typed prompt from being corrupted by an incoming `radio check`.
+[[ -n "${AUTO_MODE:-}" ]] && RADIO_ENV_PREFIX+="TASK_FORCE_AUTO_SUBMIT=1 "
 # endregion:radio-env-injection
 
 # region:worktree-creation-post-info

--- a/tests/radio_auto_submit.bats
+++ b/tests/radio_auto_submit.bats
@@ -1,0 +1,115 @@
+#!/usr/bin/env bats
+# Pins the opt-in CR (auto-submit) wake-up contract for --auto workers (#128).
+#
+# Contract:
+#   - `radio register` with TASK_FORCE_AUTO_SUBMIT=1 in env → AUTO_SUBMIT=1 in
+#     session file. Absent / any other value → no AUTO_SUBMIT line (legacy).
+#   - `radio send` to a recipient whose session file has AUTO_SUBMIT=1 writes
+#     "radio check" + CR (0x0D) via zellij write-chars. Otherwise LF (0x0A).
+#   - `_ensure_session_file` (the self-heal path) re-applies the same env check
+#     so the opt-in survives /clear, /compact, /resume.
+
+bats_load_library bats-support
+bats_load_library bats-assert
+
+load helpers/common
+
+setup() {
+  setup_task_force_home
+  setup_stubs
+  export ZELLIJ=fake-session
+  export TASK_FORCE_ROLE=test-runner
+  unset ZELLIJ_TAB
+  # pm gets tab_id=7, pane_id=700; worker-foo gets tab_id=8, pane_id=800.
+  seed_zellij_tabs pm worker-foo
+}
+
+teardown() {
+  teardown_all
+}
+
+# ----- register: persist AUTO_SUBMIT only when env opt-in is set -------------
+
+@test "register persists AUTO_SUBMIT=1 when TASK_FORCE_AUTO_SUBMIT=1 is in env" {
+  TASK_FORCE_AUTO_SUBMIT=1 "$RADIO" register --role worker-foo --tab worker-foo --agent claude
+  run cat "$TASK_FORCE_HOME/radio/sessions/worker-foo.info"
+  assert_output --partial "AUTO_SUBMIT=1"
+}
+
+@test "register omits AUTO_SUBMIT when the env var is unset (legacy default)" {
+  "$RADIO" register --role worker-foo --tab worker-foo --agent claude
+  run cat "$TASK_FORCE_HOME/radio/sessions/worker-foo.info"
+  refute_output --partial "AUTO_SUBMIT"
+}
+
+@test "register omits AUTO_SUBMIT when the env var holds anything but the exact value 1" {
+  TASK_FORCE_AUTO_SUBMIT=true "$RADIO" register --role worker-foo --tab worker-foo --agent claude
+  run cat "$TASK_FORCE_HOME/radio/sessions/worker-foo.info"
+  refute_output --partial "AUTO_SUBMIT"
+}
+
+# ----- send: CR if AUTO_SUBMIT=1, LF otherwise -------------------------------
+
+@test "send to AUTO_SUBMIT=1 recipient writes 'radio check' followed by CR (0x0D)" {
+  TASK_FORCE_AUTO_SUBMIT=1 "$RADIO" register --role worker-foo --tab worker-foo --agent claude
+  TASK_FORCE_ROLE=pm "$RADIO" send --to worker-foo --intent approved-and-merged --body "merged"
+
+  # The zellij stub records calls with the literal byte preserved.
+  # CR (0x0D) terminates the wake-up — that's the Enter the recipient TUI
+  # binds to.
+  run grep -cF $'radio check\r' "$STUB_CALLS_DIR/zellij.calls"
+  assert_output "1"
+}
+
+@test "send to default recipient (no AUTO_SUBMIT) preserves LF (0x0A) wake-up" {
+  "$RADIO" register --role worker-foo --tab worker-foo --agent claude
+  TASK_FORCE_ROLE=pm "$RADIO" send --to worker-foo --intent changes-requested --body "rework"
+
+  # No CR-terminated wake-up — legacy behaviour intact.
+  run grep -cF $'radio check\r' "$STUB_CALLS_DIR/zellij.calls"
+  assert_output "0"
+  # Sanity: write-chars did fire (recipient was idle and reachable).
+  assert_stub_called zellij "action write-chars --pane-id 800 radio check"
+}
+
+@test "send to PM (which never opts in) always uses LF, even if sender is --auto" {
+  # PM registers without the env flag.
+  "$RADIO" register --role pm --tab pm --agent claude
+  # Worker sends back review-requested with the flag in its own env. The CR/LF
+  # decision is driven by the *recipient's* session file, not the sender's env.
+  TASK_FORCE_ROLE=worker-foo TASK_FORCE_AUTO_SUBMIT=1 \
+    "$RADIO" send --to pm --intent review-requested --body "PR up"
+
+  run grep -cF $'radio check\r' "$STUB_CALLS_DIR/zellij.calls"
+  assert_output "0"
+  assert_stub_called zellij "action write-chars --pane-id 700 radio check"
+}
+
+# ----- _ensure_session_file: preserve the opt-in across self-heal -----------
+
+@test "_ensure_session_file re-seeds AUTO_SUBMIT=1 when env still has the flag" {
+  # Simulate a worker tab where SessionStart did not (or no longer) hold the
+  # session file. busy → _update_state → _ensure_session_file triggers the
+  # re-seed branch.
+  unset TASK_FORCE_ROLE
+  export TASK_FORCE_ROLE=worker-foo
+  export ZELLIJ_TAB=worker-foo
+  export TASK_FORCE_AUTO_SUBMIT=1
+
+  "$RADIO" busy
+
+  run cat "$TASK_FORCE_HOME/radio/sessions/worker-foo.info"
+  assert_output --partial "AUTO_SUBMIT=1"
+  assert_output --partial "STATE=busy"
+}
+
+@test "_ensure_session_file omits AUTO_SUBMIT when env flag is absent" {
+  unset TASK_FORCE_ROLE
+  export TASK_FORCE_ROLE=worker-foo
+  export ZELLIJ_TAB=worker-foo
+
+  "$RADIO" busy
+
+  run cat "$TASK_FORCE_HOME/radio/sessions/worker-foo.info"
+  refute_output --partial "AUTO_SUBMIT"
+}


### PR DESCRIPTION
## Summary

Implements #128. `radio send`'s zellij `write-chars` wake-up writes `radio check` + a terminator into the recipient's pane. The current LF (`\n`) leaves it sitting in Claude Code's input box until the user presses Enter — desirable for PM (protects a partially-typed prompt) but pure friction for workers, which idle most of their life waiting on PM pings.

This PR adds an **opt-in** auto-submit gated on the existing autonomy signal:

- `task-work --auto` (all 7 loadouts, `radio-env-injection` region): exports `TASK_FORCE_AUTO_SUBMIT=1` alongside the existing radio env vars.
- `radio register` + `_ensure_session_file` (all 7): if `$TASK_FORCE_AUTO_SUBMIT=1` is in env, write `AUTO_SUBMIT=1` into the session `.info` file; self-heal preserves it.
- `radio send`: reads `AUTO_SUBMIT` from the recipient's session file. `=1` → CR (`\r`, triggers Enter). Anything else (including legacy / absent) → LF (current behaviour).

Send-gate (STATE != idle → queue silently) is unchanged. PM never sets the env var, so its wake-ups stay LF-gated.

## Test plan

- [x] `./run_tests.sh` — all 651 tests pass, including new `tests/radio_auto_submit.bats` (8 tests pinning the contract).
- [x] `tools/check-drift.sh` — all 17 region groups clean (radio body + task-work radio-env-injection edits are byte-identical across all 7 loadouts).
- [ ] Manual: launch `task-work … --auto` worker, verify `~/.task-force/radio/sessions/worker-*.info` contains `AUTO_SUBMIT=1`, then `radio send` from PM and confirm the worker processes the message without a manual Enter.
- [ ] Manual negative: launch a default (non-`--auto`) worker, confirm no `AUTO_SUBMIT` line and that `radio check` still awaits Enter.
- [ ] Manual: confirm PM never auto-submits, even when pinged by an `--auto` worker.

🤖 Generated with [Claude Code](https://claude.com/claude-code)