### PR TITLE
claude-notion: reviewer self-destruct + tight-PR norm + PM reviewer perms

### DIFF
--- a/claude-notion/commands/pm.md
+++ b/claude-notion/commands/pm.md
@@ -42,7 +42,7 @@ The worker pings you via `radio` at every transition. Reciprocate so the worker 
   ```bash
   task-reviewer <pr-url-or-number> [<issue-url-or-number>]
   ```
-  in any spare tab. The reviewer runs with `--auto` (auto-permission) by default — the `/reviewer` prompt's authority list rules out anything destructive (no merge, no push, no Status edits), so hands-off dispatch is safe. Pass `--no-auto` if you want to babysit a specific review.
+  in any spare tab. The reviewer runs with `--auto` (auto-permission) by default — the `/reviewer` prompt's authority list rules out anything destructive (no merge, no push, no Status edits), so hands-off dispatch is safe. Pass `--no-auto` if you want to babysit a specific review. Add `Bash(task-reviewer *)` to your project's `.claude/settings.json` `permissions.allow` so you launch reviewers **without a permission prompt** — dispatch them hands-off, you don't need to ask the user first.
 
   Positional args:
   - **PR** (required): URL or bare number.
@@ -55,13 +55,15 @@ The worker pings you via `radio` at every transition. Reciprocate so the worker 
     gh pr merge <N> --squash --delete-branch
     radio send --to <worker-role> --intent approved-and-merged --pr <N> --body "merged"
     ```
-  - **`review-complete-with-findings`** → reviewer posted blockers / nits to the PR. Forward to the original worker so they push fixes:
+  - **`review-complete-with-findings`** → reviewer posted blockers / nits to the PR. Read its verdict on your next `radio check`, then forward to the original worker so they push fixes:
     ```bash
     radio send --to <worker-role> --intent changes-requested --pr <N> --body "see PR comments (reviewer flagged findings)"
     ```
     The actual review content is in the PR comment the reviewer posted — `radio` just carries the routing ping.
 
-  You still own the merge decision — the reviewer never approves, merges, closes, or mutates Status. The reviewer tab stays open showing the analysis (the user can scroll back); `task-done --remove-worktree` from inside that worktree cleans it up when they're done.
+  **Tight-PR norm — minimize deferrals.** When you forward findings, default to "fix ALL of these in this PR" (blockers + nits), not "defer some to a follow-up." A tight PR that lands complete beats a thin one trailing a backlog of deferred nits. Only let something be deferred when it's genuinely out of the PR's scope — and in that case *you* groom it into a ticket during this PM session (don't leave it as a loose "later"). Fold in-scope cleanup into the same changes-requested round.
+
+  You still own the merge decision — the reviewer never approves, merges, closes, or mutates Status. The reviewer is **single-shot and self-cleaning**: right after it posts the PR comment + radios you, it runs `task-done --remove-worktree` and the tab closes itself. Its analysis lives in the PR comment, not the tab — so there's nothing to scroll back to and no manual cleanup for you to do.
 
 If arguments were provided after `/pm`, treat them as the first instruction:
 $ARGUMENTS

--- a/claude-notion/commands/reviewer.md
+++ b/claude-notion/commands/reviewer.md
@@ -13,7 +13,7 @@ You are a single-shot PR reviewer worker. `task-reviewer` spawned this tab with 
 4. Run the `code-review` skill on the diff.
 5. Post **one** substantive PR comment with the full analysis (spec compliance + code-review findings + verdict).
 6. Radio PM back with `review-complete-clean` or `review-complete-with-findings` and a short summary.
-7. Idle — the tab stays open so the user can scroll through the analysis. Do NOT auto-cleanup.
+7. **Auto-destruct.** Your analysis lives in the PR comment (durable) — the tab does not need to stay open. Immediately after the PR comment is posted AND PM is radioed, run `task-done --remove-worktree` as your final action to remove this review worktree and close the tab. Do NOT idle.
 
 PRs always live in GitHub; specs live in Notion. Refer to the project's `.claude/notion-workflow.md` for Notion database conventions. Use the Notion MCP (`mcp__notion__notion-fetch`) for spec lookup and the `gh` CLI for PR I/O: `gh pr view`, `gh pr diff`, `gh pr comment`. Read-only `gh` and the Notion read MCPs are pre-allowed in `.claude/settings.json`; mutations stay confirmation-gated.
 
@@ -43,6 +43,8 @@ $ARGUMENTS
    - **Spec compliance** (omit if diff-only) — did the PR deliver what the spec asked for? List anything missing or off-spec.
    - **Code-review findings** — correctness, security, edge cases, anything substantive from the skill's output.
    - **Verdict** — `clean`, `clean-with-nits`, or `changes-requested`. Be explicit.
+
+   **Tight-PR norm — prefer fix-in-this-PR over deferral.** Frame every finding as something the worker should fix *in this PR*, not as a follow-up ticket, whenever the fix is feasible within the PR's scope. Do NOT suggest "defer to a follow-up" / "track separately" for anything in-scope — that's a deferral the team is trying to avoid. Only flag a deferral when the work is genuinely out of this PR's scope (a separate subsystem, a large refactor), and say so explicitly — PM will decide whether to groom it into a ticket. Default: tight PR, everything fixed before merge.
 7. Post the comment:
    ```bash
    gh pr comment <N> -b "<full analysis>"
