### PR TITLE
radio: read should auto-ack (move inbox→processed); add --peek escape hatch (#131)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,10 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 
 ## [Unreleased]
 
+### Changed
+
+- **`radio read <id>` now auto-acks (moves `inbox/` → `processed/`).** The previous `read` + `ack` split was a workflow footgun: workers would `read` a message, act on it, forget to `ack`, and every subsequent `radio check` would re-list the stale entry identically — making PM's silence indistinguishable from PM never having pinged. `read` now collapses both beats by default. An explicit `radio read --peek <id>` (alias: `--no-ack`) is the escape hatch for "I just want to see what's in there without consuming it." `radio ack <id>` is now idempotent: if the message was already moved by a prior `read`, it exits 0 with a friendly "already processed" line so existing `read && ack` scripts and muscle memory keep working. This is a deliberate UX change, not a bug fix — the old behavior was the intended (broken) design. (#131)
+
 ### Added
 
 - **Opt-in auto-submit on radio wake-up for `--auto` workers.** `radio send`'s zellij `write-chars` wake-up has always written `radio check\n` (LF) into the recipient's pane, leaving it sitting in the input box until the user pressed Enter. For workers launched via `task-work --auto` — already an explicit autonomy opt-in, and idle most of their life waiting on PM — that human gate is friction with no upside. `task-work --auto` now exports `TASK_FORCE_AUTO_SUBMIT=1`; `radio register` / `_ensure_session_file` persist that as `AUTO_SUBMIT=1` in the session file; `cmd_send` reads it and switches the wake-up byte to CR (`\r`), which Claude Code's raw-mode input binds to Enter. PM and default (non-`--auto`) workers leave the flag unset and keep the LF wake-up, so a `radio check` ping can never corrupt a partially-typed prompt. (#128)

--- a/README.md
+++ b/README.md
@@ -382,8 +382,9 @@ Role names are addressable strings, not free-form: the PM is `pm`, and each work
 |---------|--------------|
 | `radio send --to <role> --intent <kind> [--pr N] [--issue N] [--body TEXT]` | Send a message (e.g. `--to pm --intent review-requested --pr 42`); body can come from stdin |
 | `radio check`                       | List unread messages addressed to this role |
-| `radio read <id>`                   | Print one message |
-| `radio ack <id>`                    | Mark it acknowledged so it stops showing up in `check` |
+| `radio read <id>`                   | Print one message AND mark it acknowledged (moves `inbox/` → `processed/`) |
+| `radio read --peek <id>`            | Print without acknowledging — for inspection / debugging |
+| `radio ack <id>`                    | Mark it acknowledged (idempotent — no-op if already processed by a prior `read`) |
 | `radio register` / `radio unregister` | Add/remove this tab's session file (`~/.task-force/radio/sessions/<role>.info`) |
 | `radio ready` / `radio busy`        | Toggle this session's `STATE` field — drives the wake-up vs. queue decision on the sender side |
 | `radio orphans`                     | List session files whose heartbeat is >1h stale |

--- a/claude-gh/bin/radio
+++ b/claude-gh/bin/radio
@@ -14,8 +14,8 @@ usage() {
 Usage:
   radio send --to ROLE --intent KIND [--pr N] [--issue N] [--repo PATH] [--body TEXT | < body]
   radio check                            list unread messages for this role
-  radio read   <id>                      print message body
-  radio ack    <id>                      move message to processed/
+  radio read   [--peek|--no-ack] <id>    print body; by default also move inbox/<id>.md -> processed/
+  radio ack    <id>                      move message to processed/ (idempotent: no-op if already processed)
   radio register --role ROLE --tab TAB [--repo PATH] --agent claude|kiro [--loadout NAME]
   radio ready                            mark this role idle (and process pending)
   radio busy                             mark this role busy
@@ -529,15 +529,38 @@ cmd_check() {
 
 cmd_read() {
   _require_role
-  local id="${1:-}"
+  # Default beat is read+ack: print body, then move inbox -> processed. The
+  # split between `read` and `ack` was a footgun — workers would `read`, act,
+  # and forget to `ack`, leaving stale messages that re-listed on every
+  # `radio check` (see #131). `--peek` / `--no-ack` is the escape hatch for
+  # inspection without consuming.
+  local peek=0
+  local id=""
+  while (($#)); do
+    case "$1" in
+      --peek|--no-ack) peek=1; shift ;;
+      --) shift; break ;;
+      -*) echo "read: unknown flag $1" >&2; exit 2 ;;
+      *) id="$1"; shift ;;
+    esac
+  done
   [[ -n "$id" ]] || { echo "read: <id> required" >&2; exit 2; }
-  local f
-  f="$(_inbox_dir "$TASK_FORCE_ROLE")/${id}.md"
-  if [[ ! -f "$f" ]]; then
-    f="$(_processed_dir "$TASK_FORCE_ROLE")/${id}.md"
+  local inbox processed
+  inbox=$(_inbox_dir "$TASK_FORCE_ROLE")
+  processed=$(_processed_dir "$TASK_FORCE_ROLE")
+  local src="$inbox/${id}.md"
+  local in_inbox=1
+  if [[ ! -f "$src" ]]; then
+    src="$processed/${id}.md"
+    in_inbox=0
   fi
-  [[ -f "$f" ]] || { echo "read: message $id not found" >&2; exit 1; }
-  cat "$f"
+  [[ -f "$src" ]] || { echo "read: message $id not found" >&2; exit 1; }
+  cat "$src"
+  if (( peek == 0 )) && (( in_inbox == 1 )); then
+    mkdir -p "$processed"
+    mv -f "$src" "$processed/"
+    _log "read+ack id=$id role=$TASK_FORCE_ROLE"
+  fi
 }
 
 cmd_ack() {
@@ -548,7 +571,16 @@ cmd_ack() {
   inbox=$(_inbox_dir "$TASK_FORCE_ROLE")
   processed=$(_processed_dir "$TASK_FORCE_ROLE")
   local src="$inbox/${id}.md"
-  [[ -f "$src" ]] || { echo "ack: message $id not in inbox" >&2; exit 1; }
+  # Idempotent: if `read` already auto-acked (post-#131), exit 0 quietly so
+  # existing `read && ack` scripts and muscle memory don't break.
+  if [[ ! -f "$src" ]]; then
+    if [[ -f "$processed/${id}.md" ]]; then
+      echo "ack: message $id already processed"
+      return 0
+    fi
+    echo "ack: message $id not in inbox" >&2
+    exit 1
+  fi
   mkdir -p "$processed"
   mv -f "$src" "$processed/"
   _log "ack id=$id role=$TASK_FORCE_ROLE"

--- a/claude-jira/bin/radio
+++ b/claude-jira/bin/radio
@@ -14,8 +14,8 @@ usage() {
 Usage:
   radio send --to ROLE --intent KIND [--pr N] [--issue N] [--repo PATH] [--body TEXT | < body]
   radio check                            list unread messages for this role
-  radio read   <id>                      print message body
-  radio ack    <id>                      move message to processed/
+  radio read   [--peek|--no-ack] <id>    print body; by default also move inbox/<id>.md -> processed/
+  radio ack    <id>                      move message to processed/ (idempotent: no-op if already processed)
   radio register --role ROLE --tab TAB [--repo PATH] --agent claude|kiro [--loadout NAME]
   radio ready                            mark this role idle (and process pending)
   radio busy                             mark this role busy
@@ -529,15 +529,38 @@ cmd_check() {
 
 cmd_read() {
   _require_role
-  local id="${1:-}"
+  # Default beat is read+ack: print body, then move inbox -> processed. The
+  # split between `read` and `ack` was a footgun — workers would `read`, act,
+  # and forget to `ack`, leaving stale messages that re-listed on every
+  # `radio check` (see #131). `--peek` / `--no-ack` is the escape hatch for
+  # inspection without consuming.
+  local peek=0
+  local id=""
+  while (($#)); do
+    case "$1" in
+      --peek|--no-ack) peek=1; shift ;;
+      --) shift; break ;;
+      -*) echo "read: unknown flag $1" >&2; exit 2 ;;
+      *) id="$1"; shift ;;
+    esac
+  done
   [[ -n "$id" ]] || { echo "read: <id> required" >&2; exit 2; }
-  local f
-  f="$(_inbox_dir "$TASK_FORCE_ROLE")/${id}.md"
-  if [[ ! -f "$f" ]]; then
-    f="$(_processed_dir "$TASK_FORCE_ROLE")/${id}.md"
+  local inbox processed
+  inbox=$(_inbox_dir "$TASK_FORCE_ROLE")
+  processed=$(_processed_dir "$TASK_FORCE_ROLE")
+  local src="$inbox/${id}.md"
+  local in_inbox=1
+  if [[ ! -f "$src" ]]; then
+    src="$processed/${id}.md"
+    in_inbox=0
   fi
-  [[ -f "$f" ]] || { echo "read: message $id not found" >&2; exit 1; }
-  cat "$f"
+  [[ -f "$src" ]] || { echo "read: message $id not found" >&2; exit 1; }
+  cat "$src"
+  if (( peek == 0 )) && (( in_inbox == 1 )); then
+    mkdir -p "$processed"
+    mv -f "$src" "$processed/"
+    _log "read+ack id=$id role=$TASK_FORCE_ROLE"
+  fi
 }
 
 cmd_ack() {
@@ -548,7 +571,16 @@ cmd_ack() {
   inbox=$(_inbox_dir "$TASK_FORCE_ROLE")
   processed=$(_processed_dir "$TASK_FORCE_ROLE")
   local src="$inbox/${id}.md"
-  [[ -f "$src" ]] || { echo "ack: message $id not in inbox" >&2; exit 1; }
+  # Idempotent: if `read` already auto-acked (post-#131), exit 0 quietly so
+  # existing `read && ack` scripts and muscle memory don't break.
+  if [[ ! -f "$src" ]]; then
+    if [[ -f "$processed/${id}.md" ]]; then
+      echo "ack: message $id already processed"
+      return 0
+    fi
+    echo "ack: message $id not in inbox" >&2
+    exit 1
+  fi
   mkdir -p "$processed"
   mv -f "$src" "$processed/"
   _log "ack id=$id role=$TASK_FORCE_ROLE"

--- a/claude-local/bin/radio
+++ b/claude-local/bin/radio
@@ -14,8 +14,8 @@ usage() {
 Usage:
   radio send --to ROLE --intent KIND [--pr N] [--issue N] [--repo PATH] [--body TEXT | < body]
   radio check                            list unread messages for this role
-  radio read   <id>                      print message body
-  radio ack    <id>                      move message to processed/
+  radio read   [--peek|--no-ack] <id>    print body; by default also move inbox/<id>.md -> processed/
+  radio ack    <id>                      move message to processed/ (idempotent: no-op if already processed)
   radio register --role ROLE --tab TAB [--repo PATH] --agent claude|kiro [--loadout NAME]
   radio ready                            mark this role idle (and process pending)
   radio busy                             mark this role busy
@@ -529,15 +529,38 @@ cmd_check() {
 
 cmd_read() {
   _require_role
-  local id="${1:-}"
+  # Default beat is read+ack: print body, then move inbox -> processed. The
+  # split between `read` and `ack` was a footgun — workers would `read`, act,
+  # and forget to `ack`, leaving stale messages that re-listed on every
+  # `radio check` (see #131). `--peek` / `--no-ack` is the escape hatch for
+  # inspection without consuming.
+  local peek=0
+  local id=""
+  while (($#)); do
+    case "$1" in
+      --peek|--no-ack) peek=1; shift ;;
+      --) shift; break ;;
+      -*) echo "read: unknown flag $1" >&2; exit 2 ;;
+      *) id="$1"; shift ;;
+    esac
+  done
   [[ -n "$id" ]] || { echo "read: <id> required" >&2; exit 2; }
-  local f
-  f="$(_inbox_dir "$TASK_FORCE_ROLE")/${id}.md"
-  if [[ ! -f "$f" ]]; then
-    f="$(_processed_dir "$TASK_FORCE_ROLE")/${id}.md"
+  local inbox processed
+  inbox=$(_inbox_dir "$TASK_FORCE_ROLE")
+  processed=$(_processed_dir "$TASK_FORCE_ROLE")
+  local src="$inbox/${id}.md"
+  local in_inbox=1
+  if [[ ! -f "$src" ]]; then
+    src="$processed/${id}.md"
+    in_inbox=0
   fi
-  [[ -f "$f" ]] || { echo "read: message $id not found" >&2; exit 1; }
-  cat "$f"
+  [[ -f "$src" ]] || { echo "read: message $id not found" >&2; exit 1; }
+  cat "$src"
+  if (( peek == 0 )) && (( in_inbox == 1 )); then
+    mkdir -p "$processed"
+    mv -f "$src" "$processed/"
+    _log "read+ack id=$id role=$TASK_FORCE_ROLE"
+  fi
 }
 
 cmd_ack() {
@@ -548,7 +571,16 @@ cmd_ack() {
   inbox=$(_inbox_dir "$TASK_FORCE_ROLE")
   processed=$(_processed_dir "$TASK_FORCE_ROLE")
   local src="$inbox/${id}.md"
-  [[ -f "$src" ]] || { echo "ack: message $id not in inbox" >&2; exit 1; }
+  # Idempotent: if `read` already auto-acked (post-#131), exit 0 quietly so
+  # existing `read && ack` scripts and muscle memory don't break.
+  if [[ ! -f "$src" ]]; then
+    if [[ -f "$processed/${id}.md" ]]; then
+      echo "ack: message $id already processed"
+      return 0
+    fi
+    echo "ack: message $id not in inbox" >&2
+    exit 1
+  fi
   mkdir -p "$processed"
   mv -f "$src" "$processed/"
   _log "ack id=$id role=$TASK_FORCE_ROLE"

--- a/claude-notion/bin/radio
+++ b/claude-notion/bin/radio
@@ -14,8 +14,8 @@ usage() {
 Usage:
   radio send --to ROLE --intent KIND [--pr N] [--issue N] [--repo PATH] [--body TEXT | < body]
   radio check                            list unread messages for this role
-  radio read   <id>                      print message body
-  radio ack    <id>                      move message to processed/
+  radio read   [--peek|--no-ack] <id>    print body; by default also move inbox/<id>.md -> processed/
+  radio ack    <id>                      move message to processed/ (idempotent: no-op if already processed)
   radio register --role ROLE --tab TAB [--repo PATH] --agent claude|kiro [--loadout NAME]
   radio ready                            mark this role idle (and process pending)
   radio busy                             mark this role busy
@@ -529,15 +529,38 @@ cmd_check() {
 
 cmd_read() {
   _require_role
-  local id="${1:-}"
+  # Default beat is read+ack: print body, then move inbox -> processed. The
+  # split between `read` and `ack` was a footgun — workers would `read`, act,
+  # and forget to `ack`, leaving stale messages that re-listed on every
+  # `radio check` (see #131). `--peek` / `--no-ack` is the escape hatch for
+  # inspection without consuming.
+  local peek=0
+  local id=""
+  while (($#)); do
+    case "$1" in
+      --peek|--no-ack) peek=1; shift ;;
+      --) shift; break ;;
+      -*) echo "read: unknown flag $1" >&2; exit 2 ;;
+      *) id="$1"; shift ;;
+    esac
+  done
   [[ -n "$id" ]] || { echo "read: <id> required" >&2; exit 2; }
-  local f
-  f="$(_inbox_dir "$TASK_FORCE_ROLE")/${id}.md"
-  if [[ ! -f "$f" ]]; then
-    f="$(_processed_dir "$TASK_FORCE_ROLE")/${id}.md"
+  local inbox processed
+  inbox=$(_inbox_dir "$TASK_FORCE_ROLE")
+  processed=$(_processed_dir "$TASK_FORCE_ROLE")
+  local src="$inbox/${id}.md"
+  local in_inbox=1
+  if [[ ! -f "$src" ]]; then
+    src="$processed/${id}.md"
+    in_inbox=0
   fi
-  [[ -f "$f" ]] || { echo "read: message $id not found" >&2; exit 1; }
-  cat "$f"
+  [[ -f "$src" ]] || { echo "read: message $id not found" >&2; exit 1; }
+  cat "$src"
+  if (( peek == 0 )) && (( in_inbox == 1 )); then
+    mkdir -p "$processed"
+    mv -f "$src" "$processed/"
+    _log "read+ack id=$id role=$TASK_FORCE_ROLE"
+  fi
 }
 
 cmd_ack() {
@@ -548,7 +571,16 @@ cmd_ack() {
   inbox=$(_inbox_dir "$TASK_FORCE_ROLE")
   processed=$(_processed_dir "$TASK_FORCE_ROLE")
   local src="$inbox/${id}.md"
-  [[ -f "$src" ]] || { echo "ack: message $id not in inbox" >&2; exit 1; }
+  # Idempotent: if `read` already auto-acked (post-#131), exit 0 quietly so
+  # existing `read && ack` scripts and muscle memory don't break.
+  if [[ ! -f "$src" ]]; then
+    if [[ -f "$processed/${id}.md" ]]; then
+      echo "ack: message $id already processed"
+      return 0
+    fi
+    echo "ack: message $id not in inbox" >&2
+    exit 1
+  fi
   mkdir -p "$processed"
   mv -f "$src" "$processed/"
   _log "ack id=$id role=$TASK_FORCE_ROLE"

--- a/kiro-gh/bin/radio
+++ b/kiro-gh/bin/radio
@@ -14,8 +14,8 @@ usage() {
 Usage:
   radio send --to ROLE --intent KIND [--pr N] [--issue N] [--repo PATH] [--body TEXT | < body]
   radio check                            list unread messages for this role
-  radio read   <id>                      print message body
-  radio ack    <id>                      move message to processed/
+  radio read   [--peek|--no-ack] <id>    print body; by default also move inbox/<id>.md -> processed/
+  radio ack    <id>                      move message to processed/ (idempotent: no-op if already processed)
   radio register --role ROLE --tab TAB [--repo PATH] --agent claude|kiro [--loadout NAME]
   radio ready                            mark this role idle (and process pending)
   radio busy                             mark this role busy
@@ -529,15 +529,38 @@ cmd_check() {
 
 cmd_read() {
   _require_role
-  local id="${1:-}"
+  # Default beat is read+ack: print body, then move inbox -> processed. The
+  # split between `read` and `ack` was a footgun — workers would `read`, act,
+  # and forget to `ack`, leaving stale messages that re-listed on every
+  # `radio check` (see #131). `--peek` / `--no-ack` is the escape hatch for
+  # inspection without consuming.
+  local peek=0
+  local id=""
+  while (($#)); do
+    case "$1" in
+      --peek|--no-ack) peek=1; shift ;;
+      --) shift; break ;;
+      -*) echo "read: unknown flag $1" >&2; exit 2 ;;
+      *) id="$1"; shift ;;
+    esac
+  done
   [[ -n "$id" ]] || { echo "read: <id> required" >&2; exit 2; }
-  local f
-  f="$(_inbox_dir "$TASK_FORCE_ROLE")/${id}.md"
-  if [[ ! -f "$f" ]]; then
-    f="$(_processed_dir "$TASK_FORCE_ROLE")/${id}.md"
+  local inbox processed
+  inbox=$(_inbox_dir "$TASK_FORCE_ROLE")
+  processed=$(_processed_dir "$TASK_FORCE_ROLE")
+  local src="$inbox/${id}.md"
+  local in_inbox=1
+  if [[ ! -f "$src" ]]; then
+    src="$processed/${id}.md"
+    in_inbox=0
   fi
-  [[ -f "$f" ]] || { echo "read: message $id not found" >&2; exit 1; }
-  cat "$f"
+  [[ -f "$src" ]] || { echo "read: message $id not found" >&2; exit 1; }
+  cat "$src"
+  if (( peek == 0 )) && (( in_inbox == 1 )); then
+    mkdir -p "$processed"
+    mv -f "$src" "$processed/"
+    _log "read+ack id=$id role=$TASK_FORCE_ROLE"
+  fi
 }
 
 cmd_ack() {
@@ -548,7 +571,16 @@ cmd_ack() {
   inbox=$(_inbox_dir "$TASK_FORCE_ROLE")
   processed=$(_processed_dir "$TASK_FORCE_ROLE")
   local src="$inbox/${id}.md"
-  [[ -f "$src" ]] || { echo "ack: message $id not in inbox" >&2; exit 1; }
+  # Idempotent: if `read` already auto-acked (post-#131), exit 0 quietly so
+  # existing `read && ack` scripts and muscle memory don't break.
+  if [[ ! -f "$src" ]]; then
+    if [[ -f "$processed/${id}.md" ]]; then
+      echo "ack: message $id already processed"
+      return 0
+    fi
+    echo "ack: message $id not in inbox" >&2
+    exit 1
+  fi
   mkdir -p "$processed"
   mv -f "$src" "$processed/"
   _log "ack id=$id role=$TASK_FORCE_ROLE"

--- a/kiro-local/bin/radio
+++ b/kiro-local/bin/radio
@@ -14,8 +14,8 @@ usage() {
 Usage:
   radio send --to ROLE --intent KIND [--pr N] [--issue N] [--repo PATH] [--body TEXT | < body]
   radio check                            list unread messages for this role
-  radio read   <id>                      print message body
-  radio ack    <id>                      move message to processed/
+  radio read   [--peek|--no-ack] <id>    print body; by default also move inbox/<id>.md -> processed/
+  radio ack    <id>                      move message to processed/ (idempotent: no-op if already processed)
   radio register --role ROLE --tab TAB [--repo PATH] --agent claude|kiro [--loadout NAME]
   radio ready                            mark this role idle (and process pending)
   radio busy                             mark this role busy
@@ -529,15 +529,38 @@ cmd_check() {
 
 cmd_read() {
   _require_role
-  local id="${1:-}"
+  # Default beat is read+ack: print body, then move inbox -> processed. The
+  # split between `read` and `ack` was a footgun — workers would `read`, act,
+  # and forget to `ack`, leaving stale messages that re-listed on every
+  # `radio check` (see #131). `--peek` / `--no-ack` is the escape hatch for
+  # inspection without consuming.
+  local peek=0
+  local id=""
+  while (($#)); do
+    case "$1" in
+      --peek|--no-ack) peek=1; shift ;;
+      --) shift; break ;;
+      -*) echo "read: unknown flag $1" >&2; exit 2 ;;
+      *) id="$1"; shift ;;
+    esac
+  done
   [[ -n "$id" ]] || { echo "read: <id> required" >&2; exit 2; }
-  local f
-  f="$(_inbox_dir "$TASK_FORCE_ROLE")/${id}.md"
-  if [[ ! -f "$f" ]]; then
-    f="$(_processed_dir "$TASK_FORCE_ROLE")/${id}.md"
+  local inbox processed
+  inbox=$(_inbox_dir "$TASK_FORCE_ROLE")
+  processed=$(_processed_dir "$TASK_FORCE_ROLE")
+  local src="$inbox/${id}.md"
+  local in_inbox=1
+  if [[ ! -f "$src" ]]; then
+    src="$processed/${id}.md"
+    in_inbox=0
   fi
-  [[ -f "$f" ]] || { echo "read: message $id not found" >&2; exit 1; }
-  cat "$f"
+  [[ -f "$src" ]] || { echo "read: message $id not found" >&2; exit 1; }
+  cat "$src"
+  if (( peek == 0 )) && (( in_inbox == 1 )); then
+    mkdir -p "$processed"
+    mv -f "$src" "$processed/"
+    _log "read+ack id=$id role=$TASK_FORCE_ROLE"
+  fi
 }
 
 cmd_ack() {
@@ -548,7 +571,16 @@ cmd_ack() {
   inbox=$(_inbox_dir "$TASK_FORCE_ROLE")
   processed=$(_processed_dir "$TASK_FORCE_ROLE")
   local src="$inbox/${id}.md"
-  [[ -f "$src" ]] || { echo "ack: message $id not in inbox" >&2; exit 1; }
+  # Idempotent: if `read` already auto-acked (post-#131), exit 0 quietly so
+  # existing `read && ack` scripts and muscle memory don't break.
+  if [[ ! -f "$src" ]]; then
+    if [[ -f "$processed/${id}.md" ]]; then
+      echo "ack: message $id already processed"
+      return 0
+    fi
+    echo "ack: message $id not in inbox" >&2
+    exit 1
+  fi
   mkdir -p "$processed"
   mv -f "$src" "$processed/"
   _log "ack id=$id role=$TASK_FORCE_ROLE"

--- a/kiro-notion/bin/radio
+++ b/kiro-notion/bin/radio
@@ -14,8 +14,8 @@ usage() {
 Usage:
   radio send --to ROLE --intent KIND [--pr N] [--issue N] [--repo PATH] [--body TEXT | < body]
   radio check                            list unread messages for this role
-  radio read   <id>                      print message body
-  radio ack    <id>                      move message to processed/
+  radio read   [--peek|--no-ack] <id>    print body; by default also move inbox/<id>.md -> processed/
+  radio ack    <id>                      move message to processed/ (idempotent: no-op if already processed)
   radio register --role ROLE --tab TAB [--repo PATH] --agent claude|kiro [--loadout NAME]
   radio ready                            mark this role idle (and process pending)
   radio busy                             mark this role busy
@@ -529,15 +529,38 @@ cmd_check() {
 
 cmd_read() {
   _require_role
-  local id="${1:-}"
+  # Default beat is read+ack: print body, then move inbox -> processed. The
+  # split between `read` and `ack` was a footgun — workers would `read`, act,
+  # and forget to `ack`, leaving stale messages that re-listed on every
+  # `radio check` (see #131). `--peek` / `--no-ack` is the escape hatch for
+  # inspection without consuming.
+  local peek=0
+  local id=""
+  while (($#)); do
+    case "$1" in
+      --peek|--no-ack) peek=1; shift ;;
+      --) shift; break ;;
+      -*) echo "read: unknown flag $1" >&2; exit 2 ;;
+      *) id="$1"; shift ;;
+    esac
+  done
   [[ -n "$id" ]] || { echo "read: <id> required" >&2; exit 2; }
-  local f
-  f="$(_inbox_dir "$TASK_FORCE_ROLE")/${id}.md"
-  if [[ ! -f "$f" ]]; then
-    f="$(_processed_dir "$TASK_FORCE_ROLE")/${id}.md"
+  local inbox processed
+  inbox=$(_inbox_dir "$TASK_FORCE_ROLE")
+  processed=$(_processed_dir "$TASK_FORCE_ROLE")
+  local src="$inbox/${id}.md"
+  local in_inbox=1
+  if [[ ! -f "$src" ]]; then
+    src="$processed/${id}.md"
+    in_inbox=0
   fi
-  [[ -f "$f" ]] || { echo "read: message $id not found" >&2; exit 1; }
-  cat "$f"
+  [[ -f "$src" ]] || { echo "read: message $id not found" >&2; exit 1; }
+  cat "$src"
+  if (( peek == 0 )) && (( in_inbox == 1 )); then
+    mkdir -p "$processed"
+    mv -f "$src" "$processed/"
+    _log "read+ack id=$id role=$TASK_FORCE_ROLE"
+  fi
 }
 
 cmd_ack() {
@@ -548,7 +571,16 @@ cmd_ack() {
   inbox=$(_inbox_dir "$TASK_FORCE_ROLE")
   processed=$(_processed_dir "$TASK_FORCE_ROLE")
   local src="$inbox/${id}.md"
-  [[ -f "$src" ]] || { echo "ack: message $id not in inbox" >&2; exit 1; }
+  # Idempotent: if `read` already auto-acked (post-#131), exit 0 quietly so
+  # existing `read && ack` scripts and muscle memory don't break.
+  if [[ ! -f "$src" ]]; then
+    if [[ -f "$processed/${id}.md" ]]; then
+      echo "ack: message $id already processed"
+      return 0
+    fi
+    echo "ack: message $id not in inbox" >&2
+    exit 1
+  fi
   mkdir -p "$processed"
   mv -f "$src" "$processed/"
   _log "ack id=$id role=$TASK_FORCE_ROLE"

--- a/tests/radio.bats
+++ b/tests/radio.bats
@@ -210,7 +210,7 @@ teardown() {
   assert_output --partial "PR ready"
 }
 
-@test "read prints the full message body; ack moves it to processed/" {
+@test "read prints the full message body and auto-acks (moves to processed/) (#131)" {
   "$RADIO" register --role pm --tab pm --agent claude
   TASK_FORCE_ROLE=worker-foo "$RADIO" send --to pm --intent review-requested --body "Body content"
   local id
@@ -221,9 +221,14 @@ teardown() {
   assert_output --partial "from: worker-foo"
   assert_output --partial "Body content"
 
-  TASK_FORCE_ROLE=pm "$RADIO" ack "$id"
+  # Default `read` now auto-acks — see issue #131.
   assert [ ! -f "$TASK_FORCE_HOME/radio/mailbox/pm/inbox/${id}.md" ]
   assert [ -f "$TASK_FORCE_HOME/radio/mailbox/pm/processed/${id}.md" ]
+
+  # Legacy paired `ack` is idempotent on an already-processed id.
+  TASK_FORCE_ROLE=pm run "$RADIO" ack "$id"
+  assert_success
+  assert_output --partial "already processed"
 }
 
 @test "ack of an unknown message returns non-zero" {

--- a/tests/radio_read_auto_ack.bats
+++ b/tests/radio_read_auto_ack.bats
@@ -1,0 +1,135 @@
+#!/usr/bin/env bats
+# Pins the read+ack collapse contract from #131.
+# - `radio read <id>`         => print body AND mv inbox -> processed
+# - `radio read --peek <id>`  => print body, leave file in inbox
+# - `radio read --no-ack <id>` => same as --peek (alias)
+# - `radio ack <id>` on an already-processed message => exit 0, friendly note
+# - `radio read` of a message already in processed/ still prints (no move, no error)
+
+bats_load_library bats-support
+bats_load_library bats-assert
+
+load helpers/common
+
+setup() {
+  setup_task_force_home
+  unset ZELLIJ
+  export TASK_FORCE_ROLE=test-runner
+  "$RADIO" register --role pm --tab pm --agent claude
+}
+
+teardown() {
+  teardown_all
+}
+
+# Helper: send one message to pm and echo its id (basename without .md).
+_send_one() {
+  local intent="${1:-review-requested}"
+  local body="${2:-Body content}"
+  TASK_FORCE_ROLE=worker-foo "$RADIO" send --to pm --intent "$intent" --body "$body"
+  basename "$(ls "$TASK_FORCE_HOME/radio/mailbox/pm/inbox/"*.md | head -1)" .md
+}
+
+@test "(a) read auto-acks: body prints AND file moves inbox -> processed" {
+  local id
+  id=$(_send_one review-requested "Auto-ack me")
+
+  TASK_FORCE_ROLE=pm run "$RADIO" read "$id"
+  assert_success
+  assert_output --partial "Auto-ack me"
+
+  assert [ ! -f "$TASK_FORCE_HOME/radio/mailbox/pm/inbox/${id}.md" ]
+  assert [ -f "$TASK_FORCE_HOME/radio/mailbox/pm/processed/${id}.md" ]
+
+  # Regression of #131 root cause: subsequent check returns (no unread).
+  TASK_FORCE_ROLE=pm run "$RADIO" check
+  assert_output --partial "(no unread messages)"
+}
+
+@test "(b) read --peek prints body and leaves file in inbox" {
+  local id
+  id=$(_send_one review-requested "Peek me")
+
+  TASK_FORCE_ROLE=pm run "$RADIO" read --peek "$id"
+  assert_success
+  assert_output --partial "Peek me"
+
+  assert [ -f "$TASK_FORCE_HOME/radio/mailbox/pm/inbox/${id}.md" ]
+  assert [ ! -f "$TASK_FORCE_HOME/radio/mailbox/pm/processed/${id}.md" ]
+
+  # check still lists it
+  TASK_FORCE_ROLE=pm run "$RADIO" check
+  assert_output --partial "Peek me"
+}
+
+@test "(c) read --no-ack is a strict alias for --peek (no move)" {
+  local id
+  id=$(_send_one review-requested "No-ack me")
+
+  TASK_FORCE_ROLE=pm run "$RADIO" read --no-ack "$id"
+  assert_success
+  assert_output --partial "No-ack me"
+
+  assert [ -f "$TASK_FORCE_HOME/radio/mailbox/pm/inbox/${id}.md" ]
+  assert [ ! -f "$TASK_FORCE_HOME/radio/mailbox/pm/processed/${id}.md" ]
+}
+
+@test "(d) ack on an already-processed id is idempotent (exit 0, friendly note)" {
+  local id
+  id=$(_send_one review-requested "Ack twice")
+
+  # First read auto-acks.
+  TASK_FORCE_ROLE=pm "$RADIO" read "$id"
+  assert [ -f "$TASK_FORCE_HOME/radio/mailbox/pm/processed/${id}.md" ]
+
+  # Legacy `ack` call should now no-op cleanly instead of erroring.
+  TASK_FORCE_ROLE=pm run "$RADIO" ack "$id"
+  assert_success
+  assert_output --partial "already processed"
+}
+
+@test "(e) read of a message already in processed/ still prints (no move, no error)" {
+  local id
+  id=$(_send_one review-requested "Read me twice")
+
+  # First read auto-acks (moves to processed/).
+  TASK_FORCE_ROLE=pm "$RADIO" read "$id" >/dev/null
+
+  # Second read still finds the body in processed/ — no error, no move (it's
+  # already there), nothing to log a second time.
+  TASK_FORCE_ROLE=pm run "$RADIO" read "$id"
+  assert_success
+  assert_output --partial "Read me twice"
+  assert [ -f "$TASK_FORCE_HOME/radio/mailbox/pm/processed/${id}.md" ]
+  assert [ ! -f "$TASK_FORCE_HOME/radio/mailbox/pm/inbox/${id}.md" ]
+}
+
+@test "ack on a truly-unknown id still errors loudly" {
+  TASK_FORCE_ROLE=pm run "$RADIO" ack "never-sent-this"
+  assert_failure
+  assert_output --partial "not in inbox"
+}
+
+@test "read flag accepted both before and after id" {
+  local id
+  id=$(_send_one review-requested "Flag position")
+
+  TASK_FORCE_ROLE=pm run "$RADIO" read "$id" --peek
+  assert_success
+  assert_output --partial "Flag position"
+  assert [ -f "$TASK_FORCE_HOME/radio/mailbox/pm/inbox/${id}.md" ]
+}
+
+@test "wrong-role read does not affect target role's inbox (#131 isolation pin)" {
+  local id
+  id=$(_send_one review-requested "Body for pm")
+
+  # Register a second role and try reading pm's message as that role.
+  "$RADIO" register --role worker-bar --tab w-bar --agent claude
+  TASK_FORCE_ROLE=worker-bar run "$RADIO" read "$id"
+  assert_failure
+  assert_output --partial "not found"
+
+  # pm's message is untouched.
+  assert [ -f "$TASK_FORCE_HOME/radio/mailbox/pm/inbox/${id}.md" ]
+}


### PR DESCRIPTION
## Summary

Closes #131.

Collapses `radio read` + `radio ack` into one beat by default. The previous split was a workflow footgun: workers would read a message, act on it, forget to `ack`, and every subsequent `radio check` would re-list the stale entry identically — making PM's silence indistinguishable from PM never pinging.

- `radio read <id>` — prints body AND moves `inbox/<id>.md` → `processed/`
- `radio read --peek <id>` (alias `--no-ack`) — prints body, leaves file in inbox
- `radio ack <id>` — now idempotent: exits 0 with "already processed" if a prior `read` already moved it

Deliberate UX change, not a bug fix — old behavior was the intended (broken) design. Captured under `### Changed` in CHANGELOG, not `### Fixed`.

All 7 loadout radio copies kept in sync (drift group `radio`/`body`).

## Test plan

- [x] `./run_tests.sh` — all 659 tests green (includes new `tests/radio_read_auto_ack.bats`, 8 cases)
- [x] `tools/check-drift.sh` — all 17 groups green
- [x] Auto-ack happy path pinned in `radio_read_auto_ack.bats:(a)`
- [x] `--peek` and `--no-ack` aliases pinned in cases (b) and (c)
- [x] Idempotent ack pinned in case (d)
- [x] Re-read from `processed/` pinned in case (e)
- [x] Wrong-role isolation pinned (sender role A cannot read role B's mailbox)
- [x] Existing `tests/radio.bats` "read prints body; ack moves to processed/" updated to assert the new auto-ack behavior + legacy idempotent ack
- [x] README command surface updated with the new `--peek` row and idempotent ack note

🤖 Generated with [Claude Code](https://claude.com/claude-code)