### PR TITLE
task-init: seed read-only tool allowlist (Read, Grep, Glob, find/ls/cat) into .claude/settings.json

### DIFF
--- a/claude-gh/bin/task-init
+++ b/claude-gh/bin/task-init
@@ -305,7 +305,16 @@ _radio_install_hooks() {
           "Bash(gh label list *)",
           "Bash(gh auth status)",
           "Bash(gh repo view *)",
-          "Bash(radio *)"
+          "Bash(radio *)",
+# region:read-only-allow
+          "Read",
+          "Grep",
+          "Glob",
+          "Bash(find *)",
+          "Bash(ls *)",
+          "Bash(cat *)",
+          "Bash(rg *)"
+# endregion:read-only-allow
         ] | unique
       )
     ' "$settings_file" >"$tmp"

--- a/claude-gh/bin/task-init
+++ b/claude-gh/bin/task-init
@@ -103,6 +103,10 @@ LIB_DIR="$SCRIPT_DIR/../../lib"
 . "$LIB_DIR/install-file.sh"
 # shellcheck source=lib/preserve-placeholders.sh
 . "$LIB_DIR/preserve-placeholders.sh"
+# region:require-jq-source
+# shellcheck source=lib/require-jq.sh
+. "$LIB_DIR/require-jq.sh"
+# endregion:require-jq-source
 
 if [[ ! -f "$TEMPLATE" ]]; then
   echo "Error: template not found at $TEMPLATE"