@@ -53,7 +55,7 @@ $ARGUMENTS
    # — or —
    radio send --to pm --intent review-complete-with-findings --pr <N> --body "<one-line summary>"
    ```
-9. Idle. The tab stays open so the user can scroll back through the analysis. They'll close the tab manually when done; `task-done --remove-worktree` cleans up the review worktree if they want.
+9. **Auto-destruct.** Run `task-done --remove-worktree` as your final action — it removes this review worktree and closes the tab. PM reads your verdict from the PR comment + the radio ping (on its next `radio check`), never from this tab, so there is nothing to keep open. Self-cleaning is mandatory, not optional.
 
 ### Authority boundaries
 

--- a/claude-notion/steering/notion-workflow.example.md
+++ b/claude-notion/steering/notion-workflow.example.md
@@ -115,6 +115,29 @@ The body comes from `--body` or stdin. PR review *content* still lives in
 follow `worker-<reponame>-<slug>`; discover the live one via
 `ls ~/.task-force/radio/sessions/`.
 
+### Reviewer role (single-shot, self-cleaning)
+
+On a worker's `review-requested`, the PM may dispatch a reviewer with
+`task-reviewer <pr> [<notion-spec-url>]` (add `Bash(task-reviewer *)` to your
+project's `.claude/settings.json` `permissions.allow` so the PM dispatches
+hands-off without a permission prompt). The reviewer is **single-shot**: it reads
+the spec + diff, runs the `code-review` skill, posts **one** PR comment carrying
+its full analysis + verdict, radios the PM `review-complete-clean` /
+`review-complete-with-findings`, then **auto-destructs** (`task-done
+--remove-worktree` — removes its worktree and closes its tab). It does NOT idle
+waiting to be closed. The analysis lives in the PR comment, not the tab; the PM
+reads the verdict on its next `radio check` and forwards findings to the worker.
+
+### Tight-PR norm — minimize deferrals
+
+Default to landing each PR **complete**. The reviewer frames every finding as
+fix-in-this-PR (never "defer to a follow-up" for in-scope work), and the PM forwards
+**all** in-scope findings — blockers *and* nits — in a single `changes-requested`
+round rather than trailing a backlog of deferred items. The only thing that gets
+deferred is work genuinely out of the PR's scope (a separate subsystem, a large
+refactor) — and the PM grooms that into a ticket during the session, not left as a
+loose "later."
+
 To launch the PM agent in this repo, run `task-pm` from any tab — it renames
 the current zellij tab to `pm`, registers via the `SessionStart` hook, and
 starts the PM agent in-place.


### PR DESCRIPTION
## What & why

Three workflow improvements validated while dogfooding the claude-notion loadout on a downstream project, ported back to the framework.

### Changes (claude-notion loadout)
- **`commands/reviewer.md`** — the reviewer is now **single-shot + self-destructing**: right after it posts the PR comment and radios PM, it runs `task-done --remove-worktree` instead of idling with the tab open. Its analysis lives durably in the PR comment, so there's no reason to keep the worktree/tab around. Also adds a **tight-PR norm**: frame every finding as fix-in-this-PR, never "defer to a follow-up" for in-scope work.
- **`commands/pm.md`** — reflects the self-cleaning reviewer (no manual cleanup, nothing to scroll back to); adds the **tight-PR forwarding norm** (forward all in-scope findings — blockers + nits — in one `changes-requested` round; only genuinely out-of-scope work gets deferred, and the PM grooms that into a ticket); notes that pre-allowing `Bash(task-reviewer *)` lets PM dispatch reviewers hands-off.
- **`steering/notion-workflow.example.md`** — new "Reviewer role (single-shot, self-cleaning)" and "Tight-PR norm" sections documenting the above.

### Notes
- **Scoped to the `claude-notion` loadout only.** The same generic change applies to `claude-gh` / `claude-local` / `claude-jira` / the `.claude` dogfood copy — to follow in a separate pass.
- The `Bash(task-reviewer *)` permission is **per-project** (the loadout ships no `settings.json`), so this PR is prompt/doc-only; projects add the allow entry to their own `.claude/settings.json`.
- No project-specific identifiers in the diff (placeholders only).

🤖 Generated with [Claude Code](https://claude.com/claude-code)