### PR TITLE
task-work: recognize app.notion.com URLs (closes #158)

### DIFF
--- a/claude-notion/bin/task-work
+++ b/claude-notion/bin/task-work
@@ -85,7 +85,10 @@ fi
 [[ ${#POSITIONAL[@]} -lt 1 ]] && usage
 
 is_notion_url() {
-  [[ "$1" == *"notion.so"* || "$1" == *"notion.site"* ]]
+  # notion.com covers app.notion.com workspace/page links — the form Notion
+  # now serves and the Notion MCP fetch/search tools return (#158). Adding it
+  # is safe: notion.so/notion.site URLs never contain it, nor does a real slug.
+  [[ "$1" == *"notion.so"* || "$1" == *"notion.site"* || "$1" == *"notion.com"* ]]
 }
 
 derive_slug_from_url() {

--- a/kiro-notion/bin/task-work
+++ b/kiro-notion/bin/task-work
@@ -91,7 +91,10 @@ done
 [[ ${#POSITIONAL[@]} -lt 1 ]] && usage
 
 is_notion_url() {
-  [[ "$1" == *"notion.so"* || "$1" == *"notion.site"* ]]
+  # notion.com covers app.notion.com workspace/page links — the form Notion
+  # now serves and the Notion MCP fetch/search tools return (#158). Adding it
+  # is safe: notion.so/notion.site URLs never contain it, nor does a real slug.
+  [[ "$1" == *"notion.so"* || "$1" == *"notion.site"* || "$1" == *"notion.com"* ]]
 }
 
 derive_slug_from_url() {

--- a/tests/claude_notion_task_work.bats
+++ b/tests/claude_notion_task_work.bats
@@ -53,6 +53,30 @@ teardown() {
   assert [ -d "$WORKTREE_BASE/my-explicit-slug" ]
 }
 
+# Regression (#158): Notion serves workspace/page links — and the Notion MCP
+# fetch/search tools return them — as app.notion.com URLs. is_notion_url() must
+# recognize these or the URL is silently dropped (slug-only fallthrough).
+@test "app.notion.com URL: single arg derives slug from /p/<32hex> tail" {
+  run "$CLAUDE_NOTION_TASK_WORK" "https://app.notion.com/p/384d9a72260f81f5b3c1c639a1f78d1f"
+  assert_success
+  assert [ -d "$WORKTREE_BASE/384d9a72" ]
+}
+
+@test "app.notion.com URL: explicit slug + URL records NOTION_URL" {
+  local url="https://app.notion.com/p/384d9a72260f81f5b3c1c639a1f78d1f"
+  run "$CLAUDE_NOTION_TASK_WORK" my-feature "$url"
+  assert_success
+  source "$WORKTREE_BASE/.my-feature.info"
+  assert_equal "$NOTION_URL" "$url"
+}
+
+@test "app.notion.com URL: claude command includes task URL" {
+  local url="https://app.notion.com/p/384d9a72260f81f5b3c1c639a1f78d1f"
+  run "$CLAUDE_NOTION_TASK_WORK" my-feature "$url"
+  assert_success
+  assert_stub_called zellij "Implement task: $url"
+}
+
 # ---------------------------------------------------------------------------
 # Worktree + branch creation
 # ---------------------------------------------------------------------------

--- a/tests/kiro_task_work.bats
+++ b/tests/kiro_task_work.bats
@@ -53,6 +53,22 @@ teardown() {
   assert [ -d "$WORKTREE_BASE/my-explicit-slug" ]
 }
 
+# Regression (#158): app.notion.com links (served by Notion + returned by the
+# Notion MCP tools) must be recognized as Notion URLs, not dropped.
+@test "app.notion.com URL: single arg derives slug from /p/<32hex> tail" {
+  run "$KIRO_TASK_WORK" "https://app.notion.com/p/384d9a72260f81f5b3c1c639a1f78d1f"
+  assert_success
+  assert [ -d "$WORKTREE_BASE/384d9a72" ]
+}
+
+@test "app.notion.com URL: explicit slug + URL records NOTION_URL" {
+  local url="https://app.notion.com/p/384d9a72260f81f5b3c1c639a1f78d1f"
+  run "$KIRO_TASK_WORK" my-feature "$url"
+  assert_success
+  source "$WORKTREE_BASE/.my-feature.info"
+  assert_equal "$NOTION_URL" "$url"
+}
+
 # ---------------------------------------------------------------------------
 # Worktree + branch creation
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## Problem

Starting a worker for a Notion task silently dropped the spec URL: the worker launched with a bare `/worker` and no task, and the operator had to paste the URL in by hand. Jira was unaffected.

## Root cause (#158)

`is_notion_url()` only matched `notion.so` / `notion.site`:

```bash
is_notion_url() { [[ "$1" == *"notion.so"* || "$1" == *"notion.site"* ]]; }
```

Notion now serves workspace/page links as **`app.notion.com`** — and the Notion MCP `fetch`/`search` tools return URLs in that form. The predicate returned false, no arg-resolution branch matched, and parsing fell through to the slug-only `else`, leaving `NOTION_URL=""`. `build_claude_cmd` then emitted `claude … "/worker"` with no task identifier. Deterministic, not flaky.

## Fix

Add `notion.com` to the predicate in both Notion loadouts (`claude-notion`, `kiro-notion`):

```bash
is_notion_url() {
  [[ "$1" == *"notion.so"* || "$1" == *"notion.site"* || "$1" == *"notion.com"* ]]
}
```

Safe: real `notion.so`/`notion.site` URLs never contain `notion.com`, nor does a free-form slug. `derive_slug_from_url` already handles the `…/p/<32-hex>` tail.

## Tests

Added regression tests (confirmed red before the fix, green after) for the single-arg and explicit `slug + URL` forms using an `app.notion.com` URL:
- `tests/claude_notion_task_work.bats` (3)
- `tests/kiro_task_work.bats` (2)

Full suite: **799 passing, 0 failures**; drift check passes; shellcheck clean on both edited scripts.

## Note

#158 speculated `task-reviewer` carries the same predicate — it does not. Its non-gh path uses a generic `SPEC_IDENTIFIER="$ISSUE_INPUT"` with no Notion-specific filter, so it was never affected. No change needed there.

Closes #158

🤖 Generated with [Claude Code](https://claude.com/claude-code)