### PR TITLE
Add a dedicated reviewer role for cost-aware PR review delegation (#134)

### DIFF
--- a/bin/task-reviewer
+++ b/bin/task-reviewer
@@ -1,0 +1,32 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+# Project-aware dispatcher for task-reviewer.
+#
+# Detects which <impl>/bin/task-reviewer to run by inspecting the current git
+# repo's workflow docs (see lib/detect-impl.sh). Override with --impl <name> or
+# AW_IMPL=<name>.
+
+src="${BASH_SOURCE[0]}"
+while [ -L "$src" ]; do
+  dir=$(cd -P "$(dirname "$src")" && pwd)
+  src=$(readlink "$src")
+  [[ $src != /* ]] && src="$dir/$src"
+done
+BIN_DIR=$(cd -P "$(dirname "$src")" && pwd)
+AW_ROOT=$(dirname "$BIN_DIR")
+
+# shellcheck source=lib/detect-impl.sh
+# shellcheck source=lib/detect-impl.sh
+source "$AW_ROOT/lib/detect-impl.sh"
+
+aw_parse_impl_flag "$@" || exit 1
+IMPL=$(aw_detect_impl "$AW_PARSED_IMPL") || exit 1
+
+TARGET="$AW_ROOT/$IMPL/bin/task-reviewer"
+[[ -x "$TARGET" ]] || {
+  echo "Error: $TARGET not found or not executable. Is the repository complete?" >&2
+  exit 1
+}
+
+exec "$TARGET" ${AW_REMAINING_ARGS[@]+"${AW_REMAINING_ARGS[@]}"}

--- a/bin/task-reviewer
+++ b/bin/task-reviewer
@@ -17,16 +17,20 @@ BIN_DIR=$(cd -P "$(dirname "$src")" && pwd)
 AW_ROOT=$(dirname "$BIN_DIR")
 
 # shellcheck source=lib/detect-impl.sh
-# shellcheck source=lib/detect-impl.sh
 source "$AW_ROOT/lib/detect-impl.sh"
 
 aw_parse_impl_flag "$@" || exit 1
 IMPL=$(aw_detect_impl "$AW_PARSED_IMPL") || exit 1
 
 TARGET="$AW_ROOT/$IMPL/bin/task-reviewer"
-[[ -x "$TARGET" ]] || {
-  echo "Error: $TARGET not found or not executable. Is the repository complete?" >&2
+if [[ ! -x "$TARGET" ]]; then
+  # The reviewer role currently ships only for claude-gh and kiro-gh. Surface
+  # that explicitly rather than the generic "not found / is the repo complete"
+  # message — the impl is configured, the *reviewer* just isn't part of it.
+  echo "Error: task-reviewer is not available for impl '$IMPL'." >&2
+  echo "       Reviewer support currently ships for claude-gh and kiro-gh only." >&2
+  echo "       See https://github.com/martin-conur/task-force/issues/134 for tracking." >&2
   exit 1
-}
+fi
 
 exec "$TARGET" ${AW_REMAINING_ARGS[@]+"${AW_REMAINING_ARGS[@]}"}

--- a/claude-gh/bin/task-init
+++ b/claude-gh/bin/task-init
@@ -246,7 +246,11 @@ _radio_install_hooks() {
     exit 1
   fi
 
-  local register_cmd="radio register --role \$TASK_FORCE_ROLE --tab \$ZELLIJ_TAB --repo \$(git rev-parse --show-toplevel 2>/dev/null) --agent claude --loadout $loadout"
+  # \${TASK_FORCE_LOADOUT:-$loadout} lets per-role launchers (e.g. task-reviewer
+  # exporting TASK_FORCE_LOADOUT=reviewer) override the LOADOUT= field in the
+  # session file without rewiring task-init. Plain `claude`/task-pm/task-work
+  # sessions don't set the env var, so they keep the loadout default ($loadout).
+  local register_cmd="radio register --role \$TASK_FORCE_ROLE --tab \$ZELLIJ_TAB --repo \$(git rev-parse --show-toplevel 2>/dev/null) --agent claude --loadout \${TASK_FORCE_LOADOUT:-$loadout}"
   local busy_cmd="radio busy"
   local stop_cmd="radio ready && radio check"
   local end_cmd="radio unregister"

--- a/claude-gh/bin/task-reviewer
+++ b/claude-gh/bin/task-reviewer
@@ -8,8 +8,9 @@ set -euo pipefail
 # only coordinates the code-review skill's sub-agents; sub-agents have their
 # own model overrides and aren't affected by $ANTHROPIC_MODEL here.
 if ! git rev-parse --show-toplevel >/dev/null 2>&1; then
-  echo "Error: not in a git repo (task-reviewer requires a task-force-initialized repo" >&2
-  echo "       so the SessionStart hook can load .claude/settings.json)" >&2
+  echo "Error: not in a git repo." >&2
+  echo "       task-reviewer requires a task-force-initialized repo so the" >&2
+  echo "       SessionStart hook can load .claude/settings.json." >&2
   exit 1
 fi
 cd "$(git rev-parse --show-toplevel)"

--- a/claude-gh/bin/task-reviewer
+++ b/claude-gh/bin/task-reviewer
@@ -1,0 +1,30 @@
+#!/usr/bin/env bash
+set -euo pipefail
+# region:body
+# task-reviewer — in-place reviewer-tab takeover for claude loadouts.
+# Renames the current zellij tab to "reviewer" and exec's `claude /reviewer`
+# so the SessionStart hook in <repo>/.claude/settings.json registers the
+# reviewer mailbox. Runs on Sonnet (cheaper model) since the orchestrator
+# only coordinates the code-review skill's sub-agents; sub-agents have their
+# own model overrides and aren't affected by $ANTHROPIC_MODEL here.
+if ! git rev-parse --show-toplevel >/dev/null 2>&1; then
+  echo "Error: not in a git repo (task-reviewer requires a task-force-initialized repo" >&2
+  echo "       so the SessionStart hook can load .claude/settings.json)" >&2
+  exit 1
+fi
+cd "$(git rev-parse --show-toplevel)"
+
+REPO_NAME=$(basename "$(git rev-parse --show-toplevel)")
+
+if [[ -n "${ZELLIJ:-}" ]]; then
+  zellij action rename-tab "reviewer" >/dev/null 2>&1 || true
+fi
+
+export TASK_FORCE_ROLE="reviewer-${REPO_NAME}"
+export ZELLIJ_TAB=reviewer
+export TASK_FORCE_LOADOUT=reviewer
+# Cheap-model default for the orchestrator. Pre-set values win so a caller can
+# pin a different model (e.g. for a one-off Opus review) without editing this.
+export ANTHROPIC_MODEL="${ANTHROPIC_MODEL:-claude-sonnet-4-6}"
+exec claude "/reviewer"
+# endregion:body

--- a/claude-gh/commands/pm.md
+++ b/claude-gh/commands/pm.md
@@ -36,5 +36,11 @@ The worker pings you via `radio` at every transition. Reciprocate so the worker 
 
 - **After approving without merging** (e.g., waiting on CI): `gh pr review <N> --approve` is enough; no radio beat needed until you actually merge.
 
+- **Delegating review to a reviewer worker** (optional, cost-saving): if a dedicated reviewer tab is running (`task-reviewer` — check `ls ~/.task-force/radio/sessions/` for a `reviewer-<repo>` entry), you can forward the worker's `review-requested` ping rather than reviewing inline:
+  ```bash
+  radio send --to reviewer-<repo> --intent review-requested --pr <N>
+  ```
+  The reviewer runs the code-review skill on a cheaper model, posts comments to the PR, and radios you back with `review-complete-clean` or `review-complete-with-findings`. You still decide whether to merge or request changes — the reviewer never merges. This is opt-in: with no reviewer tab running, keep doing inline reviews.
+
 If arguments were provided after `/pm`, treat them as the first instruction:
 $ARGUMENTS

--- a/claude-gh/commands/reviewer.md
+++ b/claude-gh/commands/reviewer.md
@@ -21,7 +21,7 @@ Refer to the project's `.claude/gh-workflow.md` for GitHub owner/repo convention
      radio send --to pm --intent review-complete-clean --pr <N> --body "no findings"
      radio send --to pm --intent review-complete-with-findings --pr <N> --body "<short summary>"
      ```
-3. If `radio check` shows nothing, idle.
+3. If `radio check` shows nothing, idle. The `Stop` hook (`radio ready && radio check`) is what re-fires the loop on the next turn — when PM (or anyone) sends another `review-requested`, your tab gets woken via `zellij write-chars` and you'll see the new message on your next prompt.
 
 ### Authority boundaries
 

--- a/claude-gh/commands/reviewer.md
+++ b/claude-gh/commands/reviewer.md
@@ -1,0 +1,38 @@
+---
+description: Reviewer — runs the code-review skill on PRs, reports verdict back to PM via radio
+argument-hint: [optional PR number]
+---
+
+You are now in Reviewer mode.
+
+You are a dedicated PR-reviewer worker for this repo. When PM forwards a `review-requested` ping, run the `code-review` skill on the target PR, post substantive findings as PR comments via `gh`, then radio PM back with a single verdict — clean or with findings. You do NOT merge, approve, close, or otherwise mutate the PR beyond commenting.
+
+Refer to the project's `.claude/gh-workflow.md` for GitHub owner/repo conventions. Use the `gh` CLI for PR I/O: `gh pr view`, `gh pr diff`, `gh pr comment`. Read-only `gh` patterns are pre-allowed in `.claude/settings.json`; mutations stay confirmation-gated.
+
+### Loop
+
+1. `radio check` — list anything queued in your inbox.
+2. For each `review-requested` message:
+   - `radio read <id>` to consume the message. The PR number is in the `pr:` frontmatter field.
+   - Run the `code-review` skill on that PR. The skill orchestrates sub-agents for screen + review and produces findings.
+   - If the skill surfaces blockers / nits worth raising, post them as PR comments via `gh pr comment <N> -b "..."` (or `gh pr review <N> --comment -b "..."`). Keep comments substantive — radio carries the routing ping, not the review content.
+   - Radio PM back with one of:
+     ```bash
+     radio send --to pm --intent review-complete-clean --pr <N> --body "no findings"
+     radio send --to pm --intent review-complete-with-findings --pr <N> --body "<short summary>"
+     ```
+3. If `radio check` shows nothing, idle.
+
+### Authority boundaries
+
+You are explicitly NOT authorized to:
+- Approve PRs (`gh pr review --approve`)
+- Merge PRs (`gh pr merge`)
+- Close PRs
+- Push commits or edit branches
+- Modify project Status fields
+
+PM holds those authorities. A "clean" verdict just means "I found nothing worth blocking"; PM decides when to merge. If you think the PR is great, say so in the verdict body — but still escalate the merge decision to PM.
+
+If arguments were provided after `/reviewer` (e.g. a PR number for a manual review), treat them as the first instruction:
+$ARGUMENTS

--- a/claude-gh/install.sh
+++ b/claude-gh/install.sh
@@ -18,6 +18,8 @@ ln -sf "$SCRIPT_DIR/../bin/task-done" ~/.local/bin/task-done
 echo "  ✓ Script: task-done (shared dispatcher)"; sleep 0.05
 ln -sf "$SCRIPT_DIR/../bin/task-pm" ~/.local/bin/task-pm
 echo "  ✓ Script: task-pm (shared dispatcher)"; sleep 0.05
+ln -sf "$SCRIPT_DIR/../bin/task-reviewer" ~/.local/bin/task-reviewer
+echo "  ✓ Script: task-reviewer (shared dispatcher)"; sleep 0.05
 ln -sf "$SCRIPT_DIR/bin/radio" ~/.local/bin/radio
 echo "  ✓ Script: radio (PM↔worker mailbox CLI)"; sleep 0.05
 

--- a/kiro-gh/agents/reviewer.json
+++ b/kiro-gh/agents/reviewer.json
@@ -1,0 +1,18 @@
+{
+  "name": "reviewer",
+  "description": "Reviewer — reviews PRs forwarded by PM via radio, posts comments, reports verdict back",
+  "prompt": "You are a Reviewer agent. Your job is to review PRs that PM forwards to you via the radio mailbox, post substantive findings as PR comments, and radio PM back with a verdict — clean or with findings.\n\nKiro doesn't have an orchestrated /code-review skill the way Claude Code does, so you review prompt-driven: read the PR diff via `gh pr diff`, read the PR description and existing comments via `gh pr view --comments`, and post findings via `gh pr comment <N> -b \"...\"` (or `gh pr review <N> --comment -b \"...\"`).\n\nRefer to the project's .kiro/steering/gh-workflow.md for GitHub owner/repo conventions. Use the `gh` CLI for PR I/O (gh pr view, gh pr diff, gh pr comment).\n\n### Loop\n\n1. `radio check` — list anything queued in your inbox.\n2. For each `review-requested` message:\n   - `radio read <id>` to consume the message. The PR number is in the `pr:` frontmatter field.\n   - Read the PR: `gh pr view <N>`, `gh pr diff <N>`.\n   - Review the diff. Focus on correctness, security, obvious bugs, and missed edge cases. Don't sweat style.\n   - If you have substantive findings, post them via `gh pr comment <N> -b \"...\"`. Keep comments substantive — radio carries the routing ping, not the review content.\n   - Radio PM back with one of:\n       radio send --to pm --intent review-complete-clean --pr <N> --body \"no findings\"\n       radio send --to pm --intent review-complete-with-findings --pr <N> --body \"<short summary>\"\n3. If `radio check` shows nothing, idle. The session-start / on-stop hooks fire `radio ready && radio check` on the next prompt, which is what re-fires the loop when PM forwards another PR.\n\n### Authority boundaries\n\nYou are explicitly NOT authorized to:\n- Approve PRs (`gh pr review --approve`)\n- Merge PRs (`gh pr merge`)\n- Close PRs\n- Push commits or edit branches\n- Modify project Status fields\n\nPM holds those authorities. A clean verdict just means \"I found nothing worth blocking\"; PM decides when to merge.",
+  "tools": [
+    "fs_read",
+    "grep",
+    "glob",
+    "execute_bash"
+  ],
+  "allowedTools": [
+    "fs_read",
+    "grep",
+    "glob"
+  ],
+  "keyboardShortcut": "ctrl+shift+r",
+  "welcomeMessage": "Reviewer mode. Waiting on radio for PM to forward a PR for review."
+}

--- a/kiro-gh/bin/task-init
+++ b/kiro-gh/bin/task-init
@@ -229,8 +229,12 @@ EOF
     rm -f "$tmp"
   }
 
+  # \${TASK_FORCE_LOADOUT:-$loadout} lets per-role launchers (e.g. task-reviewer
+  # exporting TASK_FORCE_LOADOUT=reviewer) override the LOADOUT= field in the
+  # session file without rewiring task-init. Plain task-pm / task-work sessions
+  # don't set the env var, so they keep the loadout default ($loadout).
   _write_hook "radio-register" "agentSpawn" \
-    "radio register --role \$TASK_FORCE_ROLE --tab \$ZELLIJ_TAB --repo \$(git rev-parse --show-toplevel 2>/dev/null) --agent kiro --loadout ${loadout}"
+    "radio register --role \$TASK_FORCE_ROLE --tab \$ZELLIJ_TAB --repo \$(git rev-parse --show-toplevel 2>/dev/null) --agent kiro --loadout \${TASK_FORCE_LOADOUT:-${loadout}}"
   _write_hook "radio-busy"     "userPromptSubmit" "radio busy"
   _write_hook "radio-ready"    "agentStop"        "radio ready && radio check"
   # Note: kiro has no session-end trigger (agentStop fires per-turn, not on

--- a/kiro-gh/bin/task-reviewer
+++ b/kiro-gh/bin/task-reviewer
@@ -1,0 +1,29 @@
+#!/usr/bin/env bash
+set -euo pipefail
+# region:body
+# task-reviewer — in-place reviewer-tab takeover for kiro loadouts.
+# Renames the current zellij tab to "reviewer" and exec's kiro-cli's reviewer
+# agent so the session-start hook in <repo>/.kiro/ registers the reviewer
+# mailbox. Kiro doesn't have an equivalent to Claude Code's /code-review
+# orchestration skill, so the kiro reviewer reads `gh pr diff` directly and
+# posts comments via `gh pr comment` — single-agent prompt-driven review.
+if ! git rev-parse --show-toplevel >/dev/null 2>&1; then
+  echo "Error: not in a git repo." >&2
+  echo "       task-reviewer requires a task-force-initialized repo so the" >&2
+  echo "       session-start hook can load the project's hooks config." >&2
+  exit 1
+fi
+cd "$(git rev-parse --show-toplevel)"
+
+REPO_NAME=$(basename "$(git rev-parse --show-toplevel)")
+
+if [[ -n "${ZELLIJ:-}" ]]; then
+  zellij action rename-tab "reviewer" >/dev/null 2>&1 || true
+fi
+
+export TASK_FORCE_ROLE="reviewer-${REPO_NAME}"
+export ZELLIJ_TAB=reviewer
+export TASK_FORCE_LOADOUT=reviewer
+# Sonnet default; pre-set $TASK_WORK_MODEL to override (e.g. for an Opus pass).
+exec kiro-cli chat --agent reviewer --model "${TASK_WORK_MODEL:-claude-sonnet-4.6}"
+# endregion:body

--- a/kiro-gh/install.sh
+++ b/kiro-gh/install.sh
@@ -18,6 +18,8 @@ ln -sf "$SCRIPT_DIR/../bin/task-done" ~/.local/bin/task-done
 echo "  ✓ Script: task-done (shared dispatcher)"; sleep 0.05
 ln -sf "$SCRIPT_DIR/../bin/task-pm" ~/.local/bin/task-pm
 echo "  ✓ Script: task-pm (shared dispatcher)"; sleep 0.05
+ln -sf "$SCRIPT_DIR/../bin/task-reviewer" ~/.local/bin/task-reviewer
+echo "  ✓ Script: task-reviewer (shared dispatcher)"; sleep 0.05
 ln -sf "$SCRIPT_DIR/bin/radio" ~/.local/bin/radio
 echo "  ✓ Script: radio (PM↔worker mailbox CLI)"; sleep 0.05
 

--- a/tests/claude_gh_task_init.bats
+++ b/tests/claude_gh_task_init.bats
@@ -370,11 +370,13 @@ teardown() {
   assert_output "radio unregister"
 }
 
-@test "SessionStart hook command embeds the loadout name" {
+@test "SessionStart hook command embeds the loadout name (env-overridable)" {
   run "$CLAUDE_GH_TASK_INIT"
   assert_success
   run jq -r '.hooks.SessionStart[0].hooks[0].command' "$TARGET_DIR/.claude/settings.json"
-  assert_output --partial "--loadout claude-gh"
+  # The hook uses ${TASK_FORCE_LOADOUT:-claude-gh} so per-role launchers like
+  # task-reviewer can override LOADOUT= without re-running task-init.
+  assert_output --partial "--loadout \${TASK_FORCE_LOADOUT:-claude-gh}"
   assert_output --partial "--agent claude"
 }
 

--- a/tests/helpers/common.bash
+++ b/tests/helpers/common.bash
@@ -42,6 +42,7 @@ TASK_PM_CLAUDE="$REPO_ROOT_REAL/claude-gh/bin/task-pm"
 TASK_PM_KIRO="$REPO_ROOT_REAL/kiro-gh/bin/task-pm"
 TASK_PM_DISPATCHER="$REPO_ROOT_REAL/bin/task-pm"
 TASK_REVIEWER_CLAUDE="$REPO_ROOT_REAL/claude-gh/bin/task-reviewer"
+TASK_REVIEWER_KIRO="$REPO_ROOT_REAL/kiro-gh/bin/task-reviewer"
 TASK_REVIEWER_DISPATCHER="$REPO_ROOT_REAL/bin/task-reviewer"
 
 # Creates a temp directory with a git repo, sets up $MAIN_REPO,

--- a/tests/helpers/common.bash
+++ b/tests/helpers/common.bash
@@ -41,6 +41,8 @@ RADIO="$REPO_ROOT_REAL/claude-gh/bin/radio"
 TASK_PM_CLAUDE="$REPO_ROOT_REAL/claude-gh/bin/task-pm"
 TASK_PM_KIRO="$REPO_ROOT_REAL/kiro-gh/bin/task-pm"
 TASK_PM_DISPATCHER="$REPO_ROOT_REAL/bin/task-pm"
+TASK_REVIEWER_CLAUDE="$REPO_ROOT_REAL/claude-gh/bin/task-reviewer"
+TASK_REVIEWER_DISPATCHER="$REPO_ROOT_REAL/bin/task-reviewer"
 
 # Creates a temp directory with a git repo, sets up $MAIN_REPO,
 # $REPO_NAME, and $WORKTREE_BASE.

--- a/tests/kiro_gh_task_init.bats
+++ b/tests/kiro_gh_task_init.bats
@@ -272,12 +272,14 @@ teardown() {
   done
 }
 
-@test "radio-register hook embeds the loadout name and uses agentSpawn" {
+@test "radio-register hook embeds the loadout name (env-overridable) and uses agentSpawn" {
   run "$KIRO_GH_TASK_INIT"
   assert_success
   run cat "$TARGET_DIR/.kiro/hooks/radio-register.json"
   assert_output --partial "agentSpawn"
-  assert_output --partial "--loadout kiro-gh"
+  # The hook uses ${TASK_FORCE_LOADOUT:-kiro-gh} so per-role launchers like
+  # task-reviewer can override LOADOUT= without re-running task-init.
+  assert_output --partial "--loadout \${TASK_FORCE_LOADOUT:-kiro-gh}"
   assert_output --partial "--agent kiro"
 }
 

--- a/tests/task_reviewer.bats
+++ b/tests/task_reviewer.bats
@@ -93,6 +93,26 @@ EOF
   refute_output --partial "ANTHROPIC_MODEL=claude-sonnet-4-6"
 }
 
+# ----- kiro variant ---------------------------------------------------------
+
+@test "kiro task-reviewer renames the current tab to reviewer and exec's kiro-cli reviewer agent" {
+  run "$TASK_REVIEWER_KIRO"
+  assert_success
+  assert_stub_called zellij "action rename-tab reviewer"
+  run stub_calls kiro-cli
+  assert_output --partial "chat --agent reviewer"
+}
+
+@test "kiro task-reviewer errors out cleanly outside a git repo" {
+  local outside
+  outside=$(mktemp -d)
+  cd "$outside"
+  run "$TASK_REVIEWER_KIRO"
+  assert_failure
+  assert_output --partial "not in a git repo"
+  rm -rf "$outside"
+}
+
 # ----- dispatcher -----------------------------------------------------------
 
 @test "top-level task-reviewer dispatches to the claude-gh variant based on workflow doc" {
@@ -105,8 +125,30 @@ EOF
   assert_output --partial "/reviewer"
 }
 
+@test "top-level task-reviewer dispatches to the kiro-gh variant based on workflow doc" {
+  mkdir -p "$MAIN_REPO/.kiro/steering"
+  touch "$MAIN_REPO/.kiro/steering/gh-workflow.md"
+
+  run "$TASK_REVIEWER_DISPATCHER"
+  assert_success
+  run stub_calls kiro-cli
+  assert_output --partial "chat --agent reviewer"
+}
+
 @test "top-level task-reviewer errors cleanly when no workflow doc is present" {
   run "$TASK_REVIEWER_DISPATCHER"
   assert_failure
   assert_output --partial "no agentic-workflow impl configured"
+}
+
+@test "top-level task-reviewer errors cleanly for impls without a reviewer variant" {
+  # claude-local has no task-reviewer (only claude-gh + kiro-gh do). The
+  # dispatcher should surface a clear error, not the generic "Is the
+  # repository complete?" one.
+  mkdir -p "$MAIN_REPO/.claude"
+  touch "$MAIN_REPO/.claude/local-workflow.md"
+
+  run "$TASK_REVIEWER_DISPATCHER"
+  assert_failure
+  assert_output --partial "task-reviewer is not available for impl"
 }

--- a/tests/task_reviewer.bats
+++ b/tests/task_reviewer.bats
@@ -1,0 +1,112 @@
+#!/usr/bin/env bats
+# Tests for bin/task-reviewer: in-place reviewer-tab takeover.
+# Asserts:
+#   - rename-tab to "reviewer" via zellij (when $ZELLIJ is set)
+#   - exec's `claude /reviewer`
+#   - errors out cleanly outside a git repo
+#   - sets ANTHROPIC_MODEL to claude-sonnet-4-6 (default) and respects an
+#     existing value if pre-set
+#   - dispatcher routes to the claude-gh variant when the workflow doc exists
+
+bats_load_library bats-support
+bats_load_library bats-assert
+
+load helpers/common
+
+setup() {
+  setup_repo
+  setup_stubs
+  cd "$MAIN_REPO"
+  export ZELLIJ=fake-session
+}
+
+teardown() {
+  teardown_all
+}
+
+# ----- claude variant -------------------------------------------------------
+
+@test "claude task-reviewer renames the current tab to reviewer and exec's claude /reviewer" {
+  run "$TASK_REVIEWER_CLAUDE"
+  assert_success
+  assert_stub_called zellij "action rename-tab reviewer"
+  run stub_calls claude
+  assert_output --partial "/reviewer"
+}
+
+@test "claude task-reviewer: works without zellij (\$ZELLIJ unset → no rename)" {
+  unset ZELLIJ
+  run "$TASK_REVIEWER_CLAUDE"
+  assert_success
+  run stub_calls zellij
+  refute_output --partial "rename-tab"
+  run stub_calls claude
+  assert_output --partial "/reviewer"
+}
+
+@test "claude task-reviewer errors out cleanly outside a git repo" {
+  local outside
+  outside=$(mktemp -d)
+  cd "$outside"
+  run "$TASK_REVIEWER_CLAUDE"
+  assert_failure
+  assert_output --partial "not in a git repo"
+  rm -rf "$outside"
+}
+
+@test "claude task-reviewer defaults ANTHROPIC_MODEL to claude-sonnet-4-6" {
+  # Replace the claude stub with one that dumps its env, so we can assert.
+  cat >"$STUB_BIN/claude" <<'EOF'
+#!/usr/bin/env bash
+echo "claude $*" >> "${STUB_CALLS_DIR}/claude.calls"
+printf 'ANTHROPIC_MODEL=%s\n' "${ANTHROPIC_MODEL:-}" >> "${STUB_CALLS_DIR}/claude.env"
+printf 'TASK_FORCE_ROLE=%s\n' "${TASK_FORCE_ROLE:-}" >> "${STUB_CALLS_DIR}/claude.env"
+printf 'TASK_FORCE_LOADOUT=%s\n' "${TASK_FORCE_LOADOUT:-}" >> "${STUB_CALLS_DIR}/claude.env"
+printf 'ZELLIJ_TAB=%s\n' "${ZELLIJ_TAB:-}" >> "${STUB_CALLS_DIR}/claude.env"
+EOF
+  chmod +x "$STUB_BIN/claude"
+
+  run "$TASK_REVIEWER_CLAUDE"
+  assert_success
+
+  run cat "$STUB_CALLS_DIR/claude.env"
+  assert_output --partial "ANTHROPIC_MODEL=claude-sonnet-4-6"
+  assert_output --partial "TASK_FORCE_LOADOUT=reviewer"
+  assert_output --partial "ZELLIJ_TAB=reviewer"
+  # Role is reviewer-<repo-basename>; the basename is whatever mktemp produced.
+  assert_output --partial "TASK_FORCE_ROLE=reviewer-$(basename "$MAIN_REPO")"
+}
+
+@test "claude task-reviewer honors a pre-set ANTHROPIC_MODEL" {
+  cat >"$STUB_BIN/claude" <<'EOF'
+#!/usr/bin/env bash
+echo "claude $*" >> "${STUB_CALLS_DIR}/claude.calls"
+printf 'ANTHROPIC_MODEL=%s\n' "${ANTHROPIC_MODEL:-}" >> "${STUB_CALLS_DIR}/claude.env"
+EOF
+  chmod +x "$STUB_BIN/claude"
+
+  ANTHROPIC_MODEL=claude-opus-4-7 run "$TASK_REVIEWER_CLAUDE"
+  assert_success
+
+  run cat "$STUB_CALLS_DIR/claude.env"
+  assert_output --partial "ANTHROPIC_MODEL=claude-opus-4-7"
+  refute_output --partial "ANTHROPIC_MODEL=claude-sonnet-4-6"
+}
+
+# ----- dispatcher -----------------------------------------------------------
+
+@test "top-level task-reviewer dispatches to the claude-gh variant based on workflow doc" {
+  mkdir -p "$MAIN_REPO/.claude"
+  touch "$MAIN_REPO/.claude/gh-workflow.md"
+
+  run "$TASK_REVIEWER_DISPATCHER"
+  assert_success
+  run stub_calls claude
+  assert_output --partial "/reviewer"
+}
+
+@test "top-level task-reviewer errors cleanly when no workflow doc is present" {
+  run "$TASK_REVIEWER_DISPATCHER"
+  assert_failure
+  assert_output --partial "no agentic-workflow impl configured"
+}


### PR DESCRIPTION
Closes #134.

## Summary

Adds a dedicated **reviewer** worker role that PM can optionally forward `review-requested` pings to. The reviewer runs Claude under Sonnet (`ANTHROPIC_MODEL=claude-sonnet-4-6`), so the code-review skill's orchestrator no longer needs Opus and PM stops holding diff / scoring context for every PR.

- `claude-gh/bin/task-reviewer` — in-place tab takeover modeled on `task-pm`. Registers via radio as `reviewer-<repo>` with `loadout=reviewer` and `ANTHROPIC_MODEL` defaulted to Sonnet (caller can pre-set the env var to override).
- `bin/task-reviewer` — top-level project-aware dispatcher (mirror of `bin/task-pm`).
- `claude-gh/commands/reviewer.md` — `/reviewer` slash command. Defines the radio-driven loop: read `review-requested` → invoke `/code-review` → post substantive findings as PR comments → radio back `review-complete-clean` or `review-complete-with-findings`. Explicit authority boundary: **no approve, no merge, no project Status edits**.
- `claude-gh/commands/pm.md` — PM docs gain an opt-in "delegating review" section. Inline PM-direct review stays the default; forwarding only kicks in when a reviewer tab is running.
- `claude-gh/install.sh` — link `bin/task-reviewer` into `~/.local/bin`.
- `tests/task_reviewer.bats` — 7 new tests.

## Design notes (from issue open questions)

- **Env propagation**: `task-reviewer` is an in-place exec of `claude` (same model as `task-pm`), so the script-exported `ANTHROPIC_MODEL` flows straight into the Claude process — no zellij `new-tab` involved.
- **Auto-merge**: explicitly disallowed in the `/reviewer` prompt; PM keeps merge authority.
- **`gh` auth**: inherits from the shell — same path as PM / worker today.
- **Multi-PR**: reviewer is single-session; `radio check` lists every queued `review-requested` and the agent processes them sequentially.
- **Sub-agent overrides**: as the issue calls out, the cost win is orchestrator-only — the `code-review` skill's sub-agents still use their own pinned models.

## Test plan

- [x] `./run_tests.sh task_reviewer` — 7/7 pass
- [x] `./run_tests.sh` — 679/679 pass (no regressions in existing PM / radio / dispatcher suites)
- [ ] Manual smoke: in a `claude-gh`-initialized repo, run `task-reviewer` in a fresh zellij tab — verify the tab renames to `reviewer`, the radio session file has `LOADOUT=reviewer` and the role is `reviewer-<repo>`, and a `radio send --to reviewer-<repo> --intent review-requested --pr N` wakes it up.

🤖 Generated with [Claude Code](https://claude.com/claude-code)