@@ -240,11 +244,9 @@ _radio_install_hooks() {
   local settings_file="$REPO_ROOT/.claude/settings.json"
   local loadout="claude-gh"
 
-  if ! command -v jq >/dev/null 2>&1; then
-    echo "Error: jq is required to merge radio hooks into $settings_file" >&2
-    echo "       Install jq (https://jqlang.github.io/jq/) and re-run task-init." >&2
-    exit 1
-  fi
+# region:require-jq-call
+  require_jq_1_6 || exit 1
+# endregion:require-jq-call
 
   # \${TASK_FORCE_LOADOUT:-$loadout} lets per-role launchers (e.g. task-reviewer
   # exporting TASK_FORCE_LOADOUT=reviewer) override the LOADOUT= field in the

--- a/claude-jira/bin/task-init
+++ b/claude-jira/bin/task-init
@@ -89,6 +89,10 @@ LIB_DIR="$SCRIPT_DIR/../../lib"
 . "$LIB_DIR/install-file.sh"
 # shellcheck source=lib/preserve-placeholders.sh
 . "$LIB_DIR/preserve-placeholders.sh"
+# region:require-jq-source
+# shellcheck source=lib/require-jq.sh
+. "$LIB_DIR/require-jq.sh"
+# endregion:require-jq-source
 
 if [[ ! -f "$TEMPLATE" ]]; then
   echo "Error: template not found at $TEMPLATE"
@@ -209,11 +213,9 @@ _radio_install_hooks() {
   local settings_file="$REPO_ROOT/.claude/settings.json"
   local loadout="claude-jira"
 
-  if ! command -v jq >/dev/null 2>&1; then
-    echo "Error: jq is required to merge radio hooks into $settings_file" >&2
-    echo "       Install jq (https://jqlang.github.io/jq/) and re-run task-init." >&2
-    exit 1
-  fi
+# region:require-jq-call
+  require_jq_1_6 || exit 1
+# endregion:require-jq-call
 
   # \${TASK_FORCE_LOADOUT:-$loadout} lets per-role launchers (e.g. task-reviewer
   # exporting TASK_FORCE_LOADOUT=reviewer) override the LOADOUT= field in the

--- a/claude-jira/bin/task-init
+++ b/claude-jira/bin/task-init
@@ -272,7 +272,16 @@ _radio_install_hooks() {
           "mcp__atlassian__getIssueLinkTypes",
           "mcp__atlassian__lookupJiraAccountId",
           "mcp__atlassian__atlassianUserInfo",
-          "Bash(radio *)"
+          "Bash(radio *)",
+# region:read-only-allow
+          "Read",
+          "Grep",
+          "Glob",
+          "Bash(find *)",
+          "Bash(ls *)",
+          "Bash(cat *)",
+          "Bash(rg *)"
+# endregion:read-only-allow
         ] | unique
       )
     ' "$settings_file" >"$tmp"

--- a/claude-local/bin/task-init
+++ b/claude-local/bin/task-init
@@ -73,6 +73,10 @@ TEMPLATE="$SCRIPT_DIR/../steering/local-workflow.example.md"
 LIB_DIR="$SCRIPT_DIR/../../lib"
 # shellcheck source=lib/install-file.sh
 . "$LIB_DIR/install-file.sh"
+# region:require-jq-source
+# shellcheck source=lib/require-jq.sh
+. "$LIB_DIR/require-jq.sh"
+# endregion:require-jq-source
 
 if [[ ! -f "$TEMPLATE" ]]; then
   echo "Error: template not found at $TEMPLATE"
@@ -234,11 +238,9 @@ _radio_install_hooks() {
   local settings_file="$REPO_ROOT/.claude/settings.json"
   local loadout="claude-local"
 
-  if ! command -v jq >/dev/null 2>&1; then
-    echo "Error: jq is required to merge radio hooks into $settings_file" >&2
-    echo "       Install jq (https://jqlang.github.io/jq/) and re-run task-init." >&2
-    exit 1
-  fi
+# region:require-jq-call
+  require_jq_1_6 || exit 1
+# endregion:require-jq-call
 
   # \${TASK_FORCE_LOADOUT:-$loadout} lets per-role launchers (e.g. task-reviewer
   # exporting TASK_FORCE_LOADOUT=reviewer) override the LOADOUT= field in the

--- a/claude-local/bin/task-init
+++ b/claude-local/bin/task-init
@@ -282,7 +282,16 @@ _radio_install_hooks() {
     | .permissions.allow //= []
     | .permissions.allow = (
         .permissions.allow + [
-          "Bash(radio *)"
+          "Bash(radio *)",
+# region:read-only-allow
+          "Read",
+          "Grep",
+          "Glob",
+          "Bash(find *)",
+          "Bash(ls *)",
+          "Bash(cat *)",
+          "Bash(rg *)"
+# endregion:read-only-allow
         ] | unique
       )
     ' "$settings_file" >"$tmp"

--- a/claude-notion/bin/task-init
+++ b/claude-notion/bin/task-init
@@ -228,7 +228,16 @@ _radio_install_hooks() {
           "mcp__notion__notion-get-users",
           "mcp__notion__notion-get-user",
           "mcp__notion__notion-get-self",
-          "Bash(radio *)"
+          "Bash(radio *)",
+# region:read-only-allow
+          "Read",
+          "Grep",
+          "Glob",
+          "Bash(find *)",
+          "Bash(ls *)",
+          "Bash(cat *)",
+          "Bash(rg *)"
+# endregion:read-only-allow
         ] | unique
       )
     ' "$settings_file" >"$tmp"

--- a/claude-notion/bin/task-init
+++ b/claude-notion/bin/task-init
@@ -108,6 +108,10 @@ TEMPLATE="$SCRIPT_DIR/../steering/notion-workflow.example.md"
 LIB_DIR="$SCRIPT_DIR/../../lib"
 # shellcheck source=lib/install-file.sh
 . "$LIB_DIR/install-file.sh"
+# region:require-jq-source
+# shellcheck source=lib/require-jq.sh
+. "$LIB_DIR/require-jq.sh"
+# endregion:require-jq-source
 
 if [[ ! -f "$TEMPLATE" ]]; then
   echo "Error: template not found at $TEMPLATE"
@@ -164,11 +168,9 @@ _radio_install_hooks() {
   local settings_file="$REPO_ROOT/.claude/settings.json"
   local loadout="claude-notion"
 
-  if ! command -v jq >/dev/null 2>&1; then
-    echo "Error: jq is required to merge radio hooks into $settings_file" >&2
-    echo "       Install jq (https://jqlang.github.io/jq/) and re-run task-init." >&2
-    exit 1
-  fi
+# region:require-jq-call
+  require_jq_1_6 || exit 1
+# endregion:require-jq-call
 
   # \${TASK_FORCE_LOADOUT:-$loadout} lets per-role launchers (e.g. task-reviewer
   # exporting TASK_FORCE_LOADOUT=reviewer) override the LOADOUT= field in the

--- a/lib/require-jq.sh
+++ b/lib/require-jq.sh
@@ -1,0 +1,29 @@
+#!/usr/bin/env bash
+# Guard: jq >= 1.6 is required because task-init embeds `#` line-comment
+# sentinels inside the jq program (region:read-only-allow). `#` comments
+# landed in jq 1.6 (2018); jq 1.5 errors out with `unexpected '#'` and
+# leaves .claude/settings.json half-written.
+#
+# Source this file and call `require_jq_1_6` before any jq invocation
+# whose program contains `#` comments.
+
+require_jq_1_6() {
+  local v maj min
+  if ! command -v jq >/dev/null 2>&1; then
+    echo "Error: jq (>= 1.6) is required" >&2
+    echo "       Install jq (https://jqlang.github.io/jq/) and re-run task-init." >&2
+    return 1
+  fi
+  if ! v=$(jq --version 2>/dev/null); then
+    echo "Error: 'jq --version' failed — install a working jq (>= 1.6)" >&2
+    return 1
+  fi
+  v=${v#jq-}
+  IFS='.' read -r maj min _ <<<"$v"
+  maj=${maj%%[!0-9]*}
+  min=${min%%[!0-9]*}
+  if [[ -z "$maj" || -z "$min" ]] || (( maj < 1 || (maj == 1 && min < 6) )); then
+    echo "Error: jq >= 1.6 required (have ${v:-unknown}) — task-init uses '#' comments inside the jq program (introduced in 1.6)" >&2
+    return 1
+  fi
+}

--- a/tests/claude_gh_task_init.bats
+++ b/tests/claude_gh_task_init.bats
@@ -458,6 +458,14 @@ EOF
   assert_output --partial "Bash(gh search issues *)"
   assert_output --partial "Bash(gh pr view *)"
   assert_output --partial "Bash(radio *)"
+  # Shared read-only tool/shell allow-list (#141).
+  assert_output --partial "Read"
+  assert_output --partial "Grep"
+  assert_output --partial "Glob"
+  assert_output --partial "Bash(find *)"
+  assert_output --partial "Bash(ls *)"
+  assert_output --partial "Bash(cat *)"
+  assert_output --partial "Bash(rg *)"
   # Mutations must NOT be auto-allowed.
   refute_output --partial "gh issue edit"
   refute_output --partial "gh pr merge"

--- a/tests/claude_gh_task_init.bats
+++ b/tests/claude_gh_task_init.bats
@@ -499,3 +499,27 @@ EOF
   assert_output --partial "Bash(custom *)"
   assert_output --partial "Bash(gh issue view *)"
 }
+
+# ---------------------------------------------------------------------------
+# jq >= 1.6 guard (#141 follow-up)
+# ---------------------------------------------------------------------------
+
+@test "fails with clear error when jq < 1.6 is on PATH" {
+  # Shadow the real jq with a fake one that reports version 1.5 so the guard
+  # is the only thing that can decide the outcome.
+  local stub_bin
+  stub_bin=$(mktemp -d)
+  cat > "$stub_bin/jq" <<'EOF'
+#!/usr/bin/env bash
+case "${1-}" in
+  --version) echo "jq-1.5" ;;
+  *) exit 0 ;;
+esac
+EOF
+  chmod +x "$stub_bin/jq"
+  PATH="$stub_bin:$PATH" run "$CLAUDE_GH_TASK_INIT"
+  rm -rf "$stub_bin"
+  assert_failure
+  assert_output --partial "jq >= 1.6 required"
+  assert_output --partial "1.5"
+}

--- a/tests/claude_local_task_init.bats
+++ b/tests/claude_local_task_init.bats
@@ -243,6 +243,14 @@ teardown() {
   assert_success
   run jq -r '.permissions.allow[]' "$TARGET_DIR/.claude/settings.json"
   assert_output --partial "Bash(radio *)"
+  # Shared read-only tool/shell allow-list (#141).
+  assert_output --partial "Read"
+  assert_output --partial "Grep"
+  assert_output --partial "Glob"
+  assert_output --partial "Bash(find *)"
+  assert_output --partial "Bash(ls *)"
+  assert_output --partial "Bash(cat *)"
+  assert_output --partial "Bash(rg *)"
 }
 
 @test "idempotent: re-run does not duplicate the radio allow-list entry" {

--- a/tests/claude_notion_task_init.bats
+++ b/tests/claude_notion_task_init.bats
@@ -236,6 +236,14 @@ teardown() {
   assert_output --partial "mcp__notion__notion-fetch"
   assert_output --partial "mcp__notion__notion-query-data-sources"
   assert_output --partial "Bash(radio *)"
+  # Shared read-only tool/shell allow-list (#141).
+  assert_output --partial "Read"
+  assert_output --partial "Grep"
+  assert_output --partial "Glob"
+  assert_output --partial "Bash(find *)"
+  assert_output --partial "Bash(ls *)"
+  assert_output --partial "Bash(cat *)"
+  assert_output --partial "Bash(rg *)"
   # Writes must NOT be auto-allowed.
   refute_output --partial "notion-create-pages"
   refute_output --partial "notion-update-page"

--- a/tests/jira_task_init.bats
+++ b/tests/jira_task_init.bats
@@ -252,6 +252,14 @@ teardown() {
   assert_output --partial "mcp__atlassian__searchJiraIssuesUsingJql"
   assert_output --partial "mcp__atlassian__getVisibleJiraProjects"
   assert_output --partial "Bash(radio *)"
+  # Shared read-only tool/shell allow-list (#141).
+  assert_output --partial "Read"
+  assert_output --partial "Grep"
+  assert_output --partial "Glob"
+  assert_output --partial "Bash(find *)"
+  assert_output --partial "Bash(ls *)"
+  assert_output --partial "Bash(cat *)"
+  assert_output --partial "Bash(rg *)"
   # Writes must NOT be auto-allowed.
   refute_output --partial "createJiraIssue"
   refute_output --partial "editJiraIssue"

--- a/tools/check-drift.sh
+++ b/tools/check-drift.sh
@@ -29,6 +29,7 @@ GROUPS_DEFAULT=(
   "task-pm-claude|body|claude-gh/bin/task-pm claude-jira/bin/task-pm claude-local/bin/task-pm claude-notion/bin/task-pm"
   "task-pm-kiro|body|kiro-gh/bin/task-pm kiro-local/bin/task-pm kiro-notion/bin/task-pm"
   "task-reviewer-claude|body|claude-gh/bin/task-reviewer claude-jira/bin/task-reviewer claude-local/bin/task-reviewer claude-notion/bin/task-reviewer"
+  "read-only-allow|read-only-allow|claude-gh/bin/task-init claude-jira/bin/task-init claude-local/bin/task-init claude-notion/bin/task-init"
 )
 # endregion:default-manifest
 

--- a/tools/check-drift.sh
+++ b/tools/check-drift.sh
@@ -30,6 +30,8 @@ GROUPS_DEFAULT=(
   "task-pm-kiro|body|kiro-gh/bin/task-pm kiro-local/bin/task-pm kiro-notion/bin/task-pm"
   "task-reviewer-claude|body|claude-gh/bin/task-reviewer claude-jira/bin/task-reviewer claude-local/bin/task-reviewer claude-notion/bin/task-reviewer"
   "read-only-allow|read-only-allow|claude-gh/bin/task-init claude-jira/bin/task-init claude-local/bin/task-init claude-notion/bin/task-init"
+  "require-jq-source|require-jq-source|claude-gh/bin/task-init claude-jira/bin/task-init claude-local/bin/task-init claude-notion/bin/task-init"
+  "require-jq-call|require-jq-call|claude-gh/bin/task-init claude-jira/bin/task-init claude-local/bin/task-init claude-notion/bin/task-init"
 )
 # endregion:default-manifest
 


### PR DESCRIPTION
## Summary

- Append seven shared read-only entries to `permissions.allow` in all four claude-* `task-init` variants: `Read`, `Grep`, `Glob`, `Bash(find *)`, `Bash(ls *)`, `Bash(cat *)`, `Bash(rg *)`. Eliminates permission prompts for routine codebase exploration by planner / worker / reviewer roles; mutations stay confirmation-gated.
- Wrap the shared block in `# region:read-only-allow` sentinels and add the group to `tools/check-drift.sh`'s `GROUPS_DEFAULT` manifest so the four variants stay byte-identical.
- Extend the existing `seeds … permissions.allow` test in each of the four bats files with `assert_output --partial` for every new entry.

Closes #141

## Test plan
- [x] `bats tests/claude_gh_task_init.bats tests/jira_task_init.bats tests/claude_notion_task_init.bats tests/claude_local_task_init.bats` — 111/111 ok
- [x] `bats tests/drift_check.bats` — 7/7 ok
- [x] `tools/check-drift.sh` — `check-drift: 19 group(s) checked`
- [x] Smoke test: `task-init` in a scratch dir for each of the four variants produces a `.permissions.allow` containing all 7 shared entries plus its tracker-specific reads
- [ ] Manual: launch `claude --permission-mode plan` in a fresh worktree; confirm Read/Grep/Glob/find/ls do not prompt while Edit/Write/`gh issue edit` still do

🤖 Generated with [Claude Code](https://claude.com/claude-code)